### PR TITLE
fix browser script exports

### DIFF
--- a/plugins/css-blank-pseudo/CHANGELOG.md
+++ b/plugins/css-blank-pseudo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to CSS Blank Pseudo
 
+### 3.0.1
+
+- Fixed: require/import paths for browser script
+
 ### 3.0.0 (December 13, 2021)
 
 - Breaking: require/import paths have changed

--- a/plugins/css-blank-pseudo/package.json
+++ b/plugins/css-blank-pseudo/package.json
@@ -15,7 +15,9 @@
       "default": "./dist/index.mjs"
     },
     "./browser": {
-      "default": "./dist/browser.js"
+      "import": "./dist/browser.mjs",
+      "require": "./dist/browser.cjs",
+      "default": "./dist/browser.mjs"
     },
     "./browser-global": {
       "default": "./dist/browser-global.js"

--- a/plugins/css-has-pseudo/CHANGELOG.md
+++ b/plugins/css-has-pseudo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to CSS Has Pseudo
 
+### 3.0.1
+
+- Fixed: require/import paths for browser script
+
 ### 3.0.0 (December 13, 2021)
 
 - Breaking: require/import paths have changed

--- a/plugins/css-has-pseudo/package.json
+++ b/plugins/css-has-pseudo/package.json
@@ -15,7 +15,9 @@
       "default": "./dist/index.mjs"
     },
     "./browser": {
-      "default": "./dist/browser.js"
+      "import": "./dist/browser.mjs",
+      "require": "./dist/browser.cjs",
+      "default": "./dist/browser.mjs"
     },
     "./browser-global": {
       "default": "./dist/browser-global.js"

--- a/plugins/css-prefers-color-scheme/CHANGELOG.md
+++ b/plugins/css-prefers-color-scheme/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to Prefers Color Scheme
 
+### 6.0.1
+
+- Fixed: require/import paths for browser script
+
 ### 6.0.0 (December 13, 2021)
 
 - Breaking: require/import paths have changed

--- a/plugins/css-prefers-color-scheme/package.json
+++ b/plugins/css-prefers-color-scheme/package.json
@@ -15,7 +15,9 @@
       "default": "./dist/index.mjs"
     },
     "./browser": {
-      "default": "./dist/browser.js"
+      "import": "./dist/browser.mjs",
+      "require": "./dist/browser.cjs",
+      "default": "./dist/browser.mjs"
     },
     "./browser-global": {
       "default": "./dist/browser-global.js"

--- a/rollup/presets/browser.javascript.js
+++ b/rollup/presets/browser.javascript.js
@@ -29,6 +29,7 @@ export function browserJavascript() {
 			input: 'src/browser.js',
 			output: [
 				{ file: 'dist/browser.cjs', format: 'cjs', sourcemap: true, exports: 'auto', strict: false },
+				{ file: 'dist/browser.mjs', format: 'esm', sourcemap: true, exports: 'auto', strict: false },
 			],
 			external: externalsForBrowser,
 			plugins: [


### PR DESCRIPTION
This was very broken :/

`"default": "./dist/browser.js"`

`browser.js` does not exist, only `browser.cjs`

This change should ensure that both `require` and `import` will work correctly.