### PR TITLE
cleanup rollup configs

### DIFF
--- a/rollup/configs/externals.js
+++ b/rollup/configs/externals.js
@@ -2,7 +2,6 @@ export const externalsForCLI = [
 	'fs',
 	'path',
 
-	'@csstools/postcss-plugins-values-parser',
 	'autoprefixer',
 	'browserslist',
 	'caniuse-lite',
@@ -48,7 +47,6 @@ export const externalsForPlugin = [
 	'postcss',
 	/^postcss\/lib\/*/,
 
-	'@csstools/postcss-plugins-values-parser',
 	'autoprefixer',
 	'browserslist',
 	'caniuse-lite',


### PR DESCRIPTION
We migrated to `postcss-value-parser`.
These entries originated in a wip branch that had a fork of `postcss-values-parser`