### PR TITLE
manually trigger tests for node without workspaces support

### DIFF
--- a/.github/workflows/test-node-without-workspaces.yml
+++ b/.github/workflows/test-node-without-workspaces.yml
@@ -1,6 +1,6 @@
 name: test node without workspaces
 on:
-  push:
+  workflow_dispatch:
 
 concurrency:
   group: branch-no-workspaces-${{ github.ref }}


### PR DESCRIPTION
_better to run these manually than to ignore them if they fail too often_