### PR TITLE
postcss-preset-env : make logger a class instance

### DIFF
--- a/plugin-packs/postcss-preset-env/src/index.js
+++ b/plugin-packs/postcss-preset-env/src/index.js
@@ -2,19 +2,21 @@ import autoprefixer from 'autoprefixer';
 import cssdb from 'cssdb';
 import writeToExports from './side-effects/write-to-exports.mjs';
 import { pluginIdHelp } from './plugins/plugin-id-help.mjs';
-import { dumpLogs, resetLogger } from './log/helper.mjs';
+import { newLogger } from './log/helper.mjs';
 import logFeaturesList from './log/features-list.mjs';
 import { listFeatures } from './lib/list-features.mjs';
 import { initializeSharedOptions } from './lib/shared-options.mjs';
 
 const plugin = (opts) => {
+	const logger = newLogger();
+
 	// initialize options
 	const options = Object(opts);
 	const featureNamesInOptions = Object.keys(Object(options.features));
 	const browsers = options.browsers;
 	const sharedOptions = initializeSharedOptions(options);
 
-	const features = listFeatures(cssdb, options, sharedOptions);
+	const features = listFeatures(cssdb, options, sharedOptions, logger);
 	const plugins = features.map((feature) => {
 		return feature.plugin;
 	});
@@ -25,7 +27,7 @@ const plugin = (opts) => {
 		);
 	}
 
-	logFeaturesList(features, options);
+	logFeaturesList(features, options, logger);
 
 	const internalPlugin = () => {
 		return {
@@ -34,11 +36,11 @@ const plugin = (opts) => {
 				pluginIdHelp(featureNamesInOptions, root, result);
 
 				if (options.debug) {
-					dumpLogs(result);
+					logger.dumpLogs(result);
 				}
 
 				// Always reset the logger, if when debug is false
-				resetLogger();
+				logger.resetLogger();
 
 				if (options.exportTo) {
 					writeToExports(sharedOptions.exportTo, opts.exportTo);

--- a/plugin-packs/postcss-preset-env/src/lib/format-feature.mjs
+++ b/plugin-packs/postcss-preset-env/src/lib/format-feature.mjs
@@ -33,11 +33,11 @@ export function formatPolyfillableFeature(feature) {
 	};
 }
 
-export function formatStagedFeature(cssdbList, browsers, features, feature, sharedOptions) {
+export function formatStagedFeature(cssdbList, browsers, features, feature, sharedOptions, logger) {
 	let options;
 	let plugin;
 
-	options = getOptionsForBrowsersByFeature(browsers, feature, cssdbList);
+	options = getOptionsForBrowsersByFeature(browsers, feature, cssdbList, logger);
 
 	if (features[feature.id] === true) {
 		if (sharedOptions) {

--- a/plugin-packs/postcss-preset-env/src/lib/get-options-for-browsers-by-feature.mjs
+++ b/plugin-packs/postcss-preset-env/src/lib/get-options-for-browsers-by-feature.mjs
@@ -1,9 +1,8 @@
 import browserslist from 'browserslist';
 import getUnsupportedBrowsersByFeature from './get-unsupported-browsers-by-feature.mjs';
-import { log } from '../log/helper.mjs';
 
 // add extra options for certain browsers by feature
-export default function getOptionsForBrowsersByFeature(browsers, feature, cssdbList) {
+export default function getOptionsForBrowsersByFeature(browsers, feature, cssdbList, logger) {
 	const supportedBrowsers = browserslist(browsers, { ignoreUnknownVersions: true });
 
 	switch (feature.id) {
@@ -21,7 +20,7 @@ export default function getOptionsForBrowsersByFeature(browsers, feature, cssdbL
 				const feature = cssdbList.find(feature => feature.id === 'is-pseudo-class');
 
 				if (needsOptionFor(feature, supportedBrowsers)) {
-					log('Disabling :is on "nesting-rules" due to lack of browser support.');
+					logger.log('Disabling :is on "nesting-rules" due to lack of browser support.');
 					return {
 						noIsPseudoSelector: true,
 					};
@@ -37,7 +36,7 @@ export default function getOptionsForBrowsersByFeature(browsers, feature, cssdbL
 				});
 
 				if (hasIEOrEdge) {
-					log('Adding area[href] fallbacks for ":any-link" support in Edge and IE.');
+					logger.log('Adding area[href] fallbacks for ":any-link" support in Edge and IE.');
 					return {
 						subFeatures: {
 							areaHrefNeedsFixing: true,

--- a/plugin-packs/postcss-preset-env/src/lib/stage.mjs
+++ b/plugin-packs/postcss-preset-env/src/lib/stage.mjs
@@ -1,14 +1,13 @@
-import { log } from '../log/helper.mjs';
 import { clamp } from '../util/clamp.mjs';
 
 export const DEFAULT_STAGE = 2;
 export const OUT_OF_RANGE_STAGE = 5;
 
-export function stageFromOptions(options) {
+export function stageFromOptions(options, logger) {
 	let stage = DEFAULT_STAGE;
 
 	if (typeof options.stage === 'undefined') {
-		log(`Using features from Stage ${stage} (default)`);
+		logger.log(`Using features from Stage ${stage} (default)`);
 		return stage;
 	}
 
@@ -24,9 +23,9 @@ export function stageFromOptions(options) {
 	}
 
 	if (stage === OUT_OF_RANGE_STAGE) {
-		log('Stage has been disabled, features will be handled via the "features" option.');
+		logger.log('Stage has been disabled, features will be handled via the "features" option.');
 	} else {
-		log(`Using features from Stage ${stage}`);
+		logger.log(`Using features from Stage ${stage}`);
 	}
 
 	return stage;

--- a/plugin-packs/postcss-preset-env/src/log/features-list.mjs
+++ b/plugin-packs/postcss-preset-env/src/log/features-list.mjs
@@ -1,16 +1,15 @@
-import { log } from './helper.mjs';
 import { clientSideDocumentation } from '../client-side-polyfills/plugins.mjs';
 
-export default function logFeaturesList(supportedFeatures, options) {
+export default function logFeaturesList(supportedFeatures, options, logger) {
 	if (options.debug) {
-		log('Enabling the following feature(s):');
+		logger.log('Enabling the following feature(s):');
 		const clientSideFeatures = [];
 
 		supportedFeatures.forEach(feature => {
 			if (feature.id.startsWith('before') || feature.id.startsWith('after')) {
-				log(`  ${feature.id} (injected via options)`);
+				logger.log(`  ${feature.id} (injected via options)`);
 			} else {
-				log(`  ${feature.id}`);
+				logger.log(`  ${feature.id}`);
 			}
 
 			if (typeof clientSideDocumentation[feature.id] !== 'undefined') {
@@ -19,8 +18,8 @@ export default function logFeaturesList(supportedFeatures, options) {
 		});
 
 		if (clientSideFeatures.length) {
-			log('These feature(s) need a browser library to work:');
-			clientSideFeatures.forEach(featureId => log(` ${featureId}: ${clientSideDocumentation[featureId]}`));
+			logger.log('These feature(s) need a browser library to work:');
+			clientSideFeatures.forEach(featureId => logger.log(` ${featureId}: ${clientSideDocumentation[featureId]}`));
 		}
 	}
 }

--- a/plugin-packs/postcss-preset-env/src/log/helper.mjs
+++ b/plugin-packs/postcss-preset-env/src/log/helper.mjs
@@ -1,18 +1,26 @@
-const logs = [];
-
-export function log(str) {
-	logs.push(str);
-}
-
-export function resetLogger() {
-	logs.length = 0;
-}
-
-export function dumpLogs(result) {
-	if (result) {
-		logs.forEach(line => result.warn(line));
+class Logger {
+	constructor() {
+		this.logs = [];
 	}
 
-	resetLogger();
+	log(str) {
+		this.logs.push(str);
+	}
+
+	resetLogger() {
+		this.logs.length = 0;
+	}
+
+	dumpLogs(result) {
+		if (result) {
+			this.logs.forEach(line => result.warn(line));
+		}
+
+		this.resetLogger();
+	}
+}
+
+export function newLogger() {
+	return new Logger();
 }
 

--- a/plugin-packs/postcss-preset-env/src/test/lib/format-staged-feature.mjs
+++ b/plugin-packs/postcss-preset-env/src/test/lib/format-staged-feature.mjs
@@ -1,5 +1,8 @@
 import { formatStagedFeature } from '../../lib/format-feature.mjs';
 import { strict as assert } from 'assert';
+import { newTestLogger } from '../log/test-logger.mjs';
+
+const testLogger = newTestLogger();
 
 assert.deepStrictEqual(
 	formatStagedFeature(
@@ -15,6 +18,7 @@ assert.deepStrictEqual(
 			vendors_implementations: 1,
 		},
 		undefined,
+		testLogger.logger,
 	),
 	{
 		browsers: [
@@ -43,6 +47,7 @@ assert.deepStrictEqual(
 			vendors_implementations: 1,
 		},
 		undefined,
+		testLogger.logger,
 	),
 	{
 		browsers: [
@@ -73,6 +78,7 @@ assert.deepStrictEqual(
 		{
 			shared: true,
 		},
+		testLogger.logger,
 	),
 	{
 		browsers: [
@@ -101,6 +107,7 @@ assert.deepStrictEqual(
 		{
 			shared: true,
 		},
+		testLogger.logger,
 	),
 	{
 		browsers: [

--- a/plugin-packs/postcss-preset-env/src/test/lib/list-features/client-side.mjs
+++ b/plugin-packs/postcss-preset-env/src/test/lib/list-features/client-side.mjs
@@ -1,14 +1,13 @@
-import { testLogger } from '../../log/test-logger.mjs';
+import { newTestLogger } from '../../log/test-logger.mjs';
 import { strict as assert } from 'assert';
-import { dumpLogs, resetLogger } from '../../../log/helper.mjs';
 import { listFeatures } from '../../../lib/list-features.mjs';
 import { cssdb } from './cssdb-fixture.mjs';
 
-const logger = testLogger();
+const testLogger = newTestLogger();
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	cleanResult(listFeatures(cssdb, {stage: 0, enableClientSidePolyfills: false})),
+	cleanResult(listFeatures(cssdb, {stage: 0, enableClientSidePolyfills: false}, undefined, testLogger.logger)),
 	[
 		{
 			browsers: [
@@ -28,9 +27,9 @@ assert.deepStrictEqual(
 	],
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	[
 		'Using features from Stage 0',
 		'  blank-pseudo-class has been disabled by "enableClientSidePolyfills: false".',
@@ -38,9 +37,9 @@ assert.deepStrictEqual(
 	],
 );
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	cleanResult(listFeatures(cssdb, {stage: 0, enableClientSidePolyfills: true})),
+	cleanResult(listFeatures(cssdb, {stage: 0, enableClientSidePolyfills: true}, undefined, testLogger.logger)),
 	[
 		{
 			browsers: [
@@ -75,9 +74,9 @@ assert.deepStrictEqual(
 	],
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	[
 		'Using features from Stage 0',
 		'Adding area[href] fallbacks for ":any-link" support in Edge and IE.',

--- a/plugin-packs/postcss-preset-env/src/test/lib/list-features/no-options.mjs
+++ b/plugin-packs/postcss-preset-env/src/test/lib/list-features/no-options.mjs
@@ -1,14 +1,13 @@
-import { testLogger } from '../../log/test-logger.mjs';
+import { newTestLogger } from '../../log/test-logger.mjs';
 import { strict as assert } from 'assert';
-import { dumpLogs, resetLogger } from '../../../log/helper.mjs';
 import { listFeatures } from '../../../lib/list-features.mjs';
 import { cssdb }  from './cssdb-fixture.mjs';
 
-const logger = testLogger();
+const testLogger = newTestLogger();
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	cleanResult(listFeatures(cssdb, {})),
+	cleanResult(listFeatures(cssdb, {}, undefined, testLogger.logger)),
 	[
 		{
 			browsers: [
@@ -28,9 +27,9 @@ assert.deepStrictEqual(
 	],
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	[
 		'Using features from Stage 2 (default)',
 		'  blank-pseudo-class with stage 1 has been disabled',

--- a/plugin-packs/postcss-preset-env/src/test/lib/list-features/preserve.mjs
+++ b/plugin-packs/postcss-preset-env/src/test/lib/list-features/preserve.mjs
@@ -1,14 +1,13 @@
-import { testLogger } from '../../log/test-logger.mjs';
+import { newTestLogger } from '../../log/test-logger.mjs';
 import { strict as assert } from 'assert';
-import { dumpLogs, resetLogger } from '../../../log/helper.mjs';
 import { listFeatures } from '../../../lib/list-features.mjs';
 import { cssdb } from './cssdb-fixture.mjs';
 
-const logger = testLogger();
+const testLogger = newTestLogger();
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	cleanResult(listFeatures(cssdb, { stage: 0 }, { preserve: true })),
+	cleanResult(listFeatures(cssdb, { stage: 0 }, { preserve: true }, testLogger.logger)),
 	[
 		{
 			browsers: [
@@ -43,9 +42,9 @@ assert.deepStrictEqual(
 	],
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	[
 		'Using features from Stage 0',
 		'Adding area[href] fallbacks for ":any-link" support in Edge and IE.',
@@ -53,9 +52,9 @@ assert.deepStrictEqual(
 );
 
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	cleanResult(listFeatures(cssdb, { stage: 0 }, { preserve: false })),
+	cleanResult(listFeatures(cssdb, { stage: 0 }, { preserve: false }, testLogger.logger)),
 	[
 		{
 			browsers: [
@@ -90,9 +89,9 @@ assert.deepStrictEqual(
 	],
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	[
 		'Using features from Stage 0',
 		'Adding area[href] fallbacks for ":any-link" support in Edge and IE.',

--- a/plugin-packs/postcss-preset-env/src/test/lib/list-features/stage-0.mjs
+++ b/plugin-packs/postcss-preset-env/src/test/lib/list-features/stage-0.mjs
@@ -1,14 +1,13 @@
-import { testLogger } from '../../log/test-logger.mjs';
+import { newTestLogger } from '../../log/test-logger.mjs';
 import { strict as assert } from 'assert';
-import { dumpLogs, resetLogger } from '../../../log/helper.mjs';
 import { listFeatures } from '../../../lib/list-features.mjs';
 import { cssdb } from './cssdb-fixture.mjs';
 
-const logger = testLogger();
+const testLogger = newTestLogger();
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	cleanResult(listFeatures(cssdb, {stage: 0})),
+	cleanResult(listFeatures(cssdb, {stage: 0}, undefined, testLogger.logger)),
 	[
 		{
 			browsers: [
@@ -43,9 +42,9 @@ assert.deepStrictEqual(
 	],
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	[
 		'Using features from Stage 0',
 		'Adding area[href] fallbacks for ":any-link" support in Edge and IE.',

--- a/plugin-packs/postcss-preset-env/src/test/lib/list-features/vendor-implementations.mjs
+++ b/plugin-packs/postcss-preset-env/src/test/lib/list-features/vendor-implementations.mjs
@@ -1,14 +1,13 @@
-import { testLogger } from '../../log/test-logger.mjs';
+import { newTestLogger } from '../../log/test-logger.mjs';
 import { strict as assert } from 'assert';
-import { dumpLogs, resetLogger } from '../../../log/helper.mjs';
 import { listFeatures } from '../../../lib/list-features.mjs';
 import { cssdb } from './cssdb-fixture.mjs';
 
-const logger = testLogger();
+const testLogger = newTestLogger();
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	cleanResult(listFeatures(cssdb, {minimumVendorImplementations: 2, stage: 0})),
+	cleanResult(listFeatures(cssdb, {minimumVendorImplementations: 2, stage: 0}, undefined, testLogger.logger)),
 	[
 		{
 			browsers: [
@@ -28,9 +27,9 @@ assert.deepStrictEqual(
 	],
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	[
 		'Using features with 2 or more vendor implementations',
 		'Using features from Stage 0',

--- a/plugin-packs/postcss-preset-env/src/test/lib/stage.mjs
+++ b/plugin-packs/postcss-preset-env/src/test/lib/stage.mjs
@@ -1,90 +1,89 @@
-import { testLogger } from '../log/test-logger.mjs';
+import { newTestLogger } from '../log/test-logger.mjs';
 import { strict as assert } from 'assert';
 import { OUT_OF_RANGE_STAGE, stageFromOptions } from '../../lib/stage.mjs';
-import { dumpLogs, resetLogger } from '../../log/helper.mjs';
 
-const logger = testLogger();
+const testLogger = newTestLogger();
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	stageFromOptions({stage: 4}),
+	stageFromOptions({stage: 4}, testLogger.logger),
 	4,
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	['Using features from Stage 4'],
 );
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	stageFromOptions({stage: '4'}),
+	stageFromOptions({stage: '4'}, testLogger.logger),
 	4,
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	['Using features from Stage 4'],
 );
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	stageFromOptions({stage: -1}),
+	stageFromOptions({stage: -1}, testLogger.logger),
 	0,
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	['Using features from Stage 0'],
 );
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	stageFromOptions({stage: false}),
+	stageFromOptions({stage: false}, testLogger.logger),
 	OUT_OF_RANGE_STAGE,
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	['Stage has been disabled, features will be handled via the "features" option.'],
 );
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	stageFromOptions({stage: 'esfgdfg'}),
+	stageFromOptions({stage: 'esfgdfg'}, testLogger.logger),
 	0,
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	['Using features from Stage 0'],
 );
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	stageFromOptions({}),
+	stageFromOptions({}, testLogger.logger),
 	2,
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	['Using features from Stage 2 (default)'],
 );
 
-resetLogger();
+testLogger.logger.resetLogger();
 assert.deepStrictEqual(
-	stageFromOptions({stage: OUT_OF_RANGE_STAGE+2}),
+	stageFromOptions({stage: OUT_OF_RANGE_STAGE+2}, testLogger.logger),
 	OUT_OF_RANGE_STAGE,
 );
 
-dumpLogs(logger);
+testLogger.logger.dumpLogs(testLogger);
 assert.deepStrictEqual(
-	logger.getLogs(),
+	testLogger.getLogs(),
 	['Stage has been disabled, features will be handled via the "features" option.'],
 );

--- a/plugin-packs/postcss-preset-env/src/test/log/test-logger.mjs
+++ b/plugin-packs/postcss-preset-env/src/test/log/test-logger.mjs
@@ -1,7 +1,11 @@
-export function testLogger() {
+import { newLogger } from '../../log/helper.mjs';
+
+export function newTestLogger() {
 	let logs = [];
+	const logger = newLogger();
 
 	return {
+		logger: logger,
 		warn: (line) => {
 			logs.push(line);
 		},


### PR DESCRIPTION
This adds support for debug logs when doing multiple parallel runs.