### PR TITLE
add a shortcut to rewrite expect files and log warnings

### DIFF
--- a/packages/postcss-tape/src/format-asserts.ts
+++ b/packages/postcss-tape/src/format-asserts.ts
@@ -1,3 +1,5 @@
+import type { Warning } from 'postcss';
+
 export const dashesSeparator = '----------------------------------------';
 
 export function formatCSSAssertError(testCaseLabel, testCaseOptions, err, forGithubAnnotation = false) {
@@ -25,7 +27,7 @@ export function formatCSSAssertError(testCaseLabel, testCaseOptions, err, forGit
 	return formatted;
 }
 
-export function formatWarningsAssertError(testCaseLabel, testCaseOptions, actual, expected, forGithubAnnotation = false) {
+export function formatWarningsAssertError(testCaseLabel, testCaseOptions, actual: Array<Warning>, expected: number, forGithubAnnotation = false) {
 	let formatted = '';
 	formatted += `\n${testCaseLabel}\n\n`;
 
@@ -41,9 +43,17 @@ export function formatWarningsAssertError(testCaseLabel, testCaseOptions, actual
 		}
 	}
 
-	formatted += `unexpected or missing warnings :\n+ actual ${actual}\n- expected ${expected}\n`;
+	formatted += `unexpected or missing warnings :\n+ actual ${actual.length}\n- expected ${expected}\n`;
 
 	if (!forGithubAnnotation) {
+		actual.forEach((warning) => {
+			formatted += `\n[${warning.plugin}]: ${warning.text}`;
+		});
+
+		if (actual.length) {
+			formatted += '\n';
+		}
+
 		formatted += '\n' + dashesSeparator;
 	}
 

--- a/packages/postcss-tape/src/index.ts
+++ b/packages/postcss-tape/src/index.ts
@@ -223,6 +223,11 @@ export default function runner(currentPlugin: PluginCreator<unknown>) {
 			const resultString = result.css.toString();
 			await fsp.writeFile(resultFilePath, resultString, 'utf8');
 
+			// Allow contributors to rewrite `.expect.css` files through postcss-tape.
+			if (process.env.REWRITE_EXPECTS) {
+				fsp.writeFile(expectFilePath, resultString, 'utf8');
+			}
+
 			// Can't do further checks if "expect" is missing.
 			if (expected === false) {
 				continue;

--- a/packages/postcss-tape/src/index.ts
+++ b/packages/postcss-tape/src/index.ts
@@ -357,18 +357,18 @@ export default function runner(currentPlugin: PluginCreator<unknown>) {
 					if (result.warnings().length || testCaseOptions.warnings) {
 						assert.strictEqual(result.warnings().length, testCaseOptions.warnings);
 					}
-				} catch (err) {
+				} catch (_) {
 					hasErrors = true;
 
 					if (emitGitHubAnnotations) {
 						console.log(formatGitHubActionAnnotation(
-							formatWarningsAssertError(testCaseLabel, testCaseOptions, result.warnings().length, testCaseOptions.warnings, true),
+							formatWarningsAssertError(testCaseLabel, testCaseOptions, result.warnings(), testCaseOptions.warnings, true),
 							'error',
 							{ file: normalizeFilePathForGithubAnnotation(expectFilePath), line: 1, col: 1 },
 						));
 					} else {
 						failureSummary.add(testCaseLabel);
-						console.error(formatWarningsAssertError(testCaseLabel, testCaseOptions, result.warnings().length, testCaseOptions.warnings));
+						console.error(formatWarningsAssertError(testCaseLabel, testCaseOptions, result.warnings(), testCaseOptions.warnings));
 					}
 				}
 			}

--- a/packages/postcss-tape/test-self/basic.with-warnings.expect.log
+++ b/packages/postcss-tape/test-self/basic.with-warnings.expect.log
@@ -19,6 +19,8 @@ unexpected or missing warnings :
 + actual 1
 - expected 0
 
+[a-plugin]: a warning
+
 ----------------------------------------
 
 basic:with-multiple-warnings
@@ -29,6 +31,10 @@ message :
 unexpected or missing warnings :
 + actual 3
 - expected 7
+
+[a-plugin]: a warning
+[a-plugin]: a warning
+[a-plugin]: a warning
 
 ----------------------------------------
 

--- a/plugin-packs/postcss-preset-env/package.json
+++ b/plugin-packs/postcss-preset-env/package.json
@@ -21,6 +21,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
     "test": "node .tape.mjs && npm run test:exports",
+    "test:rewrite-expects": "REWRITE_EXPECTS=true node .tape.mjs",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
   },
   "engines": {

--- a/plugins/css-blank-pseudo/package.json
+++ b/plugins/css-blank-pseudo/package.json
@@ -41,6 +41,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
     "test": "node .tape.mjs && npm run test:exports",
+    "test:rewrite-expects": "REWRITE_EXPECTS=true node .tape.mjs",
     "cli": "css-blank-pseudo",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
   },

--- a/plugins/postcss-base-plugin/package.json
+++ b/plugins/postcss-base-plugin/package.json
@@ -27,6 +27,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
     "test": "node .tape.mjs && npm run test:exports",
+    "test:rewrite-expects": "REWRITE_EXPECTS=true node .tape.mjs",
     "test:cli": "bash ./test/cli/test.sh",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
   },

--- a/plugins/postcss-custom-properties/package.json
+++ b/plugins/postcss-custom-properties/package.json
@@ -33,6 +33,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
     "test": "node .tape.mjs && node .tape.cjs && npm run test:exports",
+    "test:rewrite-expects": "REWRITE_EXPECTS=true node .tape.mjs",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
   },
   "engines": {

--- a/plugins/postcss-hwb-function/package.json
+++ b/plugins/postcss-hwb-function/package.json
@@ -30,6 +30,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
     "test": "node .tape.mjs && npm run test:exports",
+    "test:rewrite-expects": "REWRITE_EXPECTS=true node .tape.mjs",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
   },
   "engines": {

--- a/plugins/postcss-image-set-function/package.json
+++ b/plugins/postcss-image-set-function/package.json
@@ -22,6 +22,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
     "test": "node .tape.mjs && npm run test:exports",
+    "test:rewrite-expects": "REWRITE_EXPECTS=true node .tape.mjs",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
   },
   "engines": {

--- a/plugins/postcss-nesting/package.json
+++ b/plugins/postcss-nesting/package.json
@@ -31,6 +31,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
     "test": "node .tape.mjs && npm run test:exports",
+    "test:rewrite-expects": "REWRITE_EXPECTS=true node .tape.mjs",
     "test:deno": "deno run --unstable --allow-env --allow-read test/deno/test.js",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
   },

--- a/plugins/postcss-pseudo-class-any-link/package.json
+++ b/plugins/postcss-pseudo-class-any-link/package.json
@@ -21,6 +21,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
     "test": "node .tape.mjs && npm run test:exports",
+    "test:rewrite-expects": "REWRITE_EXPECTS=true node .tape.mjs",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
   },
   "engines": {


### PR DESCRIPTION
_adding it towards 7.3 because `postcss-tape` was touched there_

Running this will override all `expect` files to match `result` files.
The tests will still fail the first time as the original `expect` contents have been read into memory by the time this shortcut runs.

`npm run test:rewrite-expects`

------------

Warnings are now logged when the amounts do not match.