### PR TITLE
setup dependabot and codeql

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "01:00"
+    timezone: "Europe/Brussels"
+  open-pull-requests-limit: 10
+  versioning-strategy: increase-if-necessary
+  rebase-strategy: auto
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "01:00"
+    timezone: Europe/Brussels
+  open-pull-requests-limit: 10
+  versioning-strategy: increase
+  rebase-strategy: auto

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "codeql"
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2.4.0
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: setup node
+      uses: actions/setup-node@v2.5.0
+      with:
+        node-version: 16
+        cache: 'npm'
+
+    - run: npm ci --ignore-scripts
+    - run: npm run build --workspaces --if-present
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
- both run weekly
- CodeQL can be run manually

CodeQL is very slow so running this on push would be annoying.
Running it manually helps if we want to be sure a change doesn't contain issues.