### PR TITLE
color functional notation : support for alpha value with comma separated values

### DIFF
--- a/plugins/postcss-color-functional-notation/CHANGELOG.md
+++ b/plugins/postcss-color-functional-notation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to PostCSS Color Functional Notation
 
+### 4.2.0
+
+- Added: support for Alpha value as the fourth argument in comma separated values notation.
+
 ### 4.1.0 (December 15, 2021)
 
 - Added: support for Alpha value as a CSS variable in `rgb()` and `rgba()`.

--- a/plugins/postcss-color-functional-notation/src/on-css-function.ts
+++ b/plugins/postcss-color-functional-notation/src/on-css-function.ts
@@ -1,5 +1,5 @@
-import valueParser, { SpaceNode } from 'postcss-value-parser';
-import type { FunctionNode, Dimension, Node, DivNode, WordNode } from 'postcss-value-parser';
+import valueParser from 'postcss-value-parser';
+import type { FunctionNode, Dimension, Node, DivNode, WordNode, SpaceNode } from 'postcss-value-parser';
 
 function onCSSFunction(node: FunctionNode) {
 	const value = node.value;

--- a/plugins/postcss-color-functional-notation/src/on-css-function.ts
+++ b/plugins/postcss-color-functional-notation/src/on-css-function.ts
@@ -3,7 +3,11 @@ import type { FunctionNode, Dimension, Node, DivNode, WordNode } from 'postcss-v
 
 function onCSSFunction(node: FunctionNode) {
 	const value = node.value;
-	const rawNodes = convertOldSyntaxToNewSyntaxBeforeTransform(node.nodes);
+	let rawNodes = node.nodes;
+	if (value === 'rgb' || value === 'hsl') {
+		rawNodes = convertOldSyntaxToNewSyntaxBeforeTransform(rawNodes);
+	}
+
 	const relevantNodes = rawNodes.slice().filter((x) => {
 		return x.type !== 'comment' && x.type !== 'space';
 	});

--- a/plugins/postcss-color-functional-notation/test/basic.css
+++ b/plugins/postcss-color-functional-notation/test/basic.css
@@ -61,3 +61,13 @@
 .test-unparseable-color-function {
 	color: rgb(; );
 }
+
+.rgb-with-alpha {
+	color: rgb(70% 13.5% 13.5% / 50%);
+	color: rgb(0, 0, 0, 0);
+}
+
+.hsl-with-alpha {
+	color: hsl(120 100% 50% / 50%);
+	color: hsl(120, 100%, 50%, 0);
+}

--- a/plugins/postcss-color-functional-notation/test/basic.expect.css
+++ b/plugins/postcss-color-functional-notation/test/basic.expect.css
@@ -61,3 +61,13 @@
 .test-unparseable-color-function {
 	color: rgb(; );
 }
+
+.rgb-with-alpha {
+	color: rgba(178, 34, 34, 0.5);
+	color: rgba(0, 0, 0, 0);
+}
+
+.hsl-with-alpha {
+	color: hsla(120, 100%, 50%, 0.5);
+	color: hsla(120, 100%, 50%, 0);
+}

--- a/plugins/postcss-color-functional-notation/test/basic.preserve-true.expect.css
+++ b/plugins/postcss-color-functional-notation/test/basic.preserve-true.expect.css
@@ -97,3 +97,17 @@
 .test-unparseable-color-function {
 	color: rgb(; );
 }
+
+.rgb-with-alpha {
+	color: rgba(178, 34, 34, 0.5);
+	color: rgb(70% 13.5% 13.5% / 50%);
+	color: rgba(0, 0, 0, 0);
+	color: rgb(0, 0, 0, 0);
+}
+
+.hsl-with-alpha {
+	color: hsla(120, 100%, 50%, 0.5);
+	color: hsl(120 100% 50% / 50%);
+	color: hsla(120, 100%, 50%, 0);
+	color: hsl(120, 100%, 50%, 0);
+}


### PR DESCRIPTION
fixes : https://github.com/csstools/postcss-preset-env/issues/162