### PR TITLE
color-functional-notation: var alpha values in rgb

### DIFF
--- a/plugins/postcss-color-functional-notation/src/on-css-function.ts
+++ b/plugins/postcss-color-functional-notation/src/on-css-function.ts
@@ -217,7 +217,7 @@ function rgbFunctionContents(nodes): Rgb|null {
 		out.slash = nodes[3];
 	}
 
-	if ((isNumericNodePercentageOrNumber(nodes[4]) || isCalcNode(nodes[4]))) {
+	if ((isNumericNodePercentageOrNumber(nodes[4]) || isCalcNode(nodes[4]) || isVarNode(nodes[4]))) {
 		out.alpha = nodes[4];
 	}
 

--- a/plugins/postcss-color-functional-notation/test/variables.css
+++ b/plugins/postcss-color-functional-notation/test/variables.css
@@ -4,6 +4,7 @@
 
 	--opacity-50: 0.5;
 	--firebrick-a50-var: hsl(40 68.8% 34.5% / var(--opacity-50));
+	--firebrick-rgb-a50-var: rgb(40% 68.8 34.5 / var(--opacity-50));
 
 	--fifty: 50%;
 	--firebrick-var: hsl(40 var(--fifty) 34.5% / var(--opacity-50));

--- a/plugins/postcss-color-functional-notation/test/variables.expect.css
+++ b/plugins/postcss-color-functional-notation/test/variables.expect.css
@@ -4,6 +4,7 @@
 
 	--opacity-50: 0.5;
 	--firebrick-a50-var: hsla(40, 68.8%, 34.5%, var(--opacity-50));
+	--firebrick-rgb-a50-var: rgba(102, 68.8, 34.5, var(--opacity-50));
 
 	--fifty: 50%;
 	--firebrick-var: hsl(40 var(--fifty) 34.5% / var(--opacity-50));

--- a/plugins/postcss-color-functional-notation/test/variables.preserve-true.expect.css
+++ b/plugins/postcss-color-functional-notation/test/variables.preserve-true.expect.css
@@ -4,6 +4,7 @@
 
 	--opacity-50: 0.5;
 	--firebrick-a50-var: hsla(40, 68.8%, 34.5%, var(--opacity-50));
+	--firebrick-rgb-a50-var: rgba(102, 68.8, 34.5, var(--opacity-50));
 
 	--fifty: 50%;
 	--firebrick-var: hsl(40 var(--fifty) 34.5% / var(--opacity-50));
@@ -15,5 +16,8 @@
 }
 }@supports (color: rgb(0 0 0 / 0.5)) and (color: hsl(0 0% 0% / 0.5)) {:root {
 	--firebrick-a50-var: hsl(40 68.8% 34.5% / var(--opacity-50));
+}
+}@supports (color: rgb(0 0 0 / 0.5)) and (color: hsl(0 0% 0% / 0.5)) {:root {
+	--firebrick-rgb-a50-var: rgb(40% 68.8 34.5 / var(--opacity-50));
 }
 }


### PR DESCRIPTION
Moved from https://github.com/csstools/postcss-color-functional-notation/pull/8

This is specially useful for people working with TailwindCSS because 3.0 now outputs colors using this notation, but the alpha values are set to other tailwind variables. Here is an example of code generated by Tailwind:

```css
color: rgb(255 255 255 / var(--tw-text-opacity));
background-color: rgb(0 0 0 / var(--tw-bg-opacity));
```