### PR TITLE
postcss-is-pseudo-class : browser tests and transform in 2 stages

### DIFF
--- a/plugins/postcss-is-pseudo-class/.tape.mjs
+++ b/plugins/postcss-is-pseudo-class/.tape.mjs
@@ -19,13 +19,19 @@ postcssTape(plugin)({
 	},
 	'basic:oncomplex:warning': {
 		message: "supports basic usage with { onComplexSelector: 'warning' }",
-		warnings: 8,
+		warnings: 11,
 		options: {
 			onComplexSelector: 'warning'
 		}
 	},
 	'browser': {
 		message: "prepare CSS for chrome test",
+		options: {
+			preserve: false
+		}
+	},
+	'complex': {
+		message: "supports complex selectors",
 		options: {
 			preserve: false
 		}

--- a/plugins/postcss-is-pseudo-class/.tape.mjs
+++ b/plugins/postcss-is-pseudo-class/.tape.mjs
@@ -24,6 +24,12 @@ postcssTape(plugin)({
 			onComplexSelector: 'warning'
 		}
 	},
+	'browser': {
+		message: "prepare CSS for chrome test",
+		options: {
+			preserve: false
+		}
+	},
 	'generated-selector-class-function-cases': {
 		message: "supports generated selector class function cases",
 		warnings: 1,

--- a/plugins/postcss-is-pseudo-class/package.json
+++ b/plugins/postcss-is-pseudo-class/package.json
@@ -32,6 +32,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test",
     "stryker": "stryker run --logLevel error",
     "test": "node .tape.mjs && npm run test:exports",
+    "test:browser": "node ./test/_browser.mjs",
     "test:rewrite-expects": "REWRITE_EXPECTS=true node .tape.mjs",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
   },
@@ -40,6 +41,9 @@
   },
   "peerDependencies": {
     "postcss": "^8.3"
+  },
+  "devDependencies": {
+    "puppeteer": "^13.0.1"
   },
   "keywords": [
     "postcss",

--- a/plugins/postcss-is-pseudo-class/src/split-selectors/complex.ts
+++ b/plugins/postcss-is-pseudo-class/src/split-selectors/complex.ts
@@ -1,0 +1,101 @@
+import parser from 'postcss-selector-parser';
+import { sortCompoundSelectorsInsideComplexSelector } from './compound-selector-order';
+import { childAdjacentChild } from './complex/child-adjacent-child';
+import { isInCompoundWithOneOtherElement } from './complex/is-in-compound';
+import type { Container } from 'postcss-selector-parser';
+
+export default function complexSelectors(selectors: string[], pluginOptions: { onComplexSelector?: 'warning' }, warnFn: () => void) {
+	return selectors.flatMap((selector) => {
+		if (selector.indexOf(':-csstools-matches') === -1 && selector.indexOf(':is') === -1) {
+			return selector;
+		}
+
+		const selectorAST = parser().astSync(selector);
+		selectorAST.walkPseudos((pseudo) => {
+			// `:is()` -> `:not(*)`
+			if (
+				pseudo.value === ':is' &&
+				pseudo.nodes &&
+				pseudo.nodes.length &&
+				pseudo.nodes[0].type === 'selector' &&
+				pseudo.nodes[0].nodes.length === 0
+			) {
+				pseudo.value = ':not';
+				pseudo.nodes[0].append(parser.universal());
+				return;
+			}
+
+			if (pseudo.value !== ':-csstools-matches') {
+				return;
+			}
+
+			if (pseudo.nodes && !pseudo.nodes.length) {
+				pseudo.remove();
+				return;
+			}
+
+			if (
+				pseudo.nodes.length === 1 &&
+				pseudo.nodes[0].type === 'selector'
+			) {
+				if (pseudo.nodes[0].nodes.length === 1) {
+					pseudo.replaceWith(pseudo.nodes[0].nodes[0]);
+					return;
+				}
+
+				if (!pseudo.nodes[0].some((x) => {
+					return x.type === 'combinator';
+				})) {
+					pseudo.replaceWith(...pseudo.nodes[0].nodes);
+					return;
+				}
+			}
+
+			if (
+				selectorAST.nodes.length === 1 &&
+				selectorAST.nodes[0].type === 'selector' &&
+				selectorAST.nodes[0].nodes.length === 1 &&
+				selectorAST.nodes[0].nodes[0] === pseudo
+			) {
+				pseudo.replaceWith(...pseudo.nodes[0].nodes);
+				return;
+			}
+
+			if (
+				childAdjacentChild(pseudo.parent) ||
+				isInCompoundWithOneOtherElement(pseudo.parent)
+			) {
+				return;
+			}
+
+			if (pluginOptions.onComplexSelector === 'warning') {
+				warnFn();
+			}
+
+			pseudo.value = ':is';
+		});
+
+		selectorAST.walk((node) => {
+			if (node.type !== 'selector' || !('nodes' in node)) {
+				return;
+			}
+
+			if (
+				node.nodes.length === 1 &&
+				(node.nodes[0] as Container).type === 'selector'
+			) {
+				node.replaceWith(node.nodes[0]);
+			}
+		});
+
+		selectorAST.walk((node) => {
+			if ('nodes' in node) {
+				sortCompoundSelectorsInsideComplexSelector(node);
+			}
+		});
+
+		return selectorAST.toString();
+	}).filter((x) => {
+		return !!x;
+	});
+}

--- a/plugins/postcss-is-pseudo-class/src/split-selectors/complex/child-adjacent-child.ts
+++ b/plugins/postcss-is-pseudo-class/src/split-selectors/complex/child-adjacent-child.ts
@@ -1,4 +1,4 @@
-// :is(.a > .b) + :is(.c > .d)
+// :-csstools-matches(.a > .b) + :-csstools-matches(.c > .d)
 // equivalent to
 // .a.c > .b + .d
 // because a adjacent elements have the same parent element.
@@ -14,7 +14,7 @@ export function childAdjacentChild(selector): boolean {
 		return false;
 	}
 
-	if (!selector.nodes[0] || selector.nodes[0].type !== 'pseudo' || selector.nodes[0].value !== ':is') {
+	if (!selector.nodes[0] || selector.nodes[0].type !== 'pseudo' || selector.nodes[0].value !== ':-csstools-matches') {
 		return false;
 	}
 
@@ -23,11 +23,11 @@ export function childAdjacentChild(selector): boolean {
 		return false;
 	}
 
-	if (!selector.nodes[2] || selector.nodes[2].type !== 'pseudo' || selector.nodes[2].value !== ':is') {
+	if (!selector.nodes[2] || selector.nodes[2].type !== 'pseudo' || selector.nodes[2].value !== ':-csstools-matches') {
 		return false;
 	}
 
-	// first `:is`
+	// first `:-csstools-matches`
 	{
 		if (!selector.nodes[0].nodes || selector.nodes[0].nodes.length !== 1) {
 			return false;
@@ -47,7 +47,7 @@ export function childAdjacentChild(selector): boolean {
 		}
 	}
 
-	// second `:is`
+	// second `:-csstools-matches`
 	{
 		if (!selector.nodes[2].nodes || selector.nodes[2].nodes.length !== 1) {
 			return false;

--- a/plugins/postcss-is-pseudo-class/src/split-selectors/complex/is-in-compound.ts
+++ b/plugins/postcss-is-pseudo-class/src/split-selectors/complex/is-in-compound.ts
@@ -1,12 +1,12 @@
-// .a:is(.b > .c)
+// .a:-csstools-matches(.b > .c)
 // equivalent to
 // .b > .c.a
 //
-// :is(.b > .c).a
+// :-csstools-matches(.b > .c).a
 // equivalent to
 // .b > .c.a
 //
-// because `:is()` matches the final element of the selector,
+// because `:-csstools-matches()` matches the final element of the selector,
 export function isInCompoundWithOneOtherElement(selector): boolean {
 	if (!selector || !selector.nodes) {
 		return false;
@@ -21,10 +21,10 @@ export function isInCompoundWithOneOtherElement(selector): boolean {
 
 	let isPseudoIndex;
 	let simpleSelectorIndex;
-	if (selector.nodes[0] && selector.nodes[0].type === 'pseudo' && selector.nodes[0].value === ':is') {
+	if (selector.nodes[0] && selector.nodes[0].type === 'pseudo' && selector.nodes[0].value === ':-csstools-matches') {
 		isPseudoIndex = 0;
 		simpleSelectorIndex = 1;
-	} else if (selector.nodes[1] && selector.nodes[1].type === 'pseudo' && selector.nodes[1].value === ':is') {
+	} else if (selector.nodes[1] && selector.nodes[1].type === 'pseudo' && selector.nodes[1].value === ':-csstools-matches') {
 		isPseudoIndex = 1;
 		simpleSelectorIndex = 0;
 	}

--- a/plugins/postcss-is-pseudo-class/src/split-selectors/compound-selector-order.ts
+++ b/plugins/postcss-is-pseudo-class/src/split-selectors/compound-selector-order.ts
@@ -92,6 +92,14 @@ export function sortCompoundSelector(node) {
 		}
 
 		if (a.type === b.type) {
+			if (a.value < b.value) {
+				return -1;
+			}
+
+			if (a.value > b.value) {
+				return 1;
+			}
+
 			return 0;
 		}
 

--- a/plugins/postcss-is-pseudo-class/test/_browser.html
+++ b/plugins/postcss-is-pseudo-class/test/_browser.html
@@ -10,17 +10,6 @@
 	<the-fixture id="fixture"></the-fixture>
 
 	<script type="module">
-		function rafP(callback) {
-			return new Promise((resolve) => {
-				requestAnimationFrame(() => {
-					requestAnimationFrame(() => {
-						callback();
-						resolve();
-					});
-				});
-			});
-		}
-
 		function test(cb, message) {
 			try {
 				cb();

--- a/plugins/postcss-is-pseudo-class/test/_browser.html
+++ b/plugins/postcss-is-pseudo-class/test/_browser.html
@@ -30,9 +30,13 @@
 			}
 		}
 
-		function assert_equals(a, b) {
+		function assert_equals(a, b, message) {
 			if (a !== b) {
-				throw new Error(`Expected ${a} to equal ${b}`);
+				if (message) {
+					throw new Error(`Expected ${a} to equal ${b}, for ${message}`);
+				} else {
+					throw new Error(`Expected ${a} to equal ${b}`);
+				}
 			}
 		}
 
@@ -70,9 +74,9 @@
 			const yellow = "rgb(255, 255, 0)";
 
 			test(() => {
-				assert_equals(getComputedStyle(d1).color, yellow);
-				assert_equals(getComputedStyle(d1).fontSize, "20px");
-				assert_equals(getComputedStyle(d1).width, "10px");
+				assert_equals(getComputedStyle(d1).color, yellow, "color");
+				assert_equals(getComputedStyle(d1).fontSize, "20px", "fontSize");
+				assert_equals(getComputedStyle(d1).width, "10px", "width");
 			}, "Test nested :is() chooses highest specificity for class outside :is().");
 
 			test(() => {
@@ -96,9 +100,9 @@
 			`;
 
 			test(() => {
-				assert_equals(getComputedStyle(target).width, "30px");
-				assert_equals(getComputedStyle(target).height, "20px");
-				assert_equals(getComputedStyle(target).fontSize, "10px");
+				assert_equals(getComputedStyle(target).width, "30px", "width");
+				assert_equals(getComputedStyle(target).height, "20px", "height");
+				assert_equals(getComputedStyle(target).fontSize, "10px", "fontSize");
 			}, "Test :is() uses highest possible specificity");
 
 			return true;

--- a/plugins/postcss-is-pseudo-class/test/_browser.html
+++ b/plugins/postcss-is-pseudo-class/test/_browser.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title></title>
+	<link rel="help" href="https://drafts.csswg.org/selectors-4/#matches">
+	<link rel="stylesheet" href="/test/browser.expect.css">
+</head>
+<body>
+	<the-fixture id="fixture"></the-fixture>
+
+	<script type="module">
+		function rafP(callback) {
+			return new Promise((resolve) => {
+				requestAnimationFrame(() => {
+					requestAnimationFrame(() => {
+						callback();
+						resolve();
+					});
+				});
+			});
+		}
+
+		function test(cb, message) {
+			try {
+				cb();
+			} catch (e) {
+				console.warn(e);
+				throw new Error(message + ' : ' + e.message);
+			}
+		}
+
+		function assert_equals(a, b) {
+			if (a !== b) {
+				throw new Error(`Expected ${a} to equal ${b}`);
+			}
+		}
+
+		self.runTest = function runTest() {
+			return testNested() && testSpecificity() && testInvalidation();
+		}
+
+		function testNested() {
+			// https://github.com/web-platform-tests/wpt/blob/master/css/selectors/is-nested.html
+
+			fixture.innerHTML = `
+				<div id="main_a">
+					<div class="a">
+					</div>
+					<div class="b" id="b2">
+					</div>
+					<div class="c" id="c2">
+						<div class="e">
+						</div>
+						<div class="d" id="d1">
+							Yellow
+						</div>
+					</div>
+					<div class="a">
+					</div>
+					<div class="c" id="c2">
+						<div class="e" id="e1">
+							Red
+						</div>
+					</div>
+				</div>
+			`;
+
+			const red = "rgb(255, 0, 0)";
+			const yellow = "rgb(255, 255, 0)";
+
+			test(() => {
+				assert_equals(getComputedStyle(d1).color, yellow);
+				assert_equals(getComputedStyle(d1).fontSize, "20px");
+				assert_equals(getComputedStyle(d1).width, "10px");
+			}, "Test nested :is() chooses highest specificity for class outside :is().");
+
+			test(() => {
+				assert_equals(getComputedStyle(e1).color, red);
+			}, "Test nested :is() specificity for class within arguments.");
+
+			return true;
+		}
+
+		function testSpecificity() {
+			// https://github.com/web-platform-tests/wpt/blob/master/css/selectors/is-specificity.html
+
+			fixture.innerHTML = `
+				<div id="main_b">
+					<div class="b c"></div>
+					<div class="a d e"></div>
+					<div class="q r"></div>
+					<div class="p s t"></div>
+					<div id="target"></div>
+				</div>
+			`;
+
+			test(() => {
+				assert_equals(getComputedStyle(target).width, "30px");
+				assert_equals(getComputedStyle(target).height, "20px");
+				assert_equals(getComputedStyle(target).fontSize, "10px");
+			}, "Test :is() uses highest possible specificity");
+
+			return true;
+		}
+
+		function testInvalidation() {
+			// https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/is.html
+
+			fixture.innerHTML = `
+				<div id="main_c">
+					<div id="a1">
+						<div class="b" id="b1">
+							Red
+						</div>
+						<div class="c" id="c1">
+							Red
+						</div>
+						<div class="c" id="d">
+							Green
+						</div>
+						<div class="e" id="e1">
+							Green
+						</div>
+						<div class="f" id="f1">
+							Blue
+						</div>
+						<div class="g">
+							<div class="b" id="b2">
+								Blue
+								<div class="b" id="b3">
+									Red
+								</div>
+							</div>
+						</div>
+						<div class="h" id="h1">
+							Blue
+						</div>
+					</div>
+					<div class="c" id="c2">
+						<div id="a2"></div>
+						<div class="e" id="e2">
+							Red
+						</div>
+					</div>
+				</div>
+			`;
+
+			document.body.offsetTop;
+
+			var black = "rgb(0, 0, 0)";
+			var blue = "rgb(0, 0, 255)";
+			var green = "rgb(0, 128, 0)";
+			var red = "rgb(255, 0, 0)";
+			var yellow = "rgb(255, 255, 0)";
+
+			test(() => {
+				assert_equals(getComputedStyle(b1).color, yellow);
+				assert_equals(getComputedStyle(b2).color, black);
+				assert_equals(getComputedStyle(b3).color, yellow);
+				assert_equals(getComputedStyle(c1).color, black);
+				assert_equals(getComputedStyle(d).color, black);
+				assert_equals(getComputedStyle(e1).color, black);
+				assert_equals(getComputedStyle(e2).color, black);
+				assert_equals(getComputedStyle(f1).color, black);
+				assert_equals(getComputedStyle(h1).color, black);
+			}, "Preconditions.");
+
+			test(() => {
+				a1.className = "a";
+				assert_equals(getComputedStyle(b1).color, red);
+				assert_equals(getComputedStyle(b3).color, red);
+				assert_equals(getComputedStyle(c1).color, red);
+			}, "Invalidate :is() for simple selector arguments.");
+
+			test(() => {
+				a1.className = "a";
+				assert_equals(getComputedStyle(d).color, green);
+			}, "Invalidate :is() for compound selector arguments.");
+
+			test(() => {
+				a1.className = "a";
+				assert_equals(getComputedStyle(b2).color, blue);
+				assert_equals(getComputedStyle(b3).color, red);
+				assert_equals(getComputedStyle(f1).color, blue);
+			}, "Invalidate :is() for complex selector arguments.");
+
+			test(() => {
+				a1.className = "a";
+				assert_equals(getComputedStyle(e2).color, black);
+				a2.className = "a";
+				assert_equals(getComputedStyle(e2).color, red);
+			}, "Invalidate nested :is().");
+
+			test(() => {
+				a1.className = "a";
+				assert_equals(getComputedStyle(b2).color, blue);
+				assert_equals(getComputedStyle(h1).color, blue);
+			}, "Test specificity of :is().");
+
+			return true;
+		}
+	</script>
+</body>
+</html>

--- a/plugins/postcss-is-pseudo-class/test/_browser.mjs
+++ b/plugins/postcss-is-pseudo-class/test/_browser.mjs
@@ -1,0 +1,57 @@
+import puppeteer from 'puppeteer';
+import http from 'http';
+import { promises as fsp } from 'fs';
+
+(async () => {
+	const requestListener = async function (req, res) {
+
+		const parsedUrl = new URL(req.url, 'http://localhost:8080');
+		const pathname = parsedUrl.pathname;
+
+		switch (pathname) {
+			case '':
+			case '/':
+				res.setHeader('Content-type', 'text/html');
+				res.writeHead(200);
+				res.end(await fsp.readFile('test/_browser.html', 'utf8'));
+				break;
+			case '/test/browser.expect.css':
+				res.writeHead(200);
+				res.end(await fsp.readFile('test/browser.expect.css', 'utf8'));
+				break;
+			default:
+				res.setHeader('Content-type', 'text/plain' );
+				res.writeHead(404);
+				res.end('Not found');
+				break;
+		}
+	};
+
+	const server = http.createServer(requestListener);
+	server.listen(8080);
+
+	if (!process.env.DEBUG) {
+		const browser = await puppeteer.launch({
+			headless: true,
+		});
+
+		const page = await browser.newPage();
+		page.on('pageerror', (msg) => {
+			throw msg;
+		});
+		await page.goto('http://localhost:8080');
+		const result = await page.evaluate(async() => {
+			// eslint-disable-next-line no-undef
+			return await window.runTest();
+		});
+		if (!result) {
+			throw new Error('Test failed, expected "window.runTest()" to return true');
+		}
+
+		await browser.close();
+
+		await server.close();
+	} else {
+		console.log('visit : http://localhost:8080');
+	}
+})();

--- a/plugins/postcss-is-pseudo-class/test/basic.css
+++ b/plugins/postcss-is-pseudo-class/test/basic.css
@@ -81,3 +81,15 @@ foo[baz=":is(.some, .other)"], .ok {
 .pre .alpha:is(.one > .two) {
 	order: 21;
 }
+
+:is(a, .e :is(a, b)) {
+	order: 22;
+}
+
+.empty-is:is() {
+	order: 23;
+}
+
+.invalid-is:is {
+	order: 24;
+}

--- a/plugins/postcss-is-pseudo-class/test/basic.does-not-exist.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/basic.does-not-exist.expect.css
@@ -166,7 +166,7 @@ button:focus-within {
 	order: 7;
 }
 
-button:not(.something-random):hover {
+button:hover:not(.something-random) {
 	order: 7;
 }
 
@@ -174,7 +174,7 @@ button:not(.something-random):hover {
 	order: 7;
 }
 
-button:not(.something-random):focus {
+button:focus:not(.something-random) {
 	order: 7;
 }
 
@@ -206,7 +206,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 12;
 }
 
-:is(.alpha > .beta).post + :is(:focus > .beta) {
+.post:is(.alpha > .beta) + :is(:focus > .beta) {
 	order: 13;
 }
 
@@ -214,7 +214,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 14;
 }
 
-:is(:is(.alpha ~ .delta) > .beta) + :is(:focus > .beta) {
+:focus:is(.alpha ~ .delta) > .beta + .beta {
 	order: 15;
 }
 
@@ -266,10 +266,30 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 19;
 }
 
-.pre.alpha:is(.one > .two) {
+.alpha.pre:is(.one > .two) {
 	order: 20;
 }
 
 .pre .alpha:is(.one > .two) {
 	order: 21;
+}
+
+a:not(.something-random) {
+	order: 22;
+}
+
+.e a {
+	order: 22;
+}
+
+.e b {
+	order: 22;
+}
+
+.empty-is:not(*) {
+	order: 23;
+}
+
+.invalid-is:is {
+	order: 24;
 }

--- a/plugins/postcss-is-pseudo-class/test/basic.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/basic.expect.css
@@ -166,7 +166,7 @@ button:focus-within {
 	order: 7;
 }
 
-button:not(.does-not-exist):hover {
+button:hover:not(.does-not-exist) {
 	order: 7;
 }
 
@@ -174,7 +174,7 @@ button:not(.does-not-exist):hover {
 	order: 7;
 }
 
-button:not(.does-not-exist):focus {
+button:focus:not(.does-not-exist) {
 	order: 7;
 }
 
@@ -206,7 +206,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 12;
 }
 
-:is(.alpha > .beta).post + :is(:focus > .beta) {
+.post:is(.alpha > .beta) + :is(:focus > .beta) {
 	order: 13;
 }
 
@@ -214,7 +214,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 14;
 }
 
-:is(:is(.alpha ~ .delta) > .beta) + :is(:focus > .beta) {
+:focus:is(.alpha ~ .delta) > .beta + .beta {
 	order: 15;
 }
 
@@ -266,10 +266,30 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 19;
 }
 
-.pre.alpha:is(.one > .two) {
+.alpha.pre:is(.one > .two) {
 	order: 20;
 }
 
 .pre .alpha:is(.one > .two) {
 	order: 21;
+}
+
+a:not(.does-not-exist) {
+	order: 22;
+}
+
+.e a {
+	order: 22;
+}
+
+.e b {
+	order: 22;
+}
+
+.empty-is:not(*) {
+	order: 23;
+}
+
+.invalid-is:is {
+	order: 24;
 }

--- a/plugins/postcss-is-pseudo-class/test/basic.oncomplex.warning.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/basic.oncomplex.warning.expect.css
@@ -166,7 +166,7 @@ button:focus-within {
 	order: 7;
 }
 
-button:not(.does-not-exist):hover {
+button:hover:not(.does-not-exist) {
 	order: 7;
 }
 
@@ -174,7 +174,7 @@ button:not(.does-not-exist):hover {
 	order: 7;
 }
 
-button:not(.does-not-exist):focus {
+button:focus:not(.does-not-exist) {
 	order: 7;
 }
 
@@ -206,7 +206,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 12;
 }
 
-:is(.alpha > .beta).post + :is(:focus > .beta) {
+.post:is(.alpha > .beta) + :is(:focus > .beta) {
 	order: 13;
 }
 
@@ -214,7 +214,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 14;
 }
 
-:is(:is(.alpha ~ .delta) > .beta) + :is(:focus > .beta) {
+:focus:is(.alpha ~ .delta) > .beta + .beta {
 	order: 15;
 }
 
@@ -266,10 +266,30 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 19;
 }
 
-.pre.alpha:is(.one > .two) {
+.alpha.pre:is(.one > .two) {
 	order: 20;
 }
 
 .pre .alpha:is(.one > .two) {
 	order: 21;
+}
+
+a:not(.does-not-exist) {
+	order: 22;
+}
+
+.e a {
+	order: 22;
+}
+
+.e b {
+	order: 22;
+}
+
+.empty-is:not(*) {
+	order: 23;
+}
+
+.invalid-is:is {
+	order: 24;
 }

--- a/plugins/postcss-is-pseudo-class/test/basic.preserve.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/basic.preserve.expect.css
@@ -190,7 +190,7 @@ button:is(:hover, :is(:focus, :focus-within)) {
 	order: 7;
 }
 
-button:not(.does-not-exist):hover {
+button:hover:not(.does-not-exist) {
 	order: 7;
 }
 
@@ -198,7 +198,7 @@ button:not(.does-not-exist):hover {
 	order: 7;
 }
 
-button:not(.does-not-exist):focus {
+button:focus:not(.does-not-exist) {
 	order: 7;
 }
 
@@ -242,12 +242,20 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 12;
 }
 
+.post:is(.alpha > .beta) + :is(:focus > .beta) {
+	order: 13;
+}
+
 :is(.alpha > .beta).post + :is(:focus > .beta) {
 	order: 13;
 }
 
 :is(.alpha > .beta) .post + :is(:focus > .beta) {
 	order: 14;
+}
+
+:focus:is(.alpha ~ .delta) > .beta + .beta {
+	order: 15;
 }
 
 :is(:is(.alpha ~ .delta) > .beta) + :is(:focus > .beta) {
@@ -314,10 +322,42 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 19;
 }
 
+.alpha.pre:is(.one > .two) {
+	order: 20;
+}
+
 .pre.alpha:is(.one > .two) {
 	order: 20;
 }
 
 .pre .alpha:is(.one > .two) {
 	order: 21;
+}
+
+a:not(.does-not-exist) {
+	order: 22;
+}
+
+.e a {
+	order: 22;
+}
+
+.e b {
+	order: 22;
+}
+
+:is(a, .e :is(a, b)) {
+	order: 22;
+}
+
+.empty-is:not(*) {
+	order: 23;
+}
+
+.empty-is:is() {
+	order: 23;
+}
+
+.invalid-is:is {
+	order: 24;
 }

--- a/plugins/postcss-is-pseudo-class/test/browser.css
+++ b/plugins/postcss-is-pseudo-class/test/browser.css
@@ -1,0 +1,93 @@
+/* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/is-nested.html */
+#main_a .a+.b+.c>.e+.d {
+	color: black;
+	font-size: 10px;
+	width: 10px;
+}
+
+#main_a .e:is(.b+.f, .e:is(*, .c>.e, .g, *))+.d {
+	color: red;
+	font-size: 20px;
+}
+
+#main_a .a+.b+.c>.e+.d {
+	color: yellow;
+}
+
+/* Testing specificty of a class within :is() */
+#main_a .a+.c>.e {
+	color: black;
+}
+
+#main_a .e:is(.b+.f, :is(.c>.e, .g)) {
+	color: red;
+}
+
+#main_a .c>.e {
+	color: black;
+}
+
+/* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/is-specificity.html */
+#main_b .b.c+.d+.q.r+.s+#target {
+	font-size: 10px;
+	height: 10px;
+	width: 10px;
+}
+
+#main_b :is(.a, .b.c + .d, .q)+ :is(* + .p, .q.r + .s, * + .t)+#target {
+	height: 20px;
+	width: 20px;
+}
+
+#main_b .b.c+.d+.q.r+.s+#target {
+	width: 30px;
+}
+
+/* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/is.html */
+#main_c .b {
+	color: yellow;
+}
+
+/*Simple selector arguments */
+#main_c .a :is(.b, .c) {
+	color: red;
+}
+
+/*Compound selector arguments */
+#main_c .a :is(.c#d, .e) {
+	color: green;
+}
+
+/* Complex selector arguments */
+#main_c .a .g>.b {
+	color: black;
+}
+
+#main_c .a :is(.e+.f, .g>.b, .h) {
+	color: blue;
+}
+
+#main_c .g>.b {
+	color: black;
+}
+
+#main_c .a .h {
+	color: black;
+}
+
+/* Nested */
+#main_c .a+.c>.e {
+	color: black;
+}
+
+#main_c .c>.a+.e {
+	color: black;
+}
+
+#main_c .a+:is(.b+.f, :is(.c>.e, .g)) {
+	color: red;
+}
+
+#main_c .c>.e {
+	color: black;
+}

--- a/plugins/postcss-is-pseudo-class/test/browser.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/browser.expect.css
@@ -1,0 +1,99 @@
+/* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/is-nested.html */
+#main_a .a+.b+.c>.e+.d {
+	color: black;
+	font-size: 10px;
+	width: 10px;
+}
+
+#main_a .e:is(.b+.f, .e:is(*, .c>.e, .g, *))+.d {
+	color: red;
+	font-size: 20px;
+}
+
+#main_a .a+.b+.c>.e+.d {
+	color: yellow;
+}
+
+/* Testing specificty of a class within :is() */
+#main_a .a+.c>.e {
+	color: black;
+}
+
+#main_a .e:is(.b+.f, :is(.c>.e, .g)) {
+	color: red;
+}
+
+#main_a .c>.e {
+	color: black;
+}
+
+/* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/is-specificity.html */
+#main_b .b.c+.d+.q.r+.s+#target {
+	font-size: 10px;
+	height: 10px;
+	width: 10px;
+}
+
+#main_b :is(.a, .b.c + .d, .q)+ :is(* + .p, .q.r + .s, * + .t)+#target {
+	height: 20px;
+	width: 20px;
+}
+
+#main_b .b.c+.d+.q.r+.s+#target {
+	width: 30px;
+}
+
+/* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/is.html */
+#main_c .b {
+	color: yellow;
+}
+
+/*Simple selector arguments */
+#main_c .a .b {
+	color: red;
+}
+#main_c .a .c {
+	color: red;
+}
+
+/*Compound selector arguments */
+#main_c .a #d.c {
+	color: green;
+}
+#main_c .a .e:not(#does-not-exist) {
+	color: green;
+}
+
+/* Complex selector arguments */
+#main_c .a .g>.b {
+	color: black;
+}
+
+#main_c .a :is(.e+.f, .g>.b, .h) {
+	color: blue;
+}
+
+#main_c .g>.b {
+	color: black;
+}
+
+#main_c .a .h {
+	color: black;
+}
+
+/* Nested */
+#main_c .a+.c>.e {
+	color: black;
+}
+
+#main_c .c>.a+.e {
+	color: black;
+}
+
+#main_c .a+:is(.b+.f, :is(.c>.e, .g)) {
+	color: red;
+}
+
+#main_c .c>.e {
+	color: black;
+}

--- a/plugins/postcss-is-pseudo-class/test/browser.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/browser.expect.css
@@ -5,7 +5,22 @@
 	width: 10px;
 }
 
-#main_a .e:is(.b+.f, .e:is(*, .c>.e, .g, *))+.d {
+#main_a .e:is(.b+.f:not(.does-not-exist))+.d {
+	color: red;
+	font-size: 20px;
+}
+
+#main_a *.e.e:not(.does-not-exist):not(.does-not-exist)+.d {
+	color: red;
+	font-size: 20px;
+}
+
+#main_a .e.e:is(.c>.e)+.d {
+	color: red;
+	font-size: 20px;
+}
+
+#main_a .e.e.g:not(.does-not-exist)+.d {
 	color: red;
 	font-size: 20px;
 }
@@ -19,7 +34,15 @@
 	color: black;
 }
 
-#main_a .e:is(.b+.f, :is(.c>.e, .g)) {
+#main_a .e:is(.b+.f) {
+	color: red;
+}
+
+#main_a .e:is(.c>.e) {
+	color: red;
+}
+
+#main_a .e.g:not(.does-not-exist) {
 	color: red;
 }
 
@@ -34,7 +57,47 @@
 	width: 10px;
 }
 
-#main_b :is(.a, .b.c + .d, .q)+ :is(* + .p, .q.r + .s, * + .t)+#target {
+#main_b .a:not(.does-not-exist):not(.does-not-exist)+ :is(* + .p:not(.does-not-exist):not(.does-not-exist))+#target {
+	height: 20px;
+	width: 20px;
+}
+
+#main_b .a:not(.does-not-exist):not(.does-not-exist)+ :is(.q.r + .s)+#target {
+	height: 20px;
+	width: 20px;
+}
+
+#main_b .a:not(.does-not-exist):not(.does-not-exist)+ :is(* + .t:not(.does-not-exist):not(.does-not-exist))+#target {
+	height: 20px;
+	width: 20px;
+}
+
+#main_b :is(.b.c + .d)+ :is(* + .p:not(.does-not-exist):not(.does-not-exist))+#target {
+	height: 20px;
+	width: 20px;
+}
+
+#main_b :is(.b.c + .d)+ :is(.q.r + .s)+#target {
+	height: 20px;
+	width: 20px;
+}
+
+#main_b :is(.b.c + .d)+ :is(* + .t:not(.does-not-exist):not(.does-not-exist))+#target {
+	height: 20px;
+	width: 20px;
+}
+
+#main_b .q:not(.does-not-exist):not(.does-not-exist)+ :is(* + .p:not(.does-not-exist):not(.does-not-exist))+#target {
+	height: 20px;
+	width: 20px;
+}
+
+#main_b .q:not(.does-not-exist):not(.does-not-exist)+ :is(.q.r + .s)+#target {
+	height: 20px;
+	width: 20px;
+}
+
+#main_b .q:not(.does-not-exist):not(.does-not-exist)+ :is(* + .t:not(.does-not-exist):not(.does-not-exist))+#target {
 	height: 20px;
 	width: 20px;
 }
@@ -69,7 +132,15 @@
 	color: black;
 }
 
-#main_c .a :is(.e+.f, .g>.b, .h) {
+#main_c .a :is(.e+.f) {
+	color: blue;
+}
+
+#main_c .a :is(.g>.b) {
+	color: blue;
+}
+
+#main_c .a .h:not(.does-not-exist) {
 	color: blue;
 }
 
@@ -90,7 +161,15 @@
 	color: black;
 }
 
-#main_c .a+:is(.b+.f, :is(.c>.e, .g)) {
+#main_c .a+:is(.b+.f) {
+	color: red;
+}
+
+#main_c .a+:is(.c>.e) {
+	color: red;
+}
+
+#main_c .a+.g:not(.does-not-exist) {
 	color: red;
 }
 

--- a/plugins/postcss-is-pseudo-class/test/complex.css
+++ b/plugins/postcss-is-pseudo-class/test/complex.css
@@ -1,0 +1,281 @@
+/*
+const out = [];
+cartesianProduct([' ', '+', '>', '~'], [' ', '+', '>', '~'], [' ', '+', '>', '~']).forEach((x, index) => {
+	out.push(`
+.a` + x[0] + '.b:is(.c' + x[1] + '.d)' + x[2] + `.e {
+	order: ${index + 1};
+}
+`);
+});
+
+console.log(out.join(''));
+*/
+
+.a .b:is(.c .d) .e {
+	order: 1;
+}
+
+.a .b:is(.c .d)+.e {
+	order: 2;
+}
+
+.a .b:is(.c .d)>.e {
+	order: 3;
+}
+
+.a .b:is(.c .d)~.e {
+	order: 4;
+}
+
+.a .b:is(.c+.d) .e {
+	order: 5;
+}
+
+.a .b:is(.c+.d)+.e {
+	order: 6;
+}
+
+.a .b:is(.c+.d)>.e {
+	order: 7;
+}
+
+.a .b:is(.c+.d)~.e {
+	order: 8;
+}
+
+.a .b:is(.c>.d) .e {
+	order: 9;
+}
+
+.a .b:is(.c>.d)+.e {
+	order: 10;
+}
+
+.a .b:is(.c>.d)>.e {
+	order: 11;
+}
+
+.a .b:is(.c>.d)~.e {
+	order: 12;
+}
+
+.a .b:is(.c~.d) .e {
+	order: 13;
+}
+
+.a .b:is(.c~.d)+.e {
+	order: 14;
+}
+
+.a .b:is(.c~.d)>.e {
+	order: 15;
+}
+
+.a .b:is(.c~.d)~.e {
+	order: 16;
+}
+
+.a+.b:is(.c .d) .e {
+	order: 17;
+}
+
+.a+.b:is(.c .d)+.e {
+	order: 18;
+}
+
+.a+.b:is(.c .d)>.e {
+	order: 19;
+}
+
+.a+.b:is(.c .d)~.e {
+	order: 20;
+}
+
+.a+.b:is(.c+.d) .e {
+	order: 21;
+}
+
+.a+.b:is(.c+.d)+.e {
+	order: 22;
+}
+
+.a+.b:is(.c+.d)>.e {
+	order: 23;
+}
+
+.a+.b:is(.c+.d)~.e {
+	order: 24;
+}
+
+.a+.b:is(.c>.d) .e {
+	order: 25;
+}
+
+.a+.b:is(.c>.d)+.e {
+	order: 26;
+}
+
+.a+.b:is(.c>.d)>.e {
+	order: 27;
+}
+
+.a+.b:is(.c>.d)~.e {
+	order: 28;
+}
+
+.a+.b:is(.c~.d) .e {
+	order: 29;
+}
+
+.a+.b:is(.c~.d)+.e {
+	order: 30;
+}
+
+.a+.b:is(.c~.d)>.e {
+	order: 31;
+}
+
+.a+.b:is(.c~.d)~.e {
+	order: 32;
+}
+
+.a>.b:is(.c .d) .e {
+	order: 33;
+}
+
+.a>.b:is(.c .d)+.e {
+	order: 34;
+}
+
+.a>.b:is(.c .d)>.e {
+	order: 35;
+}
+
+.a>.b:is(.c .d)~.e {
+	order: 36;
+}
+
+.a>.b:is(.c+.d) .e {
+	order: 37;
+}
+
+.a>.b:is(.c+.d)+.e {
+	order: 38;
+}
+
+.a>.b:is(.c+.d)>.e {
+	order: 39;
+}
+
+.a>.b:is(.c+.d)~.e {
+	order: 40;
+}
+
+.a>.b:is(.c>.d) .e {
+	order: 41;
+}
+
+.a>.b:is(.c>.d)+.e {
+	order: 42;
+}
+
+.a>.b:is(.c>.d)>.e {
+	order: 43;
+}
+
+.a>.b:is(.c>.d)~.e {
+	order: 44;
+}
+
+.a>.b:is(.c~.d) .e {
+	order: 45;
+}
+
+.a>.b:is(.c~.d)+.e {
+	order: 46;
+}
+
+.a>.b:is(.c~.d)>.e {
+	order: 47;
+}
+
+.a>.b:is(.c~.d)~.e {
+	order: 48;
+}
+
+.a~.b:is(.c .d) .e {
+	order: 49;
+}
+
+.a~.b:is(.c .d)+.e {
+	order: 50;
+}
+
+.a~.b:is(.c .d)>.e {
+	order: 51;
+}
+
+.a~.b:is(.c .d)~.e {
+	order: 52;
+}
+
+.a~.b:is(.c+.d) .e {
+	order: 53;
+}
+
+.a~.b:is(.c+.d)+.e {
+	order: 54;
+}
+
+.a~.b:is(.c+.d)>.e {
+	order: 55;
+}
+
+.a~.b:is(.c+.d)~.e {
+	order: 56;
+}
+
+.a~.b:is(.c>.d) .e {
+	order: 57;
+}
+
+.a~.b:is(.c>.d)+.e {
+	order: 58;
+}
+
+.a~.b:is(.c>.d)>.e {
+	order: 59;
+}
+
+.a~.b:is(.c>.d)~.e {
+	order: 60;
+}
+
+.a~.b:is(.c~.d) .e {
+	order: 61;
+}
+
+.a~.b:is(.c~.d)+.e {
+	order: 62;
+}
+
+.a~.b:is(.c~.d)>.e {
+	order: 63;
+}
+
+.a~.b:is(.c~.d)~.e {
+	order: 64;
+}
+
+/*
+const out = [];
+cartesianProduct([' ', '+', '>', '~'], [' ', '+', '>', '~'], [' ', '+', '>', '~']).forEach((x, index) => {
+	out.push(`
+.a` + x[0] + '.b:is(.c' + x[1] + '.d)' + x[2] + `.e {
+	order: ${index + 1};
+}
+`);
+});
+
+console.log(out.join(''));
+*/

--- a/plugins/postcss-is-pseudo-class/test/complex.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/complex.expect.css
@@ -1,0 +1,281 @@
+/*
+const out = [];
+cartesianProduct([' ', '+', '>', '~'], [' ', '+', '>', '~'], [' ', '+', '>', '~']).forEach((x, index) => {
+	out.push(`
+.a` + x[0] + '.b:is(.c' + x[1] + '.d)' + x[2] + `.e {
+	order: ${index + 1};
+}
+`);
+});
+
+console.log(out.join(''));
+*/
+
+.a .b:is(.c .d) .e {
+	order: 1;
+}
+
+.a .b:is(.c .d)+.e {
+	order: 2;
+}
+
+.a .b:is(.c .d)>.e {
+	order: 3;
+}
+
+.a .b:is(.c .d)~.e {
+	order: 4;
+}
+
+.a .b:is(.c+.d) .e {
+	order: 5;
+}
+
+.a .b:is(.c+.d)+.e {
+	order: 6;
+}
+
+.a .b:is(.c+.d)>.e {
+	order: 7;
+}
+
+.a .b:is(.c+.d)~.e {
+	order: 8;
+}
+
+.a .b:is(.c>.d) .e {
+	order: 9;
+}
+
+.a .b:is(.c>.d)+.e {
+	order: 10;
+}
+
+.a .b:is(.c>.d)>.e {
+	order: 11;
+}
+
+.a .b:is(.c>.d)~.e {
+	order: 12;
+}
+
+.a .b:is(.c~.d) .e {
+	order: 13;
+}
+
+.a .b:is(.c~.d)+.e {
+	order: 14;
+}
+
+.a .b:is(.c~.d)>.e {
+	order: 15;
+}
+
+.a .b:is(.c~.d)~.e {
+	order: 16;
+}
+
+.a+.b:is(.c .d) .e {
+	order: 17;
+}
+
+.a+.b:is(.c .d)+.e {
+	order: 18;
+}
+
+.a+.b:is(.c .d)>.e {
+	order: 19;
+}
+
+.a+.b:is(.c .d)~.e {
+	order: 20;
+}
+
+.a+.b:is(.c+.d) .e {
+	order: 21;
+}
+
+.a+.b:is(.c+.d)+.e {
+	order: 22;
+}
+
+.a+.b:is(.c+.d)>.e {
+	order: 23;
+}
+
+.a+.b:is(.c+.d)~.e {
+	order: 24;
+}
+
+.a+.b:is(.c>.d) .e {
+	order: 25;
+}
+
+.a+.b:is(.c>.d)+.e {
+	order: 26;
+}
+
+.a+.b:is(.c>.d)>.e {
+	order: 27;
+}
+
+.a+.b:is(.c>.d)~.e {
+	order: 28;
+}
+
+.a+.b:is(.c~.d) .e {
+	order: 29;
+}
+
+.a+.b:is(.c~.d)+.e {
+	order: 30;
+}
+
+.a+.b:is(.c~.d)>.e {
+	order: 31;
+}
+
+.a+.b:is(.c~.d)~.e {
+	order: 32;
+}
+
+.a>.b:is(.c .d) .e {
+	order: 33;
+}
+
+.a>.b:is(.c .d)+.e {
+	order: 34;
+}
+
+.a>.b:is(.c .d)>.e {
+	order: 35;
+}
+
+.a>.b:is(.c .d)~.e {
+	order: 36;
+}
+
+.a>.b:is(.c+.d) .e {
+	order: 37;
+}
+
+.a>.b:is(.c+.d)+.e {
+	order: 38;
+}
+
+.a>.b:is(.c+.d)>.e {
+	order: 39;
+}
+
+.a>.b:is(.c+.d)~.e {
+	order: 40;
+}
+
+.a>.b:is(.c>.d) .e {
+	order: 41;
+}
+
+.a>.b:is(.c>.d)+.e {
+	order: 42;
+}
+
+.a>.b:is(.c>.d)>.e {
+	order: 43;
+}
+
+.a>.b:is(.c>.d)~.e {
+	order: 44;
+}
+
+.a>.b:is(.c~.d) .e {
+	order: 45;
+}
+
+.a>.b:is(.c~.d)+.e {
+	order: 46;
+}
+
+.a>.b:is(.c~.d)>.e {
+	order: 47;
+}
+
+.a>.b:is(.c~.d)~.e {
+	order: 48;
+}
+
+.a~.b:is(.c .d) .e {
+	order: 49;
+}
+
+.a~.b:is(.c .d)+.e {
+	order: 50;
+}
+
+.a~.b:is(.c .d)>.e {
+	order: 51;
+}
+
+.a~.b:is(.c .d)~.e {
+	order: 52;
+}
+
+.a~.b:is(.c+.d) .e {
+	order: 53;
+}
+
+.a~.b:is(.c+.d)+.e {
+	order: 54;
+}
+
+.a~.b:is(.c+.d)>.e {
+	order: 55;
+}
+
+.a~.b:is(.c+.d)~.e {
+	order: 56;
+}
+
+.a~.b:is(.c>.d) .e {
+	order: 57;
+}
+
+.a~.b:is(.c>.d)+.e {
+	order: 58;
+}
+
+.a~.b:is(.c>.d)>.e {
+	order: 59;
+}
+
+.a~.b:is(.c>.d)~.e {
+	order: 60;
+}
+
+.a~.b:is(.c~.d) .e {
+	order: 61;
+}
+
+.a~.b:is(.c~.d)+.e {
+	order: 62;
+}
+
+.a~.b:is(.c~.d)>.e {
+	order: 63;
+}
+
+.a~.b:is(.c~.d)~.e {
+	order: 64;
+}
+
+/*
+const out = [];
+cartesianProduct([' ', '+', '>', '~'], [' ', '+', '>', '~'], [' ', '+', '>', '~']).forEach((x, index) => {
+	out.push(`
+.a` + x[0] + '.b:is(.c' + x[1] + '.d)' + x[2] + `.e {
+	order: ${index + 1};
+}
+`);
+});
+
+console.log(out.join(''));
+*/

--- a/plugins/postcss-is-pseudo-class/test/generated-selector-class-function-cases.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/generated-selector-class-function-cases.expect.css
@@ -2,10 +2,6 @@
 	order: 0;
 }
 
-.some.other {
-	order: 0;
-}
-
 .other.some {
 	order: 0;
 }
@@ -22,10 +18,6 @@
 	order: 1;
 }
 
-.some.other {
-	order: 1;
-}
-
 .other.some {
 	order: 1;
 }
@@ -39,10 +31,6 @@
 }
 
 .some.some {
-	order: 2;
-}
-
-.some.other {
 	order: 2;
 }
 
@@ -98,6 +86,22 @@
 	order: 4;
 }
 
+.some .some {
+	order: 5;
+}
+
+.some .other {
+	order: 5;
+}
+
+.other .some {
+	order: 5;
+}
+
+.other .other {
+	order: 5;
+}
+
 :is(:is(.some, .other) :is(.some, .other)) {
 	order: 5;
 }
@@ -140,6 +144,22 @@
 
 :is(.some, .other)  :is(.some, .other) {
 	order: 7;
+}
+
+.some  .some {
+	order: 8;
+}
+
+.some  .other {
+	order: 8;
+}
+
+.other  .some {
+	order: 8;
+}
+
+.other  .other {
+	order: 8;
 }
 
 :is(:is(.some, .other)  :is(.some, .other)) {
@@ -186,6 +206,22 @@
 	order: 10;
 }
 
+.some+.some {
+	order: 11;
+}
+
+.some+.other {
+	order: 11;
+}
+
+.other+.some {
+	order: 11;
+}
+
+.other+.other {
+	order: 11;
+}
+
 :is(:is(.some, .other)+:is(.some, .other)) {
 	order: 11;
 }
@@ -228,6 +264,22 @@
 
 :is(.some, .other) + :is(.some, .other) {
 	order: 13;
+}
+
+.some + .some {
+	order: 14;
+}
+
+.some + .other {
+	order: 14;
+}
+
+.other + .some {
+	order: 14;
+}
+
+.other + .other {
+	order: 14;
 }
 
 :is(:is(.some, .other) + :is(.some, .other)) {
@@ -274,6 +326,22 @@
 	order: 16;
 }
 
+.some~.some {
+	order: 17;
+}
+
+.some~.other {
+	order: 17;
+}
+
+.other~.some {
+	order: 17;
+}
+
+.other~.other {
+	order: 17;
+}
+
 :is(:is(.some, .other)~:is(.some, .other)) {
 	order: 17;
 }
@@ -316,6 +384,22 @@
 
 :is(.some, .other) ~ :is(.some, .other) {
 	order: 19;
+}
+
+.some ~ .some {
+	order: 20;
+}
+
+.some ~ .other {
+	order: 20;
+}
+
+.other ~ .some {
+	order: 20;
+}
+
+.other ~ .other {
+	order: 20;
 }
 
 :is(:is(.some, .other) ~ :is(.some, .other)) {
@@ -362,6 +446,22 @@
 	order: 22;
 }
 
+.some>.some {
+	order: 23;
+}
+
+.some>.other {
+	order: 23;
+}
+
+.other>.some {
+	order: 23;
+}
+
+.other>.other {
+	order: 23;
+}
+
 :is(:is(.some, .other)>:is(.some, .other)) {
 	order: 23;
 }
@@ -406,6 +506,22 @@
 	order: 25;
 }
 
+.some > .some {
+	order: 26;
+}
+
+.some > .other {
+	order: 26;
+}
+
+.other > .some {
+	order: 26;
+}
+
+.other > .other {
+	order: 26;
+}
+
 :is(:is(.some, .other) > :is(.some, .other)) {
 	order: 26;
 }
@@ -418,24 +534,8 @@
 	order: 27;
 }
 
-.some {
-	order: 27;
-}
-
-.other {
-	order: 27;
-}
-
 :is(.some, .other), :is(.some, .other) {
 	order: 27;
-}
-
-.some {
-	order: 28;
-}
-
-.other {
-	order: 28;
 }
 
 .some {
@@ -518,6 +618,10 @@ button :is(.some, .other) {
 	order: 34;
 }
 
+button button {
+	order: 35;
+}
+
 :is(button button) {
 	order: 35;
 }
@@ -544,6 +648,10 @@ button  :is(.some, .other) {
 
 :is(.some, .other)  button {
 	order: 37;
+}
+
+button  button {
+	order: 38;
 }
 
 :is(button  button) {
@@ -574,6 +682,10 @@ button+:is(.some, .other) {
 	order: 40;
 }
 
+button+button {
+	order: 41;
+}
+
 :is(button+button) {
 	order: 41;
 }
@@ -600,6 +712,10 @@ button + :is(.some, .other) {
 
 :is(.some, .other) + button {
 	order: 43;
+}
+
+button + button {
+	order: 44;
 }
 
 :is(button + button) {
@@ -630,6 +746,10 @@ button~:is(.some, .other) {
 	order: 46;
 }
 
+button~button {
+	order: 47;
+}
+
 :is(button~button) {
 	order: 47;
 }
@@ -656,6 +776,10 @@ button ~ :is(.some, .other) {
 
 :is(.some, .other) ~ button {
 	order: 49;
+}
+
+button ~ button {
+	order: 50;
 }
 
 :is(button ~ button) {
@@ -686,6 +810,10 @@ button>:is(.some, .other) {
 	order: 52;
 }
 
+button>button {
+	order: 53;
+}
+
 :is(button>button) {
 	order: 53;
 }
@@ -712,6 +840,10 @@ button > :is(.some, .other) {
 
 :is(.some, .other) > button {
 	order: 55;
+}
+
+button > button {
+	order: 56;
 }
 
 :is(button > button) {
@@ -814,6 +946,10 @@ button {
 	order: 64;
 }
 
+.🧑🏾‍🎤 .🧑🏾‍🎤 {
+	order: 65;
+}
+
 :is(.🧑🏾‍🎤 .🧑🏾‍🎤) {
 	order: 65;
 }
@@ -840,6 +976,10 @@ button {
 
 :is(.some, .other)  .🧑🏾‍🎤 {
 	order: 67;
+}
+
+.🧑🏾‍🎤  .🧑🏾‍🎤 {
+	order: 68;
 }
 
 :is(.🧑🏾‍🎤  .🧑🏾‍🎤) {
@@ -870,6 +1010,10 @@ button {
 	order: 70;
 }
 
+.🧑🏾‍🎤+.🧑🏾‍🎤 {
+	order: 71;
+}
+
 :is(.🧑🏾‍🎤+.🧑🏾‍🎤) {
 	order: 71;
 }
@@ -896,6 +1040,10 @@ button {
 
 :is(.some, .other) + .🧑🏾‍🎤 {
 	order: 73;
+}
+
+.🧑🏾‍🎤 + .🧑🏾‍🎤 {
+	order: 74;
 }
 
 :is(.🧑🏾‍🎤 + .🧑🏾‍🎤) {
@@ -926,6 +1074,10 @@ button {
 	order: 76;
 }
 
+.🧑🏾‍🎤~.🧑🏾‍🎤 {
+	order: 77;
+}
+
 :is(.🧑🏾‍🎤~.🧑🏾‍🎤) {
 	order: 77;
 }
@@ -952,6 +1104,10 @@ button {
 
 :is(.some, .other) ~ .🧑🏾‍🎤 {
 	order: 79;
+}
+
+.🧑🏾‍🎤 ~ .🧑🏾‍🎤 {
+	order: 80;
 }
 
 :is(.🧑🏾‍🎤 ~ .🧑🏾‍🎤) {
@@ -982,6 +1138,10 @@ button {
 	order: 82;
 }
 
+.🧑🏾‍🎤>.🧑🏾‍🎤 {
+	order: 83;
+}
+
 :is(.🧑🏾‍🎤>.🧑🏾‍🎤) {
 	order: 83;
 }
@@ -1008,6 +1168,10 @@ button {
 
 :is(.some, .other) > .🧑🏾‍🎤 {
 	order: 85;
+}
+
+.🧑🏾‍🎤 > .🧑🏾‍🎤 {
+	order: 86;
 }
 
 :is(.🧑🏾‍🎤 > .🧑🏾‍🎤) {
@@ -1054,11 +1218,11 @@ button {
 	order: 89;
 }
 
-.some.foo {
+.foo.some {
 	order: 90;
 }
 
-.other.foo {
+.foo.other {
 	order: 90;
 }
 
@@ -1066,11 +1230,11 @@ button {
 	order: 90;
 }
 
-.some.foo {
+.foo.some {
 	order: 91;
 }
 
-.other.foo {
+.foo.other {
 	order: 91;
 }
 
@@ -1110,6 +1274,10 @@ button {
 	order: 94;
 }
 
+.foo .foo {
+	order: 95;
+}
+
 :is(.foo .foo) {
 	order: 95;
 }
@@ -1136,6 +1304,10 @@ button {
 
 :is(.some, .other)  .foo {
 	order: 97;
+}
+
+.foo  .foo {
+	order: 98;
 }
 
 :is(.foo  .foo) {
@@ -1166,6 +1338,10 @@ button {
 	order: 100;
 }
 
+.foo+.foo {
+	order: 101;
+}
+
 :is(.foo+.foo) {
 	order: 101;
 }
@@ -1192,6 +1368,10 @@ button {
 
 :is(.some, .other) + .foo {
 	order: 103;
+}
+
+.foo + .foo {
+	order: 104;
 }
 
 :is(.foo + .foo) {
@@ -1222,6 +1402,10 @@ button {
 	order: 106;
 }
 
+.foo~.foo {
+	order: 107;
+}
+
 :is(.foo~.foo) {
 	order: 107;
 }
@@ -1248,6 +1432,10 @@ button {
 
 :is(.some, .other) ~ .foo {
 	order: 109;
+}
+
+.foo ~ .foo {
+	order: 110;
 }
 
 :is(.foo ~ .foo) {
@@ -1278,6 +1466,10 @@ button {
 	order: 112;
 }
 
+.foo>.foo {
+	order: 113;
+}
+
 :is(.foo>.foo) {
 	order: 113;
 }
@@ -1304,6 +1496,10 @@ button {
 
 :is(.some, .other) > .foo {
 	order: 115;
+}
+
+.foo > .foo {
+	order: 116;
 }
 
 :is(.foo > .foo) {
@@ -1406,6 +1602,10 @@ button {
 	order: 124;
 }
 
+#foo #foo {
+	order: 125;
+}
+
 :is(#foo #foo) {
 	order: 125;
 }
@@ -1432,6 +1632,10 @@ button {
 
 :is(.some, .other)  #foo {
 	order: 127;
+}
+
+#foo  #foo {
+	order: 128;
 }
 
 :is(#foo  #foo) {
@@ -1462,6 +1666,10 @@ button {
 	order: 130;
 }
 
+#foo+#foo {
+	order: 131;
+}
+
 :is(#foo+#foo) {
 	order: 131;
 }
@@ -1488,6 +1696,10 @@ button {
 
 :is(.some, .other) + #foo {
 	order: 133;
+}
+
+#foo + #foo {
+	order: 134;
 }
 
 :is(#foo + #foo) {
@@ -1518,6 +1730,10 @@ button {
 	order: 136;
 }
 
+#foo~#foo {
+	order: 137;
+}
+
 :is(#foo~#foo) {
 	order: 137;
 }
@@ -1544,6 +1760,10 @@ button {
 
 :is(.some, .other) ~ #foo {
 	order: 139;
+}
+
+#foo ~ #foo {
+	order: 140;
 }
 
 :is(#foo ~ #foo) {
@@ -1574,6 +1794,10 @@ button {
 	order: 142;
 }
 
+#foo>#foo {
+	order: 143;
+}
+
 :is(#foo>#foo) {
 	order: 143;
 }
@@ -1600,6 +1824,10 @@ button {
 
 :is(.some, .other) > #foo {
 	order: 145;
+}
+
+#foo > #foo {
+	order: 146;
 }
 
 :is(#foo > #foo) {
@@ -1702,6 +1930,10 @@ __foo :is(.some, .other) {
 	order: 154;
 }
 
+__foo __foo {
+	order: 155;
+}
+
 :is(__foo __foo) {
 	order: 155;
 }
@@ -1728,6 +1960,10 @@ __foo  :is(.some, .other) {
 
 :is(.some, .other)  __foo {
 	order: 157;
+}
+
+__foo  __foo {
+	order: 158;
 }
 
 :is(__foo  __foo) {
@@ -1758,6 +1994,10 @@ __foo+:is(.some, .other) {
 	order: 160;
 }
 
+__foo+__foo {
+	order: 161;
+}
+
 :is(__foo+__foo) {
 	order: 161;
 }
@@ -1784,6 +2024,10 @@ __foo + :is(.some, .other) {
 
 :is(.some, .other) + __foo {
 	order: 163;
+}
+
+__foo + __foo {
+	order: 164;
 }
 
 :is(__foo + __foo) {
@@ -1814,6 +2058,10 @@ __foo~:is(.some, .other) {
 	order: 166;
 }
 
+__foo~__foo {
+	order: 167;
+}
+
 :is(__foo~__foo) {
 	order: 167;
 }
@@ -1840,6 +2088,10 @@ __foo ~ :is(.some, .other) {
 
 :is(.some, .other) ~ __foo {
 	order: 169;
+}
+
+__foo ~ __foo {
+	order: 170;
 }
 
 :is(__foo ~ __foo) {
@@ -1870,6 +2122,10 @@ __foo>:is(.some, .other) {
 	order: 172;
 }
 
+__foo>__foo {
+	order: 173;
+}
+
 :is(__foo>__foo) {
 	order: 173;
 }
@@ -1896,6 +2152,10 @@ __foo > :is(.some, .other) {
 
 :is(.some, .other) > __foo {
 	order: 175;
+}
+
+__foo > __foo {
+	order: 176;
 }
 
 :is(__foo > __foo) {
@@ -1998,6 +2258,10 @@ __foo {
 	order: 184;
 }
 
+:--foo :--foo {
+	order: 185;
+}
+
 :is(:--foo :--foo) {
 	order: 185;
 }
@@ -2024,6 +2288,10 @@ __foo {
 
 :is(.some, .other)  :--foo {
 	order: 187;
+}
+
+:--foo  :--foo {
+	order: 188;
 }
 
 :is(:--foo  :--foo) {
@@ -2054,6 +2322,10 @@ __foo {
 	order: 190;
 }
 
+:--foo+:--foo {
+	order: 191;
+}
+
 :is(:--foo+:--foo) {
 	order: 191;
 }
@@ -2080,6 +2352,10 @@ __foo {
 
 :is(.some, .other) + :--foo {
 	order: 193;
+}
+
+:--foo + :--foo {
+	order: 194;
 }
 
 :is(:--foo + :--foo) {
@@ -2110,6 +2386,10 @@ __foo {
 	order: 196;
 }
 
+:--foo~:--foo {
+	order: 197;
+}
+
 :is(:--foo~:--foo) {
 	order: 197;
 }
@@ -2136,6 +2416,10 @@ __foo {
 
 :is(.some, .other) ~ :--foo {
 	order: 199;
+}
+
+:--foo ~ :--foo {
+	order: 200;
 }
 
 :is(:--foo ~ :--foo) {
@@ -2166,6 +2450,10 @@ __foo {
 	order: 202;
 }
 
+:--foo>:--foo {
+	order: 203;
+}
+
 :is(:--foo>:--foo) {
 	order: 203;
 }
@@ -2192,6 +2480,10 @@ __foo {
 
 :is(.some, .other) > :--foo {
 	order: 205;
+}
+
+:--foo > :--foo {
+	order: 206;
 }
 
 :is(:--foo > :--foo) {
@@ -2294,6 +2586,10 @@ __foo {
 	order: 214;
 }
 
+[foo="baz"] [foo="baz"] {
+	order: 215;
+}
+
 :is([foo="baz"] [foo="baz"]) {
 	order: 215;
 }
@@ -2320,6 +2616,10 @@ __foo {
 
 :is(.some, .other)  [foo="baz"] {
 	order: 217;
+}
+
+[foo="baz"]  [foo="baz"] {
+	order: 218;
 }
 
 :is([foo="baz"]  [foo="baz"]) {
@@ -2350,6 +2650,10 @@ __foo {
 	order: 220;
 }
 
+[foo="baz"]+[foo="baz"] {
+	order: 221;
+}
+
 :is([foo="baz"]+[foo="baz"]) {
 	order: 221;
 }
@@ -2376,6 +2680,10 @@ __foo {
 
 :is(.some, .other) + [foo="baz"] {
 	order: 223;
+}
+
+[foo="baz"] + [foo="baz"] {
+	order: 224;
 }
 
 :is([foo="baz"] + [foo="baz"]) {
@@ -2406,6 +2714,10 @@ __foo {
 	order: 226;
 }
 
+[foo="baz"]~[foo="baz"] {
+	order: 227;
+}
+
 :is([foo="baz"]~[foo="baz"]) {
 	order: 227;
 }
@@ -2432,6 +2744,10 @@ __foo {
 
 :is(.some, .other) ~ [foo="baz"] {
 	order: 229;
+}
+
+[foo="baz"] ~ [foo="baz"] {
+	order: 230;
 }
 
 :is([foo="baz"] ~ [foo="baz"]) {
@@ -2462,6 +2778,10 @@ __foo {
 	order: 232;
 }
 
+[foo="baz"]>[foo="baz"] {
+	order: 233;
+}
+
 :is([foo="baz"]>[foo="baz"]) {
 	order: 233;
 }
@@ -2488,6 +2808,10 @@ __foo {
 
 :is(.some, .other) > [foo="baz"] {
 	order: 235;
+}
+
+[foo="baz"] > [foo="baz"] {
+	order: 236;
 }
 
 :is([foo="baz"] > [foo="baz"]) {
@@ -2590,6 +2914,10 @@ __foo {
 	order: 244;
 }
 
+* * {
+	order: 245;
+}
+
 :is(* *) {
 	order: 245;
 }
@@ -2616,6 +2944,10 @@ __foo {
 
 :is(.some, .other)  * {
 	order: 247;
+}
+
+*  * {
+	order: 248;
 }
 
 :is(*  *) {
@@ -2646,6 +2978,10 @@ __foo {
 	order: 250;
 }
 
+*+* {
+	order: 251;
+}
+
 :is(*+*) {
 	order: 251;
 }
@@ -2672,6 +3008,10 @@ __foo {
 
 :is(.some, .other) + * {
 	order: 253;
+}
+
+* + * {
+	order: 254;
 }
 
 :is(* + *) {
@@ -2702,6 +3042,10 @@ __foo {
 	order: 256;
 }
 
+*~* {
+	order: 257;
+}
+
 :is(*~*) {
 	order: 257;
 }
@@ -2728,6 +3072,10 @@ __foo {
 
 :is(.some, .other) ~ * {
 	order: 259;
+}
+
+* ~ * {
+	order: 260;
 }
 
 :is(* ~ *) {
@@ -2758,6 +3106,10 @@ __foo {
 	order: 262;
 }
 
+*>* {
+	order: 263;
+}
+
 :is(*>*) {
 	order: 263;
 }
@@ -2784,6 +3136,10 @@ __foo {
 
 :is(.some, .other) > * {
 	order: 265;
+}
+
+* > * {
+	order: 266;
 }
 
 :is(* > *) {
@@ -2886,6 +3242,10 @@ __foo {
 	order: 274;
 }
 
+:hover :hover {
+	order: 275;
+}
+
 :is(:hover :hover) {
 	order: 275;
 }
@@ -2912,6 +3272,10 @@ __foo {
 
 :is(.some, .other)  :hover {
 	order: 277;
+}
+
+:hover  :hover {
+	order: 278;
 }
 
 :is(:hover  :hover) {
@@ -2942,6 +3306,10 @@ __foo {
 	order: 280;
 }
 
+:hover+:hover {
+	order: 281;
+}
+
 :is(:hover+:hover) {
 	order: 281;
 }
@@ -2968,6 +3336,10 @@ __foo {
 
 :is(.some, .other) + :hover {
 	order: 283;
+}
+
+:hover + :hover {
+	order: 284;
 }
 
 :is(:hover + :hover) {
@@ -2998,6 +3370,10 @@ __foo {
 	order: 286;
 }
 
+:hover~:hover {
+	order: 287;
+}
+
 :is(:hover~:hover) {
 	order: 287;
 }
@@ -3024,6 +3400,10 @@ __foo {
 
 :is(.some, .other) ~ :hover {
 	order: 289;
+}
+
+:hover ~ :hover {
+	order: 290;
 }
 
 :is(:hover ~ :hover) {
@@ -3054,6 +3434,10 @@ __foo {
 	order: 292;
 }
 
+:hover>:hover {
+	order: 293;
+}
+
 :is(:hover>:hover) {
 	order: 293;
 }
@@ -3080,6 +3464,10 @@ __foo {
 
 :is(.some, .other) > :hover {
 	order: 295;
+}
+
+:hover > :hover {
+	order: 296;
 }
 
 :is(:hover > :hover) {
@@ -3182,6 +3570,10 @@ __foo {
 	order: 304;
 }
 
+::before ::before {
+	order: 305;
+}
+
 :is(::before ::before) {
 	order: 305;
 }
@@ -3208,6 +3600,10 @@ __foo {
 
 :is(.some, .other)  ::before {
 	order: 307;
+}
+
+::before  ::before {
+	order: 308;
 }
 
 :is(::before  ::before) {
@@ -3238,6 +3634,10 @@ __foo {
 	order: 310;
 }
 
+::before+::before {
+	order: 311;
+}
+
 :is(::before+::before) {
 	order: 311;
 }
@@ -3264,6 +3664,10 @@ __foo {
 
 :is(.some, .other) + ::before {
 	order: 313;
+}
+
+::before + ::before {
+	order: 314;
 }
 
 :is(::before + ::before) {
@@ -3294,6 +3698,10 @@ __foo {
 	order: 316;
 }
 
+::before~::before {
+	order: 317;
+}
+
 :is(::before~::before) {
 	order: 317;
 }
@@ -3320,6 +3728,10 @@ __foo {
 
 :is(.some, .other) ~ ::before {
 	order: 319;
+}
+
+::before ~ ::before {
+	order: 320;
 }
 
 :is(::before ~ ::before) {
@@ -3350,6 +3762,10 @@ __foo {
 	order: 322;
 }
 
+::before>::before {
+	order: 323;
+}
+
 :is(::before>::before) {
 	order: 323;
 }
@@ -3376,6 +3792,10 @@ __foo {
 
 :is(.some, .other) > ::before {
 	order: 325;
+}
+
+::before > ::before {
+	order: 326;
 }
 
 :is(::before > ::before) {
@@ -3420,6 +3840,10 @@ __foo {
 
 :is(::before) {
 	order: 329;
+}
+
+:not(*) {
+	order: 330;
 }
 
 :is() {


### PR DESCRIPTION
The previous version wasn't able to transform nested `:is` easily without causing infinite loops.

Finally had an idea to work around this that is more solid :

- transform lists firsts and replace `:is` with something else `:-csstools-matches`. This clearly separates touched vs untouched, making recursion much easier.
- handle removing `:is` or `:-csstools-matches` in a second step.

This also made the code easier to split in smaller, more understandable parts.

For debugging I also found it handy to disable the second stage and see the output from only the first.

This doesn't break any existing behaviour and adds a few more cases it can handle :

- `:is()` -> `:not(*)`
- `:is(<complex selector>)` -> `<complex selector>` (no parts before or after `:is()`)
