### PR TITLE
fix custom properties node 12/14

### DIFF
--- a/plugins/postcss-custom-properties/tsconfig.json
+++ b/plugins/postcss-custom-properties/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "declarationDir": ".",
-    "module": "es2020"
+    "module": "es6"
   },
   "include": ["./src/**/*"],
   "exclude": ["dist"],


### PR DESCRIPTION
I changed this when I was working on a bit that eventually got removed.
Changing it apparently breaks node 12/14 support.
I would have expected babel to still correctly transpile everything after typescript.

(was trying to get the importFrom with script files to run in sandboxed vm's)