### PR TITLE
custom properties : plugin reset on exit

### DIFF
--- a/plugins/postcss-custom-properties/CHANGELOG.md
+++ b/plugins/postcss-custom-properties/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to PostCSS Custom Properties
 
+### Unreleased (patch)
+
+- Reset plugin state after each process. It is now safe to use the plugin multiple times for different processes or when watching.
+
 ### 12.1.2 (January 12, 2022)
 
 - Fix TypeScript transpilation.

--- a/plugins/postcss-custom-properties/src/index.ts
+++ b/plugins/postcss-custom-properties/src/index.ts
@@ -19,7 +19,6 @@ export interface PluginOptions {
 
 	/** Specifies if `importFrom` properties or `:root` properties have priority. */
 	overrideImportFromWithRoot?: boolean
-
 }
 
 const creator: PluginCreator<PluginOptions> = (opts?: PluginOptions) => {
@@ -62,6 +61,9 @@ const creator: PluginCreator<PluginOptions> = (opts?: PluginOptions) => {
 					Declaration: (decl) => {
 						transformProperties(decl, customProperties, { preserve });
 					},
+					OnceExit: () => {
+						customProperties.clear();
+					},
 				};
 			} else {
 				return {
@@ -83,6 +85,9 @@ const creator: PluginCreator<PluginOptions> = (opts?: PluginOptions) => {
 					},
 					Declaration: (decl) => {
 						transformProperties(decl, customProperties, { preserve });
+					},
+					OnceExit: () => {
+						customProperties.clear();
 					},
 				};
 			}


### PR DESCRIPTION
When using the same plugin object for multiple processes or with a watcher there is an edge case we don't currently handle :

1. re-use the same instance
2. add a custom property declaration on `:root`
3. process runs
4. (accidentally) remove the declaration from `:root`
5. process runs again
6. the removed variable still exists in the `Map` on the plugin instance and can be used to polyfill

This can lead to hard to debug cases where something worked locally with a watcher running and then breaks after a build in CI.