### PR TITLE
script to create a new plugin

### DIFF
--- a/.github/bin/new-plugin.mjs
+++ b/.github/bin/new-plugin.mjs
@@ -1,0 +1,120 @@
+import { promises as fsp } from 'fs';
+import path from 'path';
+
+const pluginName = process.argv.slice(2).join(' ');
+
+// Plugin name checks
+{
+	if (!pluginName) {
+		console.warn('A plugin name must be provided:\n  new-plugin <human readable name>\n  new-plugin Cascade Layers');
+		process.exit(1);
+	}
+
+	if (pluginName.startsWith('postcss-')) {
+		console.warn('Plugin name cannot start with "postcss-", it is added by this scripts.');
+		process.exit(1);
+	}
+
+	if (pluginName.includes('/')) {
+		console.warn('Plugin name cannot contain "/"');
+		process.exit(1);
+	}
+}
+
+// Derived values
+const pluginSlug = 'postcss-' + pluginName.replace(/\s+/g, '-').toLowerCase();
+const packageName = '@csstools/' + pluginSlug;
+const basePluginDir = './plugins/postcss-base-plugin';
+const pluginDir = './plugins/' + pluginSlug;
+
+console.log(`- Creating new plugin ${pluginName}`);
+
+// Copy base plugin
+{
+	await fsp.rm(pluginDir, { recursive: true, force: true });
+	await fsp.cp(basePluginDir, pluginDir, { recursive: true });
+
+	console.log('- Copied base plugin to', pluginDir);
+}
+
+// Remove unnecessary files
+{
+	await fsp.rm(path.join(pluginDir, 'dist'), { recursive: true, force: true });
+	await fsp.rm(path.join(pluginDir, 'node_modules'), { recursive: true, force: true });
+	await fsp.rm(path.join(pluginDir, 'stryker.conf.json'));
+
+	await fsp.rm(path.join(pluginDir, 'src', 'cli.ts'), { recursive: true, force: true });
+	await fsp.rm(path.join(pluginDir, 'test', 'cli'), { recursive: true, force: true });
+
+	console.log('- Cleaned up files and directories not required in a new plugin');
+}
+
+// Relabel references to base plugin
+{
+	await replaceBasePluginReferencesForFilePath(path.join(pluginDir, 'src', 'index.ts'));
+	await replaceBasePluginReferencesForFilePath(path.join(pluginDir, 'test', '_import.mjs'));
+	await replaceBasePluginReferencesForFilePath(path.join(pluginDir, 'test', '_require.cjs'));
+	await replaceBasePluginReferencesForFilePath(path.join(pluginDir, '.tape.mjs'));
+	await replaceBasePluginReferencesForFilePath(path.join(pluginDir, 'README.md'));
+	await replaceBasePluginReferencesForFilePath(path.join(pluginDir, 'INSTALL.md'));
+	await fsp.writeFile(
+		path.join(pluginDir, 'CHANGELOG.md'),
+		`# Changes to PostCSS ${pluginName}
+
+### 1.0.0 (Unreleased)
+
+- Initial version
+`,
+	);
+
+	console.log('- Relabeled references to base plugin');
+}
+
+// Update package.json
+{
+	const packageInfo = JSON.parse(await fsp.readFile(path.join(pluginDir, 'package.json'), 'utf8'));
+	packageInfo.name = packageName;
+	packageInfo.description = `TODO: Add description for ${pluginName}`;
+	packageInfo.version = '1.0.0';
+	packageInfo.homepage = `https://github.com/csstools/postcss-plugins/tree/main/plugins/${pluginSlug}#readme`;
+	packageInfo.bugs = `https://github.com/csstools/postcss-plugins/issues`;
+	delete packageInfo.bin;
+	delete packageInfo.scripts['test:cli'];
+
+	packageInfo.repository.directory = `plugins/${pluginSlug}`;
+
+	await fsp.writeFile(path.join(pluginDir, 'package.json'), JSON.stringify(packageInfo, null, 2));
+
+	console.log('- Updated "package.json"');
+}
+
+console.log('\nDone! 🎉');
+
+// Next steps
+{
+	console.log('\nYour next steps:');
+	console.log('- Run : "npm install" from the root directory');
+	console.log(`- Run : "cd plugins/${pluginSlug}"`);
+	console.log('- Run : "npm run build" to build your plugin');
+	console.log('- Run : "npm run test" to test your plugin');
+	console.log('- Run : "npm run test:rewrite-expects" to update test expects');
+	console.log('\nChange "blue" to "purple" in "src/index.ts" and see how it affects the test outcome');
+}
+
+// Helpers
+async function replaceBasePluginReferencesForFilePath(filePath) {
+	await fsp.writeFile(
+		filePath,
+		replaceBasePluginReferences(
+			(await fsp.readFile(filePath, 'utf8')).toString()
+		),
+	);
+}
+
+function replaceBasePluginReferences(source) {
+	source = source.replaceAll('@csstools/postcss-base-plugin', packageName);
+	source = source.replaceAll('postcss-base-plugin', pluginSlug);
+	source = source.replaceAll('Base Plugin', pluginName);
+
+	return source;
+}

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,5 @@
 "common-tools":
+  - .github/**
   - packages/base-cli/**
   - packages/postcss-tape/**
   - plugins/postcss-base-plugin/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,40 @@ scope and avoid unrelated commits.
 
 That’s it! Now [open a pull request] with a clear title and description.
 
+## Creating a new plugin here
+
+- follow the guide for submitting a pull request
+- run `npm run new-plugin` to create a new plugin.
+
+```bash
+npm run new-plugin
+
+A plugin name must be provided:
+  new-plugin <human readable name>
+  new-plugin Cascade Layers
+```
+
+```bash
+npm run new-plugin Cascade Layers
+
+- Creating new plugin Cascade Layers
+- Copied base plugin to ./plugins/postcss-cascade-layers
+- Cleaned up files and directories not required in a new plugin
+- Relabeled references to base plugin
+- Updated "package.json"
+
+Done! 🎉
+
+Your next steps:
+- Run : "npm install" from the root directory
+- Run : "cd plugins/postcss-cascade-layers"
+- Run : "npm run build" to build your plugin
+- Run : "npm run test" to test your plugin
+- Run : "npm run test:rewrite-expects" to update test expects
+
+Change "blue" to "purple" in "src/index.ts" and see how it affects the test outcome
+```
+
 [already been reported]: issues
 [fork this project]:     fork
 [live example]:          https://codepen.io/pen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,16 @@ Your next steps:
 Change "blue" to "purple" in "src/index.ts" and see how it affects the test outcome
 ```
 
+## Trouble shooting
+
+This is a mono repo that contains unpublished packages.
+If you get warning about missing files, modules, packages you should do :
+
+- `npm install` -> get public dependencies
+- `npm run build` -> build private dependencies
+
+_if your issues is not mentioned here please open an issue so that we can extend the guides_
+
 [already been reported]: issues
 [fork this project]:     fork
 [live example]:          https://codepen.io/pen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,10 @@ scope and avoid unrelated commits.
    # Assign the original repo to a remote called "upstream"
    git remote add upstream https://github.com/csstools/postcss-plugins.git
 
-   # Install the tools necessary for testing
-   # Node 16 or higher is required to build and run tests.
-   # There is config for nvm and volta to help you use the right version.
-   npm install
-
-   # Do an initial build of everything to make sure local dependencies can be found.
-   npm run build --workspaces
+   # Install and build the needed things to start local development
+   # This also does an initial test of everything.
+   # If this gives errors please open an issue so that we can look into it.
+   npm run get-me-going
    ```
 
 2. Create a branch for your feature or fix:
@@ -80,6 +77,7 @@ That’s it! Now [open a pull request] with a clear title and description.
 ## Creating a new plugin here
 
 - follow the guide for submitting a pull request
+- run `npm run get-me-going` if you want to start local development.
 - run `npm run new-plugin` to create a new plugin.
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "typescript": "^4.5.5"
   },
   "scripts": {
+    "get-me-going": "npm run clean && npm ci && npm run build && npm run test",
     "build": "npm run build --workspaces --if-present",
+    "clean": "git clean -dfx",
     "lint": "npm run lint --workspaces --if-present && npm run lint:rollup-config",
     "lint:rollup-config": "eslint ./rollup --ext .js --ext .ts --ext .mjs --no-error-on-unmatched-pattern",
     "new-plugin": "node ./.github/bin/new-plugin.mjs",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build": "npm run build --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present && npm run lint:rollup-config",
     "lint:rollup-config": "eslint ./rollup --ext .js --ext .ts --ext .mjs --no-error-on-unmatched-pattern",
+    "new-plugin": "node ./.github/bin/new-plugin.mjs",
     "test": "npm run test --workspaces --if-present"
   },
   "volta": {


### PR DESCRIPTION
It is not obvious how to create and contribute a new plugin as mentioned here : https://github.com/csstools/postcss-plugins/issues/105#issuecomment-1036112815

help text :

```bash
npm run new-plugin

A plugin name must be provided:
  new-plugin <human readable name>
  new-plugin Cascade Layers
```

correct usage :

```bash
npm run new-plugin Cascade Layers

- Creating new plugin Cascade Layers
- Copied base plugin to ./plugins/postcss-cascade-layers
- Cleaned up files and directories not required in a new plugin
- Relabeled references to base plugin
- Updated "package.json"

Done! 🎉

Your next steps:
- Run : "npm install" from the root directory
- Run : "cd plugins/postcss-cascade-layers"
- Run : "npm run build" to build your plugin
- Run : "npm run test" to test your plugin
- Run : "npm run test:rewrite-expects" to update test expects

Change "blue" to "purple" in "src/index.ts" and see how it affects the test outcome
```

if a mistake is spotted :

```bash
npm run new-plugin postcss-cascade-layers

Plugin name cannot start with "postcss-", it is added by this scripts.
```

------

`npm run clean`

Removes any files not tracked by git

- `node_modules` directories
- `dist` directories
- `result.css` files

It helps you get back to a clean state.

------

`npm run get-me-going`

This does all the (non) obvious steps to make the mono repo functional :

- `npm run clean` (not needed for first time setup, but it can help to get you going **again**)
- `npm ci`
- `npm run build`
- `npm run test`

After these steps the contributor should never see an error unless something is unexpected in their environment (node version to old). 

------

@oluoluoxenfree Thank you for bumping the prio of this.
Has been on my list for a long time :)