### PR TITLE
cleanup for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "eslint": "^8.1.0",
     "rollup": "^2.58.3",
     "rollup-plugin-terser": "^7.0.2",
-    "tslib": "^2.3.1",
     "typescript": "^4.4.4"
   },
   "scripts": {
     "build": "npm run build --workspaces --if-present",
+    "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present"
   },
   "volta": {

--- a/packages/base-cli/package.json
+++ b/packages/base-cli/package.json
@@ -16,7 +16,9 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint src/**/*.ts",
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
     "test": "node ./test/test.mjs"
   },

--- a/plugin-packs/postcss-preset-env/package.json
+++ b/plugin-packs/postcss-preset-env/package.json
@@ -19,11 +19,12 @@
     "postcss-preset-env": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"
@@ -65,8 +66,8 @@
   },
   "devDependencies": {
     "postcss": "^8.3.6",
-    "postcss-tape": "^6.0.1",
-    "postcss-simple-vars": "^6.0.3"
+    "postcss-simple-vars": "^6.0.3",
+    "postcss-tape": "^6.0.1"
   },
   "peerDependencies": {
     "postcss": "^8.3"

--- a/plugins/css-blank-pseudo/package.json
+++ b/plugins/css-blank-pseudo/package.json
@@ -32,11 +32,12 @@
     "css-blank-pseudo": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/css-has-pseudo/package.json
+++ b/plugins/css-has-pseudo/package.json
@@ -32,11 +32,12 @@
     "css-has-pseudo": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/css-prefers-color-scheme/package.json
+++ b/plugins/css-prefers-color-scheme/package.json
@@ -32,11 +32,12 @@
     "css-prefers-color-scheme": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-base-plugin/package.json
+++ b/plugins/postcss-base-plugin/package.json
@@ -22,12 +22,13 @@
     "postcss-base-plugin": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build --if-present && npm run test --if-present",
-    "lint": "eslint src/**/*.ts",
-    "test": "postcss-tape --ci",
-    "test:cli": "bash ./test/cli/test.sh",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci",
+    "test:cli": "bash ./test/cli/test.sh"
   },
   "devDependencies": {
     "postcss": "^8.3.6",

--- a/plugins/postcss-color-functional-notation/package.json
+++ b/plugins/postcss-color-functional-notation/package.json
@@ -20,11 +20,12 @@
     "postcss-color-functional-notation": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.ts",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-dir-pseudo-class/package.json
+++ b/plugins/postcss-dir-pseudo-class/package.json
@@ -19,11 +19,12 @@
     "postcss-dir-pseudo-class": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-double-position-gradients/package.json
+++ b/plugins/postcss-double-position-gradients/package.json
@@ -19,11 +19,12 @@
     "postcss-double-position-gradients": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-env-function/package.json
+++ b/plugins/postcss-env-function/package.json
@@ -19,11 +19,12 @@
     "postcss-env-function": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-focus-visible/package.json
+++ b/plugins/postcss-focus-visible/package.json
@@ -20,11 +20,12 @@
     "postcss-focus-visible": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.ts",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-focus-within/package.json
+++ b/plugins/postcss-focus-within/package.json
@@ -20,11 +20,12 @@
     "postcss-focus-within": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.ts",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-gap-properties/package.json
+++ b/plugins/postcss-gap-properties/package.json
@@ -19,11 +19,12 @@
     "postcss-gap-properties": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-image-set-function/package.json
+++ b/plugins/postcss-image-set-function/package.json
@@ -20,11 +20,12 @@
     "postcss-image-set-function": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.ts",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-lab-function/package.json
+++ b/plugins/postcss-lab-function/package.json
@@ -20,12 +20,13 @@
     "postcss-lab-function": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build --if-present && npm run test --if-present",
-    "lint": "eslint src/**/*.ts",
-    "test": "node ./test/color/test.mjs && postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "generate-color-corpus": "python3 ./test/color/generate.py",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
-    "generate-color-corpus": "python3 ./test/color/generate.py"
+    "test": "node ./test/color/test.mjs && postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-logical/package.json
+++ b/plugins/postcss-logical/package.json
@@ -19,11 +19,12 @@
     "postcss-logical": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-nesting/package.json
+++ b/plugins/postcss-nesting/package.json
@@ -28,12 +28,13 @@
     "postcss-nesting": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
-    "test:deno": "deno run --unstable --allow-env --allow-read test/deno/test.js",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci",
+    "test:deno": "deno run --unstable --allow-env --allow-read test/deno/test.js"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-overflow-shorthand/package.json
+++ b/plugins/postcss-overflow-shorthand/package.json
@@ -19,11 +19,12 @@
     "postcss-overflow-shorthand": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-place/package.json
+++ b/plugins/postcss-place/package.json
@@ -19,11 +19,12 @@
     "postcss-place": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"

--- a/plugins/postcss-pseudo-class-any-link/package.json
+++ b/plugins/postcss-pseudo-class-any-link/package.json
@@ -19,11 +19,12 @@
     "postcss-pseudo-class-any-link": "dist/cli.mjs"
   },
   "scripts": {
-    "prepublishOnly": "npm run build && npm run test",
-    "lint": "eslint src/**/*.js",
-    "test": "postcss-tape --ci",
     "build": "rollup -c ../../rollup/default.js",
-    "stryker": "stryker run --logLevel error"
+    "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
+    "lint": "eslint src/**/*.ts src/**/*.js --no-error-on-unmatched-pattern",
+    "prepublishOnly": "npm run clean && npm run build && npm run test",
+    "stryker": "stryker run --logLevel error",
+    "test": "postcss-tape --ci"
   },
   "engines": {
     "node": "^12 || ^14 || >=16"


### PR DESCRIPTION
- remove `tslib` (I think I added this while trying something and that it is no longer needed. build passes without)
- 🔤 `scripts` in `package.json`
- checked that all dependency versions are consistent
- checked `prepublishOnly` and added `clean` to list
- `clean` script to remove `dist`. (so we don't accidentally publish old files)
- consistent `lint` command (now the same for typescript and javascript)

For `clean` I did not want to add `rimraf` while still having cross platform support.
The simplest was just using node itself as it is a requirement anyway.

`fs.rmSync('./dist', { recursive: true, force: true });` only works in node 14 and above but this is fine because we require node 16 to do actual development and publishing in the mono repo.