### PR TITLE
postcss-color-function : fix percentage handling

### DIFF
--- a/plugins/postcss-color-function/CHANGELOG.md
+++ b/plugins/postcss-color-function/CHANGELOG.md
@@ -1,22 +1,9 @@
 # Changes to PostCSS Color Function
 
-### Unreleased (minor)
+### Unreleased (patch)
 
-- Add support for `none` color component.
 - Add tests for percentage values in non-xyz color spaces.
-- Ignore percentage values in xyz color space as they are not supported.
-
-```css
-.none-color-component {
-	color: color(display-p3 none none 1);
-}
-
-/* becomes */
-
-.none-color-component {
-	color: rgb(0,0,255);
-}
-```
+- Ignore percentage values in xyz color space as these are not supported.
 
 ### 1.0.0 (February 7, 2022)
 

--- a/plugins/postcss-color-function/CHANGELOG.md
+++ b/plugins/postcss-color-function/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changes to PostCSS Color Function
 
+### Unreleased (minor)
+
+- Add support for `none` color component.
+- Add tests for percentage values in non-xyz color spaces.
+- Ignore percentage values in xyz color space as they are not supported.
+
+```css
+.none-color-component {
+	color: color(display-p3 none none 1);
+}
+
+/* becomes */
+
+.none-color-component {
+	color: rgb(0,0,255);
+}
+```
+
 ### 1.0.0 (February 7, 2022)
 
 - Initial version

--- a/plugins/postcss-color-function/src/index.ts
+++ b/plugins/postcss-color-function/src/index.ts
@@ -5,8 +5,12 @@ import { hasFallback } from './has-fallback-decl';
 import { hasSupportsAtRuleAncestor } from './has-supports-at-rule-ancestor';
 import { modifiedValues } from './modified-value';
 
+type basePluginOptions = {
+	preserve: boolean,
+}
+
 /** Transform color() function in CSS. */
-const basePlugin: PluginCreator<{ preserve: boolean }> = (opts?: { preserve: boolean }) => {
+const basePlugin: PluginCreator<basePluginOptions> = (opts: basePluginOptions) => {
 	const preserve = 'preserve' in Object(opts) ? Boolean(opts.preserve) : false;
 	return {
 		postcssPlugin: 'postcss-color-function',
@@ -40,22 +44,29 @@ const basePlugin: PluginCreator<{ preserve: boolean }> = (opts?: { preserve: boo
 
 basePlugin.postcss = true;
 
-/** Dynamically include "postcssProgressiveCustomProperties" only when needed. */
-const postcssPlugin: PluginCreator<{ preserve?: boolean, enableProgressiveCustomProperties?: boolean }> = (opts?: { preserve?: boolean, enableProgressiveCustomProperties?: boolean }) => {
-	const preserve = 'preserve' in Object(opts) ? Boolean(opts.preserve) : false;
-	const enableProgressiveCustomProperties = 'enableProgressiveCustomProperties' in Object(opts) ? Boolean(opts.enableProgressiveCustomProperties) : true;
+type pluginOptions = {
+	preserve?: boolean,
+	enableProgressiveCustomProperties?: boolean,
+}
 
-	if (enableProgressiveCustomProperties && preserve) {
+/* Transform color() function in CSS. */
+const postcssPlugin: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
+	const options = Object.assign({
+		preserve: false,
+		enableProgressiveCustomProperties: true,
+	}, opts);
+
+	if (options.enableProgressiveCustomProperties && options.preserve) {
 		return {
 			postcssPlugin: 'postcss-color-function',
 			plugins: [
 				postcssProgressiveCustomProperties(),
-				basePlugin({ preserve: preserve }),
+				basePlugin(options),
 			],
 		};
 	}
 
-	return basePlugin({ preserve: preserve });
+	return basePlugin(options);
 };
 
 postcssPlugin.postcss = true;

--- a/plugins/postcss-color-function/src/on-css-function.ts
+++ b/plugins/postcss-color-function/src/on-css-function.ts
@@ -189,10 +189,6 @@ function isNumericNodePercentageOrNumber(node: Node): node is WordNode {
 	return unitAndValue.unit === '%' || unitAndValue.unit === '';
 }
 
-function isNoneNode(node: Node): node is FunctionNode {
-	return node && node.type === 'word' && node.value === 'none';
-}
-
 function isCalcNode(node: Node): node is FunctionNode {
 	return node && node.type === 'function' && node.value === 'calc';
 }
@@ -240,17 +236,8 @@ function colorFunctionContents(nodes): Color|null {
 			}
 		}
 
-		if (isNoneNode(nodes[i])) {
-			// https://drafts.csswg.org/css-color/#missing
-			out.parameters.push({
-				value: {
-					number: '0',
-					unit: '',
-				},
-				node: nodes[i],
-			});
-
-		} else if (!out.colorSpace.startsWith('xyz') && isNumericNodePercentageOrNumber(nodes[i])) {
+		if (!out.colorSpace.startsWith('xyz') && isNumericNodePercentageOrNumber(nodes[i])) {
+			// non-xyz DOES support percentages
 			const unitAndValue = valueParser.unit(nodes[i].value) as Dimension;
 			if (unitAndValue.unit === '%') {
 				// transform the channel from a Percentage to (0-1) Number
@@ -265,7 +252,7 @@ function colorFunctionContents(nodes): Color|null {
 			});
 
 		} else if (out.colorSpace.startsWith('xyz') && isNumericNodePercentageOrNumber(nodes[i])) {
-			// xyz does not support percentages
+			// xyz DOES NOT support percentages
 			const unitAndValue = valueParser.unit(nodes[i].value) as Dimension;
 			if (unitAndValue.unit !== '') {
 				return null;

--- a/plugins/postcss-color-function/test/basic.css
+++ b/plugins/postcss-color-function/test/basic.css
@@ -7,8 +7,24 @@
 	color-6: color(display-p3 1 1 1 1 / 0.5);
 }
 
+.test-color-none {
+	color-1: color(display-p3 none);
+	color-3: color(display-p3 none none);
+	color-4: color(display-p3 none none none);
+	color-5: color(display-p3 1 none 1);
+	color-6: color(display-p3 1 none none);
+	color-7: color(display-p3 none 1 none);
+	color-8: color(display-p3 none none 1);
+}
+
 .test-unknown-space {
 	color-1: color(unknown 0.64331 0.19245 0.16771);
+}
+
+.test-percentage-rgb {
+	color-1: color(srgb 64.331% 0.19245 0.16771);
+	color-2: color(srgb 0.64331 19.245% 0.16771);
+	color-3: color(srgb 0.64331 0.19245 16.771%);
 }
 
 .test-srgb {
@@ -40,6 +56,12 @@
 	color-1: color(xyz-d50 0.2005 0.14089 0.4472);
 	color-2: color(xyz-d65 0.21661 0.14602 0.59452);
 	color-3: color(xyz 0.21661 0.14602 0.59452);
+}
+
+.test-percentage-xyz {
+	color-1: color(xyz-d50 64.331% 0.19245 0.16771);
+	color-2: color(xyz-d65 0.64331 19.245% 0.16771);
+	color-3: color(xyz 0.64331 0.19245 16.771%);
 }
 
 .test-author-provided-fallback {

--- a/plugins/postcss-color-function/test/basic.css
+++ b/plugins/postcss-color-function/test/basic.css
@@ -17,6 +17,11 @@
 	color-8: color(display-p3 none none 1);
 }
 
+.test-css-color-5-interop {
+	color-1: color(from color(a98-rgb 0.7 0.5 0.3) a98-rgb r g b / none);
+	color-2: color(from color(prophoto-rgb 0.7 0.5 0.3) prophoto-rgb r g none);
+}
+
 .test-unknown-space {
 	color-1: color(unknown 0.64331 0.19245 0.16771);
 }

--- a/plugins/postcss-color-function/test/basic.expect.css
+++ b/plugins/postcss-color-function/test/basic.expect.css
@@ -17,6 +17,11 @@
 	color-8: rgb(0,0,255);
 }
 
+.test-css-color-5-interop {
+	color-1: color(from rgb(196,129,72) a98-rgb r g b / none);
+	color-2: color(from rgb(234,133,82) prophoto-rgb r g none);
+}
+
 .test-unknown-space {
 	color-1: color(unknown 0.64331 0.19245 0.16771);
 }

--- a/plugins/postcss-color-function/test/basic.expect.css
+++ b/plugins/postcss-color-function/test/basic.expect.css
@@ -7,8 +7,24 @@
 	color-6: rgba(255,255,255,0.5);
 }
 
+.test-color-none {
+	color-1: rgb(0,0,0);
+	color-3: rgb(0,0,0);
+	color-4: rgb(0,0,0);
+	color-5: rgb(255,76,241);
+	color-6: rgb(255,30,24);
+	color-7: rgb(0,247,78);
+	color-8: rgb(0,0,255);
+}
+
 .test-unknown-space {
 	color-1: color(unknown 0.64331 0.19245 0.16771);
+}
+
+.test-percentage-rgb {
+	color-1: rgb(164,49,43);
+	color-2: rgb(164,49,43);
+	color-3: rgb(164,49,43);
 }
 
 .test-srgb {
@@ -40,6 +56,12 @@
 	color-1: rgb(118,84,205);
 	color-2: rgb(118,84,205);
 	color-3: rgb(118,84,205);
+}
+
+.test-percentage-xyz {
+	color-1: color(xyz-d50 64.331% 0.19245 0.16771);
+	color-2: color(xyz-d65 0.64331 19.245% 0.16771);
+	color-3: color(xyz 0.64331 0.19245 16.771%);
 }
 
 .test-author-provided-fallback {

--- a/plugins/postcss-color-function/test/basic.expect.css
+++ b/plugins/postcss-color-function/test/basic.expect.css
@@ -8,13 +8,13 @@
 }
 
 .test-color-none {
-	color-1: rgb(0,0,0);
-	color-3: rgb(0,0,0);
-	color-4: rgb(0,0,0);
-	color-5: rgb(255,76,241);
-	color-6: rgb(255,30,24);
-	color-7: rgb(0,247,78);
-	color-8: rgb(0,0,255);
+	color-1: color(display-p3 none);
+	color-3: color(display-p3 none none);
+	color-4: color(display-p3 none none none);
+	color-5: color(display-p3 1 none 1);
+	color-6: color(display-p3 1 none none);
+	color-7: color(display-p3 none 1 none);
+	color-8: color(display-p3 none none 1);
 }
 
 .test-css-color-5-interop {

--- a/plugins/postcss-color-function/test/basic.preserve-true.expect.css
+++ b/plugins/postcss-color-function/test/basic.preserve-true.expect.css
@@ -30,6 +30,13 @@
 	color-8: color(display-p3 none none 1);
 }
 
+.test-css-color-5-interop {
+	color-1: color(from rgb(196,129,72) a98-rgb r g b / none);
+	color-1: color(from color(a98-rgb 0.7 0.5 0.3) a98-rgb r g b / none);
+	color-2: color(from rgb(234,133,82) prophoto-rgb r g none);
+	color-2: color(from color(prophoto-rgb 0.7 0.5 0.3) prophoto-rgb r g none);
+}
+
 .test-unknown-space {
 	color-1: color(unknown 0.64331 0.19245 0.16771);
 }

--- a/plugins/postcss-color-function/test/basic.preserve-true.expect.css
+++ b/plugins/postcss-color-function/test/basic.preserve-true.expect.css
@@ -14,19 +14,12 @@
 }
 
 .test-color-none {
-	color-1: rgb(0,0,0);
 	color-1: color(display-p3 none);
-	color-3: rgb(0,0,0);
 	color-3: color(display-p3 none none);
-	color-4: rgb(0,0,0);
 	color-4: color(display-p3 none none none);
-	color-5: rgb(255,76,241);
 	color-5: color(display-p3 1 none 1);
-	color-6: rgb(255,30,24);
 	color-6: color(display-p3 1 none none);
-	color-7: rgb(0,247,78);
 	color-7: color(display-p3 none 1 none);
-	color-8: rgb(0,0,255);
 	color-8: color(display-p3 none none 1);
 }
 

--- a/plugins/postcss-color-function/test/basic.preserve-true.expect.css
+++ b/plugins/postcss-color-function/test/basic.preserve-true.expect.css
@@ -13,8 +13,34 @@
 	color-6: color(display-p3 1 1 1 1 / 0.5);
 }
 
+.test-color-none {
+	color-1: rgb(0,0,0);
+	color-1: color(display-p3 none);
+	color-3: rgb(0,0,0);
+	color-3: color(display-p3 none none);
+	color-4: rgb(0,0,0);
+	color-4: color(display-p3 none none none);
+	color-5: rgb(255,76,241);
+	color-5: color(display-p3 1 none 1);
+	color-6: rgb(255,30,24);
+	color-6: color(display-p3 1 none none);
+	color-7: rgb(0,247,78);
+	color-7: color(display-p3 none 1 none);
+	color-8: rgb(0,0,255);
+	color-8: color(display-p3 none none 1);
+}
+
 .test-unknown-space {
 	color-1: color(unknown 0.64331 0.19245 0.16771);
+}
+
+.test-percentage-rgb {
+	color-1: rgb(164,49,43);
+	color-1: color(srgb 64.331% 0.19245 0.16771);
+	color-2: rgb(164,49,43);
+	color-2: color(srgb 0.64331 19.245% 0.16771);
+	color-3: rgb(164,49,43);
+	color-3: color(srgb 0.64331 0.19245 16.771%);
 }
 
 .test-srgb {
@@ -63,6 +89,12 @@
 	color-2: color(xyz-d65 0.21661 0.14602 0.59452);
 	color-3: rgb(118,84,205);
 	color-3: color(xyz 0.21661 0.14602 0.59452);
+}
+
+.test-percentage-xyz {
+	color-1: color(xyz-d50 64.331% 0.19245 0.16771);
+	color-2: color(xyz-d65 0.64331 19.245% 0.16771);
+	color-3: color(xyz 0.64331 0.19245 16.771%);
 }
 
 .test-author-provided-fallback {


### PR DESCRIPTION
`xyz` color spaces do not support channel components with `%` units.

Also cleaned up a few bits :
- code comments
- plugin option typings
- some tests for future features (for interop)