### PR TITLE
cli : emit warnings

### DIFF
--- a/cli/csstools-cli/CHANGELOG.md
+++ b/cli/csstools-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to CSSTools CLI
 
+### Unreleased (patch)
+
+- Emit warnings from plugins
+
 ### 1.0.0 (January 2, 2022)
 
 - Initial version

--- a/packages/base-cli/src/io-fs-to-fs.ts
+++ b/packages/base-cli/src/io-fs-to-fs.ts
@@ -22,6 +22,10 @@ export async function fsToFs(plugin: Plugin, argo: Arguments): Promise<never> {
 				map: (argo.inlineMap || argo.externalMap) ? { inline: argo.inlineMap } : false,
 			});
 
+			result.warnings().forEach(warn => {
+				console.warn(warn.toString());
+			});
+
 			if (argo.externalMap && result.map) {
 				await Promise.all([
 					await fsp.writeFile(output, result.css + (argo.inlineMap ? '\n' : '')),

--- a/packages/base-cli/src/io-fs-to-stdout.ts
+++ b/packages/base-cli/src/io-fs-to-stdout.ts
@@ -14,6 +14,10 @@ export async function fsToStdout(plugin: Plugin, argo: Arguments): Promise<never
 				map: false,
 			});
 
+			result.warnings().forEach(warn => {
+				console.warn(warn.toString());
+			});
+
 			return result.css;
 		}));
 	} catch (error) {

--- a/packages/base-cli/src/io-stdin-to-fs.ts
+++ b/packages/base-cli/src/io-stdin-to-fs.ts
@@ -25,6 +25,10 @@ export async function stdinToFs(plugin: Plugin, argo: Arguments, helpLogger: () 
 			map: (argo.inlineMap || argo.externalMap) ? { inline: argo.inlineMap } : false,
 		});
 
+		result.warnings().forEach(warn => {
+			console.warn(warn.toString());
+		});
+
 		if (argo.externalMap && result.map) {
 			await Promise.all([
 				await fsp.writeFile(output, result.css + (argo.inlineMap ? '\n' : '')),

--- a/packages/base-cli/src/io-stdin-to-stdout.ts
+++ b/packages/base-cli/src/io-stdin-to-stdout.ts
@@ -20,6 +20,10 @@ export async function stdinToStdout(plugin: Plugin, argo : Arguments, helpLogger
 			map: argo.inlineMap ? { inline: true } : false,
 		});
 
+		result.warnings().forEach(warn => {
+			console.warn(warn.toString());
+		});
+
 		resultCSS = result.css;
 	} catch (error) {
 		console.error(argo.debug ? error : error.message);


### PR DESCRIPTION
Warnings were previously thrown away by the cli.
This was not intentional.

This change emits all warnings over `stderr`.

`stdout` is not poluted.

```
echo ".foo:dir(ltr) .baz:dir(rtl) { padding-inline: 20px 40px; }" | npx @csstools/csstools-cli postcss-dir-pseudo-class > out.css
```

In this case `out.css` will not contain the warning.
The warning will appear in the console.