### PR TITLE
add plugin id help for config's

### DIFF
--- a/plugin-packs/postcss-preset-env/.tape.js
+++ b/plugin-packs/postcss-preset-env/.tape.js
@@ -218,5 +218,15 @@ module.exports = {
 				}
 			});
 		}
+	},
+	"unknown-feature": {
+		message: 'warns on unknown features',
+		warnings: 2,
+		options: {
+			features: {
+				"custom-media": true,
+				"postcss-logica": true,
+			}
+		},
 	}
 };

--- a/plugin-packs/postcss-preset-env/.tape.js
+++ b/plugin-packs/postcss-preset-env/.tape.js
@@ -114,49 +114,49 @@ module.exports = {
 		}
 	},
 	'insert:before': {
-		message: 'supports { stage: 1, features: { "color-mod-function": true }, insertBefore: { "color-mod-function": [ require("postcss-simple-vars") ] } } usage',
+		message: 'supports { stage: 1, features: { "lab-function": true }, insertBefore: { "lab-function": [ require("postcss-simple-vars") ] } } usage',
 		options: {
 			stage: 1,
 			features: {
-				'color-mod-function': true
+				'lab-function': true
 			},
 			insertBefore: {
-				'color-mod-function': [
+				'lab-function': [
 					require('postcss-simple-vars')()
 				]
 			}
 		}
 	},
 	'insert:after': {
-		message: 'supports { stage: 1, insertAfter: { "color-mod-function": [ require("postcss-simple-vars")() ] } } usage',
+		message: 'supports { stage: 1, insertAfter: { "lab-function": [ require("postcss-simple-vars")() ] } } usage',
 		options: {
 			stage: 1,
 			insertAfter: {
-				'color-mod-function': require('postcss-simple-vars')()
+				'lab-function': require('postcss-simple-vars')()
 			}
 		},
 	},
 	'insert:after:exec': {
-		message: 'supports { stage: 2, features: { "color-mod-function": { unresolved: "ignore" } }, insertAfter: { "color-mod-function": require("postcss-simple-vars")() } } usage',
+		message: 'supports { stage: 2, features: { "lab-function": { unresolved: "ignore" } }, insertAfter: { "lab-function": require("postcss-simple-vars")() } } usage',
 		options: {
 			stage: 2,
 			insertAfter: {
-				'color-mod-function': require('postcss-simple-vars')()
+				'lab-function': require('postcss-simple-vars')()
 			}
 		},
 		expect: 'insert.after.expect.css'
 	},
 	'insert:after:array': {
-		message: 'supports { stage: 1, after: { "color-mod-function": [ require("postcss-simple-vars") ] } } usage',
+		message: 'supports { stage: 1, after: { "lab-function": [ require("postcss-simple-vars") ] } } usage',
 		options: {
 			stage: 1,
 			insertAfter: {
-				'color-mod-function': [
+				'lab-function': [
 					require('postcss-simple-vars')()
 				]
 			},
 			features: {
-				'color-mod-function': {
+				'lab-function': {
 					unresolved: 'ignore'
 				}
 			}
@@ -221,10 +221,11 @@ module.exports = {
 	},
 	"unknown-feature": {
 		message: 'warns on unknown features',
-		warnings: 2,
+		warnings: 3,
 		options: {
 			features: {
 				"custom-media": true,
+				"postcss-logical": true,
 				"postcss-logica": true,
 			}
 		},

--- a/plugin-packs/postcss-preset-env/src/index.js
+++ b/plugin-packs/postcss-preset-env/src/index.js
@@ -1,16 +1,18 @@
 import autoprefixer from 'autoprefixer';
 import browserslist from 'browserslist';
 import cssdb from 'cssdb';
-import plugins from './lib/plugins-by-id';
+import { pluginsById as plugins } from './lib/plugins-by-id';
 import getTransformedInsertions from './lib/get-transformed-insertions';
 import getUnsupportedBrowsersByFeature from './lib/get-unsupported-browsers-by-feature';
 import idsByExecutionOrder from './lib/ids-by-execution-order';
 import writeToExports from './lib/write-to-exports';
 import getOptionsForBrowsersByFeature from './lib/get-options-for-browsers-by-feature';
+import { pluginIdHelp } from './lib/plugin-id-help';
 
 const plugin = opts => {
 	// initialize options
 	const features = Object(Object(opts).features);
+	const featureNamesInOptions = Object.keys(features);
 	const insertBefore = Object(Object(opts).insertBefore);
 	const insertAfter = Object(Object(opts).insertAfter);
 	const browsers = Object(opts).browsers;
@@ -113,14 +115,24 @@ const plugin = opts => {
 	const usedPlugins = supportedFeatures.map(feature => feature.plugin);
 	usedPlugins.push(stagedAutoprefixer);
 
+	const internalPlugin = () => {
+		return {
+			postcssPlugin: 'postcss-preset-env',
+			OnceExit: function (root, { result }) {
+				pluginIdHelp(featureNamesInOptions, root, result);
+				if (Object(opts).exportTo) {
+					writeToExports(sharedOpts.exportTo, opts.exportTo);
+				}
+			},
+		};
+	};
+
+	internalPlugin.postcss = true;
+
 	return {
 		postcssPlugin: 'postcss-preset-env',
-		plugins: usedPlugins,
-		OnceExit: function() {
-			if ( Object( opts ).exportTo ) {
-				writeToExports( sharedOpts.exportTo, opts.exportTo );
-			}
-		},
+		plugins: [...usedPlugins, internalPlugin()],
+
 	};
 };
 

--- a/plugin-packs/postcss-preset-env/src/lib/plugin-id-help.js
+++ b/plugin-packs/postcss-preset-env/src/lib/plugin-id-help.js
@@ -1,0 +1,59 @@
+import { idsToPackageNames, packageNamesToIds } from './plugins-by-id';
+
+export function pluginIdHelp(featureNamesInOptions, root, result) {
+	const featureNames = Object.keys(idsToPackageNames);
+	const packageNames = Object.keys(packageNamesToIds);
+	featureNamesInOptions.forEach((featureName) => {
+		if (featureNames.includes(featureName)) {
+			return;
+		}
+
+		const byId = mostSimilar(featureName, featureNames);
+		const byPackage = mostSimilar(featureName, packageNames);
+
+		if (byId.distance < byPackage.distance) {
+			root.warn(result, `Unknown feature: "${featureName}" did you mean: "${byId.mostSimilar}"`);
+		} else {
+			root.warn(result, `Unknown feature: "${featureName}" did you mean: "${packageNamesToIds[byPackage.mostSimilar]}"`);
+		}
+	});
+}
+
+function mostSimilar(a, b) {
+	let mostSimilar = 'unknown';
+	let leastDistance = Infinity;
+
+	for (let j = 0; j < b.length; j++) {
+		const distance = levenshteinDistance(a, b[j]);
+		if (distance < leastDistance) {
+			leastDistance = distance;
+			mostSimilar = b[j];
+		}
+	}
+
+	return {
+		mostSimilar: mostSimilar,
+		distance: leastDistance,
+	};
+}
+
+function levenshteinDistance(s, t) {
+	if (!s.length) return t.length;
+	if (!t.length) return s.length;
+	const arr = [];
+	for (let i = 0; i <= t.length; i++) {
+		arr[i] = [i];
+		for (let j = 1; j <= s.length; j++) {
+			arr[i][j] =
+				i === 0
+					? j
+					: Math.min(
+							arr[i - 1][j] + 1,
+							arr[i][j - 1] + 1,
+							arr[i - 1][j - 1] + (s[j - 1] === t[i - 1] ? 0 : 1),
+						);
+		}
+	}
+	return arr[t.length][s.length];
+}
+

--- a/plugin-packs/postcss-preset-env/src/lib/plugin-id-help.js
+++ b/plugin-packs/postcss-preset-env/src/lib/plugin-id-help.js
@@ -11,6 +11,10 @@ export function pluginIdHelp(featureNamesInOptions, root, result) {
 		const byId = mostSimilar(featureName, featureNames);
 		const byPackage = mostSimilar(featureName, packageNames);
 
+		// TODO :
+		// 1. create markdown docs with the plugin id's
+		// 2. set a distance limit (>10) and if above output link to docs.
+
 		if (byId.distance < byPackage.distance) {
 			root.warn(result, `Unknown feature: "${featureName}" did you mean: "${byId.mostSimilar}"`);
 		} else {

--- a/plugin-packs/postcss-preset-env/src/lib/plugins-by-id.js
+++ b/plugin-packs/postcss-preset-env/src/lib/plugins-by-id.js
@@ -29,8 +29,50 @@ import postcssPseudoClassAnyLink from 'postcss-pseudo-class-any-link';
 import postcssReplaceOverflowWrap from 'postcss-replace-overflow-wrap';
 import postcssSelectorNot from 'postcss-selector-not';
 
+export const packageNamesToIds = {
+	'css-blank-pseudo': 'blank-pseudo-class',
+	'css-has-pseudo': 'has-pseudo-class',
+	'css-prefers-color-scheme': 'prefers-color-scheme-query',
+	'postcss-attribute-case-insensitive': 'case-insensitive-attributes',
+	'postcss-color-functional-notation': 'color-functional-notation',
+	'postcss-color-hex-alpha': 'hexadecimal-alpha-notation',
+	'postcss-color-rebeccapurple': 'rebeccapurple-color',
+	'postcss-custom-media': 'custom-media-queries',
+	'postcss-custom-properties': 'custom-properties',
+	'postcss-custom-selectors': 'custom-selectors',
+	'postcss-dir-pseudo-class': 'dir-pseudo-class',
+	'postcss-double-position-gradients': 'double-position-gradients',
+	'postcss-env-function': 'environment-variables',
+	'postcss-focus-visible': 'focus-visible-pseudo-class',
+	'postcss-focus-within': 'focus-within-pseudo-class',
+	'postcss-font-variant': 'font-variant-property',
+	'postcss-gap-properties': 'gap-properties',
+	'postcss-image-set-function': 'image-set-function',
+	'postcss-initial': 'all-property',
+	'postcss-lab-function': 'lab-function',
+	'postcss-logical': 'logical-properties-and-values',
+	'postcss-media-minmax': 'media-query-ranges',
+	'postcss-nesting': 'nesting-rules',
+	'postcss-overflow-shorthand': 'overflow-property',
+	'postcss-page-break': 'break-properties',
+	'postcss-place': 'place-properties',
+	'postcss-pseudo-class-any-link': 'any-link-pseudo-class',
+	'postcss-replace-overflow-wrap': 'overflow-wrap-property',
+	'postcss-selector-not': 'not-pseudo-class',
+	'postcss-system-ui-font-family': 'system-ui-font-family',
+};
+
+export const idsToPackageNames = (() => {
+	const out = {};
+	for (const [packageName, id] of Object.entries(packageNamesToIds)) {
+		out[id] = packageName;
+	}
+
+	return out;
+})();
+
 // postcss plugins ordered by id
-export default {
+export const pluginsById = {
 	'all-property': postcssInitial,
 	'any-link-pseudo-class': postcssPseudoClassAnyLink,
 	'blank-pseudo-class': postcssBlankPseudo,

--- a/plugin-packs/postcss-preset-env/test/insert.after.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.after.expect.css
@@ -1,5 +1,3 @@
-$font: system-ui;
-
 .test-variable {
-	font-family: $font;
+	font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
 }

--- a/plugin-packs/postcss-preset-env/test/unknown-feature.css
+++ b/plugin-packs/postcss-preset-env/test/unknown-feature.css
@@ -1,0 +1,3 @@
+.foo {
+	content: 'file contents are not important here';
+}

--- a/plugin-packs/postcss-preset-env/test/unknown-feature.expect.css
+++ b/plugin-packs/postcss-preset-env/test/unknown-feature.expect.css
@@ -1,0 +1,3 @@
+.foo {
+	content: 'file contents are not important here';
+}


### PR DESCRIPTION
partial fix for : https://github.com/csstools/postcss-preset-env/issues/156

Also see : https://github.com/csstools/postcss-plugins/discussions/86#discussioncomment-1887319

Uses a levenshtein distance to possibly suggest the correct plugin.

```
options: {
	features: {
		"custom-media": true,
		"postcss-logical": true,
		"postcss-logica": true,
	}
},
```

```
Unknown feature: "custom-media" did you mean: "custom-media-queries"
Unknown feature: "postcss-logical" did you mean: "logical-properties-and-values"
Unknown feature: "postcss-logica" did you mean: "logical-properties-and-values"
```

----------

Tests failed because we still had some that were using `color-mod` and this then throw warnings with the new help stuff.

Maybe the entire `insertBefore` `insertAfter` stuff is outdated since this is no longer of PostCSS plugins run? But this is outside the scope of this change.
