### PR TITLE
preset-env : fix after/before and export tests

### DIFF
--- a/plugin-packs/postcss-preset-env/.tape.js
+++ b/plugin-packs/postcss-preset-env/.tape.js
@@ -200,10 +200,13 @@ module.exports = {
 			}
 		}
 	},
-	'insert:after:match-result': {
-		message: 'supports { stage: 2, features: { "lab-function": { unresolved: "ignore" } }, insertAfter: { "lab-function": require("postcss-simple-vars")() } } usage',
+	'insert:after:match-result:exec': {
+		message: 'supports { insertAfter with a single plugin, not an array } usage when looking for a result',
 		options: {
-			stage: 2,
+			stage: 0,
+			features: {
+				'lab-function': true
+			},
 			insertAfter: {
 				'lab-function': orderDetectionPlugin('after', (decl) => {
 					return decl.value.indexOf('rgba(') === 0;

--- a/plugin-packs/postcss-preset-env/.tape.js
+++ b/plugin-packs/postcss-preset-env/.tape.js
@@ -1,3 +1,17 @@
+const orderDetectionPlugin = (prop, changeWhenMatches) => {
+	return {
+		postcssPlugin: 'order-detection',
+		Declaration(decl) {
+			if (changeWhenMatches(decl)) {
+				decl.prop = prop;
+				decl.value = 'changed-this-declaration';
+			}
+		},
+	}
+}
+
+orderDetectionPlugin.postcss = true
+
 module.exports = {
 	'basic': {
 		message: 'supports basic usage'
@@ -113,55 +127,90 @@ module.exports = {
 			}
 		}
 	},
-	'insert:before': {
-		message: 'supports { stage: 1, features: { "lab-function": true }, insertBefore: { "lab-function": [ require("postcss-simple-vars") ] } } usage',
+	'insert:baseline': {
+		message: 'supports { insertBefore/insertAfter } usage baseline',
 		options: {
-			stage: 1,
+			stage: 0,
+			features: {
+				'lab-function': true
+			}
+		}
+	},
+	'insert:before:match-source': {
+		message: 'supports { insertBefore } usage when looking for source',
+		options: {
+			stage: 0,
 			features: {
 				'lab-function': true
 			},
 			insertBefore: {
 				'lab-function': [
-					require('postcss-simple-vars')()
+					orderDetectionPlugin('before', (decl) => {
+						return decl.value.indexOf('lab(') === 0;
+					})
 				]
 			}
 		}
 	},
-	'insert:after': {
-		message: 'supports { stage: 1, insertAfter: { "lab-function": [ require("postcss-simple-vars")() ] } } usage',
+	'insert:before:match-result': {
+		message: 'supports { insertBefore } usage when looking for a result',
 		options: {
-			stage: 1,
-			insertAfter: {
-				'lab-function': require('postcss-simple-vars')()
+			stage: 0,
+			features: {
+				'lab-function': true
+			},
+			insertBefore: {
+				'lab-function': [
+					orderDetectionPlugin('before', (decl) => {
+						return decl.value.indexOf('rgba(') === 0;
+					})
+				]
 			}
-		},
+		}
 	},
-	'insert:after:exec': {
+	'insert:after:match-source': {
+		message: 'supports { insertAfter } usage when looking for source',
+		options: {
+			stage: 0,
+			features: {
+				'lab-function': true
+			},
+			insertAfter: {
+				'lab-function': [
+					orderDetectionPlugin('after', (decl) => {
+						return decl.value.indexOf('lab(') === 0;
+					})
+				]
+			}
+		}
+	},
+	'insert:after:match-result': {
+		message: 'supports { insertAfter } usage when looking for a result',
+		options: {
+			stage: 0,
+			features: {
+				'lab-function': true
+			},
+			insertAfter: {
+				'lab-function': [
+					orderDetectionPlugin('after', (decl) => {
+						return decl.value.indexOf('rgba(') === 0;
+					})
+				]
+			}
+		}
+	},
+	'insert:after:match-result': {
 		message: 'supports { stage: 2, features: { "lab-function": { unresolved: "ignore" } }, insertAfter: { "lab-function": require("postcss-simple-vars")() } } usage',
 		options: {
 			stage: 2,
 			insertAfter: {
-				'lab-function': require('postcss-simple-vars')()
+				'lab-function': orderDetectionPlugin('after', (decl) => {
+					return decl.value.indexOf('rgba(') === 0;
+				})
 			}
 		},
-		expect: 'insert.after.expect.css'
-	},
-	'insert:after:array': {
-		message: 'supports { stage: 1, after: { "lab-function": [ require("postcss-simple-vars") ] } } usage',
-		options: {
-			stage: 1,
-			insertAfter: {
-				'lab-function': [
-					require('postcss-simple-vars')()
-				]
-			},
-			features: {
-				'lab-function': {
-					unresolved: 'ignore'
-				}
-			}
-		},
-		expect: 'insert.after.expect.css'
+		expect: 'insert.after.match-result.expect.css'
 	},
 	'import': {
 		message: 'supports { importFrom: { customMedia, customProperties, customSelectors, environmentVariables } } usage',
@@ -197,12 +246,24 @@ module.exports = {
 		expect: 'basic.stage0.expect.css',
 		result: 'basic.stage0.result.css',
 		before() {
-			global.__exportTo = {
-				css: require('fs').readFileSync('test/generated-custom-exports.css', 'utf8'),
-				js: require('fs').readFileSync('test/generated-custom-exports.js', 'utf8'),
-				json: require('fs').readFileSync('test/generated-custom-exports.json', 'utf8'),
-				mjs: require('fs').readFileSync('test/generated-custom-exports.mjs', 'utf8')
-			};
+			try {
+				global.__exportTo = {
+					css: require('fs').readFileSync('test/generated-custom-exports.css', 'utf8'),
+					js: require('fs').readFileSync('test/generated-custom-exports.js', 'utf8'),
+					json: require('fs').readFileSync('test/generated-custom-exports.json', 'utf8'),
+					mjs: require('fs').readFileSync('test/generated-custom-exports.mjs', 'utf8')
+				};
+
+				require('fs').rmSync('test/generated-custom-exports.css');
+				require('fs').rmSync('test/generated-custom-exports.js');
+				require('fs').rmSync('test/generated-custom-exports.json');
+				require('fs').rmSync('test/generated-custom-exports.mjs');
+			} catch (_) {
+				// ignore errors here.
+				// If the files are removed manually test run will regenerate these.
+				// The after step will still fail.
+				// The real test is in the after step.
+			}
 		},
 		after() {
 			global.__exportAs = {

--- a/plugin-packs/postcss-preset-env/src/index.js
+++ b/plugin-packs/postcss-preset-env/src/index.js
@@ -132,7 +132,6 @@ const plugin = opts => {
 	return {
 		postcssPlugin: 'postcss-preset-env',
 		plugins: [...usedPlugins, internalPlugin()],
-
 	};
 };
 

--- a/plugin-packs/postcss-preset-env/test/insert.after.array.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.after.array.expect.css
@@ -1,0 +1,3 @@
+.test-variable {
+	color: rgba(0, 0, 0, 0);
+}

--- a/plugin-packs/postcss-preset-env/test/insert.after.array.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.after.array.expect.css
@@ -1,3 +1,0 @@
-.test-variable {
-	color: rgba(0, 0, 0, 0);
-}

--- a/plugin-packs/postcss-preset-env/test/insert.after.exec.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.after.exec.expect.css
@@ -1,0 +1,3 @@
+.test-variable {
+	color: rgba(0, 0, 0, 0);
+}

--- a/plugin-packs/postcss-preset-env/test/insert.after.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.after.expect.css
@@ -1,3 +1,0 @@
-.test-variable {
-	font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
-}

--- a/plugin-packs/postcss-preset-env/test/insert.after.match-result.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.after.match-result.expect.css
@@ -1,0 +1,3 @@
+.test-variable {
+	after: changed-this-declaration;
+}

--- a/plugin-packs/postcss-preset-env/test/insert.after.match-source.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.after.match-source.expect.css
@@ -1,0 +1,3 @@
+.test-variable {
+	color: rgba(0, 0, 0, 0);
+}

--- a/plugin-packs/postcss-preset-env/test/insert.baseline.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.baseline.expect.css
@@ -1,0 +1,3 @@
+.test-variable {
+	color: rgba(0, 0, 0, 0);
+}

--- a/plugin-packs/postcss-preset-env/test/insert.before.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.before.expect.css
@@ -1,3 +1,0 @@
-.test-variable {
-	font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
-}

--- a/plugin-packs/postcss-preset-env/test/insert.before.match-result.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.before.match-result.expect.css
@@ -1,0 +1,3 @@
+.test-variable {
+	before: changed-this-declaration;
+}

--- a/plugin-packs/postcss-preset-env/test/insert.before.match-source.expect.css
+++ b/plugin-packs/postcss-preset-env/test/insert.before.match-source.expect.css
@@ -1,0 +1,3 @@
+.test-variable {
+	before: changed-this-declaration;
+}

--- a/plugin-packs/postcss-preset-env/test/insert.css
+++ b/plugin-packs/postcss-preset-env/test/insert.css
@@ -1,5 +1,3 @@
-$font: system-ui;
-
 .test-variable {
-	font-family: $font;
+	color: lab(0% 0 0 / 0%);
 }


### PR DESCRIPTION
## insertBefore / insertAfter

see : https://github.com/csstools/postcss-plugins/pull/103#discussion_r777131651

| insert | matches | should change | why |
| ---- | ---- | ---- | --- |
| `before` | `source` | yes | it runs before other plugins |
| `before` | `result` | yes | PostCSS 8 revisits changed nodes |
| `after` | `source` | no | source has been changed by other plugins |
| `after` | `result` | yes | it runs after other plugins |

I added tests that check all these options and this seems to work.
So there is nuance in PostCSS 8 plugin execution order.

Plugin execution has an order. But because nodes are revisited, plugins that come before can still do their work after other plugins.

I assume this will be different if one or more of the plugins have `async` functions.

-------

## exportTo

see : https://github.com/csstools/postcss-plugins/pull/103#discussion_r777125676

These tests had false positives before.

The test result files were tracked by git so always existed and the test just checked that they matched the contents before and after the test.

Because the `exportTo` functionality never ran after updating to PostCSS 8 the files were never changed. Tests passed simply because the files existed.

I updated the test to remove the files during the run.
If we have a regression and `exportTo` breaks again, tests will fail.

