### PR TITLE
document autoprefixer grid edge case

### DIFF
--- a/plugin-packs/postcss-preset-env/README.md
+++ b/plugin-packs/postcss-preset-env/README.md
@@ -240,10 +240,10 @@ Becomes :
 }
 ```
 
-The prefixed `-ms-grid-columns` still has a custom property: `1fr var(--grid-gap) 1fr;` which won't work.
+The prefixed `-ms-grid-columns` still has a custom property: `1fr var(--grid-gap) 1fr;` which won't work.<br />
 This example shows issues with custom properties but other transforms might have similar issues.
 
-If you target IE or older Edge it is best to avoid using other modern features in grid property values.
+If you target IE or older Edge it is best to avoid using other modern features in grid property values.<br />
 As a last resort you can set [`preserve: false`](#preserve), we do not advice this as doing so purely to fix issues with CSS grid.
 
 _older Edge is any version before chromium (<79)_

--- a/plugin-packs/postcss-preset-env/README.md
+++ b/plugin-packs/postcss-preset-env/README.md
@@ -214,6 +214,37 @@ postcssPresetEnv({
 
 Passing `autoprefixer: false` disables autoprefixer.
 
+⚠️ [autoprefixer] has [complex logic to fix CSS Grid in IE en older Edge](https://github.com/postcss/autoprefixer#grid-autoplacement-support-in-ie).
+
+This can have unexpected results when [`preserve: true`](#preserve) is used. (defaults to `true`)
+
+```pcss
+:root {
+  --grid-gap: 15px;
+}
+
+.test-grid {
+	grid-gap: var(--grid-gap);
+	grid-template-columns: repeat(2, 1fr);
+}
+```
+
+Becomes :
+
+```
+.test-grid {
+	grid-gap: 15px;
+	grid-gap: var(--grid-gap);
+	-ms-grid-columns: 1fr var(--grid-gap) 1fr;
+	grid-template-columns: repeat(2, 1fr);
+}
+```
+
+The prefixed `-ms-grid-columns` still has a custom property: `1fr var(--grid-gap) 1fr;` which won't work.
+If you target IE or older Edge you can set [`preserve: false`](#preserve) or avoid certain features in grid related properties.
+
+_older Edge is any version before chromium (<79)_
+
 ### preserve
 
 The `preserve` option determines whether all plugins should receive a

--- a/plugin-packs/postcss-preset-env/README.md
+++ b/plugin-packs/postcss-preset-env/README.md
@@ -216,7 +216,7 @@ Passing `autoprefixer: false` disables autoprefixer.
 
 ⚠️ [autoprefixer] has [complex logic to fix CSS Grid in IE en older Edge](https://github.com/postcss/autoprefixer#grid-autoplacement-support-in-ie).
 
-This can have unexpected results when [`preserve: true`](#preserve) is used. (defaults to `true`)
+This can have unexpected results with certain features and when [`preserve: true`](#preserve) is used. (defaults to `true`)
 
 ```pcss
 :root {
@@ -241,7 +241,10 @@ Becomes :
 ```
 
 The prefixed `-ms-grid-columns` still has a custom property: `1fr var(--grid-gap) 1fr;` which won't work.
-If you target IE or older Edge you can set [`preserve: false`](#preserve) or avoid certain features in grid related properties.
+This example shows issues with custom properties but other transforms might have similar issues.
+
+If you target IE or older Edge it is best to avoid using other modern features in grid property values.
+As a last resort you can set [`preserve: false`](#preserve), we do not advice this as doing so purely to fix issues with CSS grid.
 
 _older Edge is any version before chromium (<79)_
 


### PR DESCRIPTION
see : https://github.com/postcss/autoprefixer/issues/1442#issuecomment-1008939516

I ended up deciding it is best we document this here.
The `preserve` option is something we mainly do and we set a fixed order of plugins.
Both of which contribute to the issue.