### PR TITLE
postcss-progressive-custom-properties : use ast matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6888,8 +6888,8 @@
       "name": "@csstools/postcss-progressive-custom-properties",
       "version": "1.0.0",
       "license": "CC0-1.0",
-      "devDependencies": {
-        "mdn-data": "^2.0.25"
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": "^12 || ^14 || >=16"
@@ -8152,7 +8152,7 @@
     "@csstools/postcss-progressive-custom-properties": {
       "version": "file:plugins/postcss-progressive-custom-properties",
       "requires": {
-        "mdn-data": "^2.0.25"
+        "postcss-value-parser": "^4.2.0"
       }
     },
     "@csstools/postcss-tape": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6888,6 +6888,9 @@
       "name": "@csstools/postcss-progressive-custom-properties",
       "version": "1.0.0",
       "license": "CC0-1.0",
+      "devDependencies": {
+        "mdn-data": "^2.0.25"
+      },
       "engines": {
         "node": "^12 || ^14 || >=16"
       },
@@ -8148,7 +8151,9 @@
     },
     "@csstools/postcss-progressive-custom-properties": {
       "version": "file:plugins/postcss-progressive-custom-properties",
-      "requires": {}
+      "requires": {
+        "mdn-data": "^2.0.25"
+      }
     },
     "@csstools/postcss-tape": {
       "version": "file:packages/postcss-tape",

--- a/plugins/postcss-color-function/test/variables.preserve-true.expect.css
+++ b/plugins/postcss-color-function/test/variables.preserve-true.expect.css
@@ -9,19 +9,19 @@
 	--one-var: color(srgb 0.64331 var(--point-5) 0.16771 / var(--opacity-50));
 }
 
-@supports (color: color(display-p3 0 0 0)) {
+@supports (color: color(srgb 0 0 0)) {
 :root {
 	--one: color(srgb 0.64331 0.19245 0.16771);
 }
 }
 
-@supports (color: color(display-p3 0 0 0)) {
+@supports (color: color(srgb 0 0 0)) {
 :root {
 	--one-a50: color(srgb 0.64331 0.19245 0.16771 / 50);
 }
 }
 
-@supports (color: color(display-p3 0 0 0)) {
+@supports (color: color(srgb 0 0 0)) {
 :root {
 	--one-a50-var: color(srgb 0.64331 0.19245 0.16771 / var(--opacity-50));
 }

--- a/plugins/postcss-color-function/test/variables.preserve-true.expect.css
+++ b/plugins/postcss-color-function/test/variables.preserve-true.expect.css
@@ -9,19 +9,19 @@
 	--one-var: color(srgb 0.64331 var(--point-5) 0.16771 / var(--opacity-50));
 }
 
-@supports (--one: color(srgb 0.64331 0.19245 0.16771)) {
+@supports (color: color(display-p3 0 0 0)) {
 :root {
 	--one: color(srgb 0.64331 0.19245 0.16771);
 }
 }
 
-@supports (--one-a50: color(srgb 0.64331 0.19245 0.16771 / 50)) {
+@supports (color: color(display-p3 0 0 0)) {
 :root {
 	--one-a50: color(srgb 0.64331 0.19245 0.16771 / 50);
 }
 }
 
-@supports (--one-a50-var: color(srgb 0.64331 0.19245 0.16771 / var(--opacity-50))) {
+@supports (color: color(display-p3 0 0 0)) {
 :root {
 	--one-a50-var: color(srgb 0.64331 0.19245 0.16771 / var(--opacity-50));
 }

--- a/plugins/postcss-oklab-function/test/variables.expect.css
+++ b/plugins/postcss-oklab-function/test/variables.expect.css
@@ -9,19 +9,19 @@
 	--firebrick-var: oklch(40% var(--point-five) 0.1324 / var(--opacity-50));
 }
 
-@supports (--firebrick: color(display-p3 0.33927 0.26183 0.19371)) {
+@supports (color: color(display-p3 0 0 0)) {
 :root {
 	--firebrick: color(display-p3 0.33927 0.26183 0.19371);
 }
 }
 
-@supports (--firebrick-a50: color(display-p3 0.31481 0.26364 0.27826 / 50%)) {
+@supports (color: color(display-p3 0 0 0)) {
 :root {
 	--firebrick-a50: color(display-p3 0.31481 0.26364 0.27826 / 50%);
 }
 }
 
-@supports (--firebrick-a50-var: color(display-p3 0.31481 0.26364 0.27826 / var(--opacity-50))) {
+@supports (color: color(display-p3 0 0 0)) {
 :root {
 	--firebrick-a50-var: color(display-p3 0.31481 0.26364 0.27826 / var(--opacity-50));
 }

--- a/plugins/postcss-oklab-function/test/variables.preserve-true.display-p3-false.expect.css
+++ b/plugins/postcss-oklab-function/test/variables.preserve-true.display-p3-false.expect.css
@@ -9,19 +9,19 @@
 	--firebrick-var: oklch(40% var(--point-five) 0.1324 / var(--opacity-50));
 }
 
-@supports (--firebrick: oklab(40% 0.0234 0.039)) {
+@supports (color: oklab(0% 0 0)) {
 :root {
 	--firebrick: oklab(40% 0.0234 0.039);
 }
 }
 
-@supports (--firebrick-a50: oklch(40% 0.0234 0.039 / 50%)) {
+@supports (color: oklch(0% 0 0)) {
 :root {
 	--firebrick-a50: oklch(40% 0.0234 0.039 / 50%);
 }
 }
 
-@supports (--firebrick-a50-var: oklch(40% 0.0234 0.039 / var(--opacity-50))) {
+@supports (color: oklch(0% 0 0)) {
 :root {
 	--firebrick-a50-var: oklch(40% 0.0234 0.039 / var(--opacity-50));
 }

--- a/plugins/postcss-oklab-function/test/variables.preserve-true.expect.css
+++ b/plugins/postcss-oklab-function/test/variables.preserve-true.expect.css
@@ -9,37 +9,37 @@
 	--firebrick-var: oklch(40% var(--point-five) 0.1324 / var(--opacity-50));
 }
 
-@supports (--firebrick: color(display-p3 0.33927 0.26183 0.19371)) {
+@supports (color: color(display-p3 0 0 0)) {
 :root {
 	--firebrick: color(display-p3 0.33927 0.26183 0.19371);
 }
 }
 
-@supports (--firebrick: oklab(40% 0.0234 0.039)) {
+@supports (color: oklab(0% 0 0)) {
 :root {
 	--firebrick: oklab(40% 0.0234 0.039);
 }
 }
 
-@supports (--firebrick-a50: color(display-p3 0.31481 0.26364 0.27826 / 50%)) {
+@supports (color: color(display-p3 0 0 0)) {
 :root {
 	--firebrick-a50: color(display-p3 0.31481 0.26364 0.27826 / 50%);
 }
 }
 
-@supports (--firebrick-a50: oklch(40% 0.0234 0.039 / 50%)) {
+@supports (color: oklch(0% 0 0)) {
 :root {
 	--firebrick-a50: oklch(40% 0.0234 0.039 / 50%);
 }
 }
 
-@supports (--firebrick-a50-var: color(display-p3 0.31481 0.26364 0.27826 / var(--opacity-50))) {
+@supports (color: color(display-p3 0 0 0)) {
 :root {
 	--firebrick-a50-var: color(display-p3 0.31481 0.26364 0.27826 / var(--opacity-50));
 }
 }
 
-@supports (--firebrick-a50-var: oklch(40% 0.0234 0.039 / var(--opacity-50))) {
+@supports (color: oklch(0% 0 0)) {
 :root {
 	--firebrick-a50-var: oklch(40% 0.0234 0.039 / var(--opacity-50));
 }

--- a/plugins/postcss-progressive-custom-properties/CHANGELOG.md
+++ b/plugins/postcss-progressive-custom-properties/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes to PostCSS Progressive Custom Properties
 
+## Unreleased (minor)
+
+- No longer uses custom properties in `@supports` rules.
+- Implement AST matching for values and units and generate minimal `@supports` for select features.
+
 ## 1.0.0 (February 6, 2022)
 
 Initial release

--- a/plugins/postcss-progressive-custom-properties/README.md
+++ b/plugins/postcss-progressive-custom-properties/README.md
@@ -28,7 +28,7 @@ The solution is to wrap Custom Property declarations in an `@supports` rule.
 	--a-color: red;
 }
 
-@supports (--a-color: oklch(40% 0.234 0.39 / var(--opacity-50))) {
+@supports (color: oklch(0% 0 0)) {
 	:root {
 		--a-color: oklch(40% 0.234 0.39 / var(--opacity-50));
 	}

--- a/plugins/postcss-progressive-custom-properties/generate/color.mjs
+++ b/plugins/postcss-progressive-custom-properties/generate/color.mjs
@@ -1,26 +1,27 @@
 import { matcherForValue } from './matcher-for-value.mjs';
 
 export const colorMatchers = [
-	{
-		'supports': 'color(display-p3 0 0 0)',
-		'property': 'color',
-		'sniff': 'color',
-		'matchers': [
-			matcherForValue('color(srgb $1 $2 $3)'),
-			matcherForValue('color(srgb $1 $2 $3 / $4)'),
-			matcherForValue('color(display-p3 $1 $2 $3)'),
-			matcherForValue('color(display-p3 $1 $2 $3 / $4)'),
-		],
-	},
-	{
-		'supports': 'color(xyz 0 0 0)',
-		'property': 'color',
-		'sniff': 'color',
-		'matchers': [
-			matcherForValue('color($1 $2 $3 $4)'),
-			matcherForValue('color($1 $2 $3 $4 / $5)'),
-		],
-	},
+	...([
+		'srgb',
+		'srgb-linear',
+		'a98-rgb',
+		'prophoto-rgb',
+		'display-p3',
+		'rec2020',
+		'xyz-d50',
+		'xyz-d65',
+		'xyz',
+	].map((colorSpace) => {
+		return {
+			'supports': `color(${colorSpace} 0 0 0)`,
+			'property': 'color',
+			'sniff': 'color',
+			'matchers': [
+				matcherForValue(`color(${colorSpace} $1 $2 $3)`),
+				matcherForValue(`color(${colorSpace} $1 $2 $3 / $4)`),
+			],
+		};
+	})),
 ];
 
 export const hslMatchers = [
@@ -29,6 +30,7 @@ export const hslMatchers = [
 		'property': 'color',
 		'sniff': 'hsl',
 		'matchers': [
+			matcherForValue('hsl($1,$2,$3,$4)'),
 			matcherForValue('hsl($1, $2, $3, $4)'),
 		],
 	},
@@ -113,11 +115,12 @@ export const oklchMatchers = [
 
 export const rgbMatchers = [
 	{
-		'supports': 'rgb(0, 0, 0)',
+		'supports': 'rgb(0, 0, 0, 0)',
 		'property': 'color',
 		'sniff': 'rgb',
 		'matchers': [
 			matcherForValue('rgb($1, $2, $3, $4)'),
+			matcherForValue('rgb($1,$2,$3,$4)'),
 		],
 	},
 	{

--- a/plugins/postcss-progressive-custom-properties/generate/color.mjs
+++ b/plugins/postcss-progressive-custom-properties/generate/color.mjs
@@ -1,0 +1,140 @@
+import { matcherForValue } from './matcher-for-value.mjs';
+
+export const colorMatchers = [
+	{
+		'supports': 'color(display-p3 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			matcherForValue('color(srgb $1 $2 $3)'),
+			matcherForValue('color(srgb $1 $2 $3 / $4)'),
+			matcherForValue('color(display-p3 $1 $2 $3)'),
+			matcherForValue('color(display-p3 $1 $2 $3 / $4)'),
+		],
+	},
+	{
+		'supports': 'color(xyz 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			matcherForValue('color($1 $2 $3 $4)'),
+			matcherForValue('color($1 $2 $3 $4 / $5)'),
+		],
+	},
+];
+
+export const hslMatchers = [
+	{
+		'supports': 'hsl(0, 0%, 0%)',
+		'property': 'color',
+		'sniff': 'hsl',
+		'matchers': [
+			matcherForValue('hsl($1, $2, $3, $4)'),
+		],
+	},
+	{
+		'supports': 'hsl(0 0% 0% / 0)',
+		'property': 'color',
+		'sniff': 'hsl',
+		'matchers': [
+			matcherForValue('hsl($1 $2 $3)'),
+			matcherForValue('hsl($1 $2 $3 / $4)'),
+		],
+	},
+	{
+		'supports': 'hsla(0 0% 0% / 0)',
+		'property': 'color',
+		'sniff': 'hsla',
+		'matchers': [
+			matcherForValue('hsla($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+export const hwbMatchers = [
+	{
+		'supports': 'hwb(0 0% 0%)',
+		'property': 'color',
+		'sniff': 'hwb',
+		'matchers': [
+			matcherForValue('hwb($1 $2 $3)'),
+			matcherForValue('hwb($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+export const labMatchers = [
+	{
+		'supports': 'lab(0% 0 0)',
+		'property': 'color',
+		'sniff': 'lab',
+		'matchers': [
+			matcherForValue('lab($1 $2 $3)'),
+			matcherForValue('lab($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+export const lchMatchers = [
+	{
+		'supports': 'lch(0% 0 0)',
+		'property': 'color',
+		'sniff': 'lch',
+		'matchers': [
+			matcherForValue('lch($1 $2 $3)'),
+			matcherForValue('lch($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+export const oklabMatchers = [
+	{
+		'supports': 'oklab(0% 0 0)',
+		'property': 'color',
+		'sniff': 'oklab',
+		'matchers': [
+			matcherForValue('oklab($1 $2 $3)'),
+			matcherForValue('oklab($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+export const oklchMatchers = [
+	{
+		'supports': 'oklch(0% 0 0)',
+		'property': 'color',
+		'sniff': 'oklch',
+		'matchers': [
+			matcherForValue('oklch($1 $2 $3)'),
+			matcherForValue('oklch($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+export const rgbMatchers = [
+	{
+		'supports': 'rgb(0, 0, 0)',
+		'property': 'color',
+		'sniff': 'rgb',
+		'matchers': [
+			matcherForValue('rgb($1, $2, $3, $4)'),
+		],
+	},
+	{
+		'supports': 'rgb(0 0 0 / 0)',
+		'property': 'color',
+		'sniff': 'rgb',
+		'matchers': [
+			matcherForValue('rgb($1 $2 $3)'),
+			matcherForValue('rgb($1 $2 $3 / $4)'),
+		],
+	},
+	{
+		'supports': 'rgba(0 0 0 / 0)',
+		'property': 'color',
+		'sniff': 'rgba',
+		'matchers': [
+			matcherForValue('rgba($1 $2 $3 / $4)'),
+		],
+	},
+];

--- a/plugins/postcss-progressive-custom-properties/generate/font-size.mjs
+++ b/plugins/postcss-progressive-custom-properties/generate/font-size.mjs
@@ -1,0 +1,12 @@
+import { matcherForValue } from './matcher-for-value.mjs';
+
+export const icUnitMatchers = [
+	{
+		'supports': '1ic',
+		'property': 'font-size',
+		'sniff': 'ic',
+		'matchers': [
+			matcherForValue('1ic'),
+		],
+	},
+];

--- a/plugins/postcss-progressive-custom-properties/generate/matcher-for-value.mjs
+++ b/plugins/postcss-progressive-custom-properties/generate/matcher-for-value.mjs
@@ -1,0 +1,35 @@
+import valueParser from 'postcss-value-parser';
+
+export function matcherForValue(value) {
+
+	try {
+		const ast = valueParser(value);
+		ast.walk((node) => {
+			delete node.sourceIndex;
+			delete node.before;
+			delete node.after;
+			delete node.sourceEndIndex;
+
+			if (node.value.startsWith('$')) {
+				delete node.value;
+				node.isVariable = true;
+			} else {
+				try {
+					node.dimension = valueParser.unit(node.value);
+				} finally {
+					if (node.dimension === false) {
+						delete node.dimension;
+					}
+				}
+			}
+		});
+
+		if (ast.nodes.length === 1) {
+			return ast.nodes[0];
+		} else {
+			return ast.nodes;
+		}
+	} catch (_) {
+		/* ignore */
+	}
+}

--- a/plugins/postcss-progressive-custom-properties/generate/matchers.mjs
+++ b/plugins/postcss-progressive-custom-properties/generate/matchers.mjs
@@ -1,0 +1,193 @@
+import valueParser from 'postcss-value-parser';
+import { promises as fsp } from 'fs';
+
+function matcherForValue(value) {
+
+	try {
+		const ast = valueParser(value);
+		ast.walk((node) => {
+			delete node.sourceIndex;
+			delete node.before;
+			delete node.after;
+			delete node.sourceEndIndex;
+
+			if (node.value.startsWith('$')) {
+				delete node.value;
+				node.isVariable = true;
+			} else {
+				try {
+					node.dimension = valueParser.unit(node.value);
+				} finally {
+					if (node.dimension === false) {
+						delete node.dimension;
+					}
+				}
+			}
+		});
+
+		if (ast.nodes.length === 1) {
+			return ast.nodes[0];
+		} else {
+			return ast.nodes;
+		}
+	} catch (_) {
+		/* ignore */
+	}
+}
+
+const colorMatchers = [
+	{
+		'supports': 'color(display-p3 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			matcherForValue('color(srgb $1 $2 $3)'),
+			matcherForValue('color(srgb $1 $2 $3 / $4)'),
+			matcherForValue('color(display-p3 $1 $2 $3)'),
+			matcherForValue('color(display-p3 $1 $2 $3 / $4)'),
+		],
+	},
+	{
+		'supports': 'color(xyz 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			matcherForValue('color($1 $2 $3 $4)'),
+			matcherForValue('color($1 $2 $3 $4 / $5)'),
+		],
+	},
+];
+
+const hslMatchers = [
+	{
+		'supports': 'hsl(0, 0%, 0%)',
+		'property': 'color',
+		'sniff': 'hsl',
+		'matchers': [
+			matcherForValue('hsl($1, $2, $3, $4)'),
+		],
+	},
+	{
+		'supports': 'hsl(0 0% 0% / 0)',
+		'property': 'color',
+		'sniff': 'hsl',
+		'matchers': [
+			matcherForValue('hsl($1 $2 $3)'),
+			matcherForValue('hsl($1 $2 $3 / $4)'),
+		],
+	},
+	{
+		'supports': 'hsla(0 0% 0% / 0)',
+		'property': 'color',
+		'sniff': 'hsla',
+		'matchers': [
+			matcherForValue('hsla($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+const hwbMatchers = [
+	{
+		'supports': 'hwb(0 0% 0%)',
+		'property': 'color',
+		'sniff': 'hwb',
+		'matchers': [
+			matcherForValue('hwb($1 $2 $3)'),
+			matcherForValue('hwb($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+const labMatchers = [
+	{
+		'supports': 'lab(0% 0 0)',
+		'property': 'color',
+		'sniff': 'lab',
+		'matchers': [
+			matcherForValue('lab($1 $2 $3)'),
+			matcherForValue('lab($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+const lchMatchers = [
+	{
+		'supports': 'lch(0% 0 0)',
+		'property': 'color',
+		'sniff': 'lch',
+		'matchers': [
+			matcherForValue('lch($1 $2 $3)'),
+			matcherForValue('lch($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+const oklabMatchers = [
+	{
+		'supports': 'oklab(0% 0 0)',
+		'property': 'color',
+		'sniff': 'oklab',
+		'matchers': [
+			matcherForValue('oklab($1 $2 $3)'),
+			matcherForValue('oklab($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+const oklchMatchers = [
+	{
+		'supports': 'oklch(0% 0 0)',
+		'property': 'color',
+		'sniff': 'oklch',
+		'matchers': [
+			matcherForValue('oklch($1 $2 $3)'),
+			matcherForValue('oklch($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+const rgbMatchers = [
+	{
+		'supports': 'rgb(0, 0, 0)',
+		'property': 'color',
+		'sniff': 'rgb',
+		'matchers': [
+			matcherForValue('rgb($1, $2, $3, $4)'),
+		],
+	},
+	{
+		'supports': 'rgb(0 0 0 / 0)',
+		'property': 'color',
+		'sniff': 'rgb',
+		'matchers': [
+			matcherForValue('rgb($1 $2 $3)'),
+			matcherForValue('rgb($1 $2 $3 / $4)'),
+		],
+	},
+	{
+		'supports': 'rgba(0 0 0 / 0)',
+		'property': 'color',
+		'sniff': 'rgba',
+		'matchers': [
+			matcherForValue('rgba($1 $2 $3 / $4)'),
+		],
+	},
+];
+
+fsp.writeFile(
+	'./src/matchers.ts',
+	'export const matchers = ' + JSON.stringify(
+		[
+			...colorMatchers,
+			...hslMatchers,
+			...hwbMatchers,
+			...labMatchers,
+			...lchMatchers,
+			...oklabMatchers,
+			...oklchMatchers,
+			...rgbMatchers,
+		],
+		null,
+		'\t',
+	),
+);

--- a/plugins/postcss-progressive-custom-properties/generate/matchers.mjs
+++ b/plugins/postcss-progressive-custom-properties/generate/matchers.mjs
@@ -1,183 +1,12 @@
-import valueParser from 'postcss-value-parser';
 import { promises as fsp } from 'fs';
-
-function matcherForValue(value) {
-
-	try {
-		const ast = valueParser(value);
-		ast.walk((node) => {
-			delete node.sourceIndex;
-			delete node.before;
-			delete node.after;
-			delete node.sourceEndIndex;
-
-			if (node.value.startsWith('$')) {
-				delete node.value;
-				node.isVariable = true;
-			} else {
-				try {
-					node.dimension = valueParser.unit(node.value);
-				} finally {
-					if (node.dimension === false) {
-						delete node.dimension;
-					}
-				}
-			}
-		});
-
-		if (ast.nodes.length === 1) {
-			return ast.nodes[0];
-		} else {
-			return ast.nodes;
-		}
-	} catch (_) {
-		/* ignore */
-	}
-}
-
-const colorMatchers = [
-	{
-		'supports': 'color(display-p3 0 0 0)',
-		'property': 'color',
-		'sniff': 'color',
-		'matchers': [
-			matcherForValue('color(srgb $1 $2 $3)'),
-			matcherForValue('color(srgb $1 $2 $3 / $4)'),
-			matcherForValue('color(display-p3 $1 $2 $3)'),
-			matcherForValue('color(display-p3 $1 $2 $3 / $4)'),
-		],
-	},
-	{
-		'supports': 'color(xyz 0 0 0)',
-		'property': 'color',
-		'sniff': 'color',
-		'matchers': [
-			matcherForValue('color($1 $2 $3 $4)'),
-			matcherForValue('color($1 $2 $3 $4 / $5)'),
-		],
-	},
-];
-
-const hslMatchers = [
-	{
-		'supports': 'hsl(0, 0%, 0%)',
-		'property': 'color',
-		'sniff': 'hsl',
-		'matchers': [
-			matcherForValue('hsl($1, $2, $3, $4)'),
-		],
-	},
-	{
-		'supports': 'hsl(0 0% 0% / 0)',
-		'property': 'color',
-		'sniff': 'hsl',
-		'matchers': [
-			matcherForValue('hsl($1 $2 $3)'),
-			matcherForValue('hsl($1 $2 $3 / $4)'),
-		],
-	},
-	{
-		'supports': 'hsla(0 0% 0% / 0)',
-		'property': 'color',
-		'sniff': 'hsla',
-		'matchers': [
-			matcherForValue('hsla($1 $2 $3 / $4)'),
-		],
-	},
-];
-
-const hwbMatchers = [
-	{
-		'supports': 'hwb(0 0% 0%)',
-		'property': 'color',
-		'sniff': 'hwb',
-		'matchers': [
-			matcherForValue('hwb($1 $2 $3)'),
-			matcherForValue('hwb($1 $2 $3 / $4)'),
-		],
-	},
-];
-
-const labMatchers = [
-	{
-		'supports': 'lab(0% 0 0)',
-		'property': 'color',
-		'sniff': 'lab',
-		'matchers': [
-			matcherForValue('lab($1 $2 $3)'),
-			matcherForValue('lab($1 $2 $3 / $4)'),
-		],
-	},
-];
-
-const lchMatchers = [
-	{
-		'supports': 'lch(0% 0 0)',
-		'property': 'color',
-		'sniff': 'lch',
-		'matchers': [
-			matcherForValue('lch($1 $2 $3)'),
-			matcherForValue('lch($1 $2 $3 / $4)'),
-		],
-	},
-];
-
-const oklabMatchers = [
-	{
-		'supports': 'oklab(0% 0 0)',
-		'property': 'color',
-		'sniff': 'oklab',
-		'matchers': [
-			matcherForValue('oklab($1 $2 $3)'),
-			matcherForValue('oklab($1 $2 $3 / $4)'),
-		],
-	},
-];
-
-const oklchMatchers = [
-	{
-		'supports': 'oklch(0% 0 0)',
-		'property': 'color',
-		'sniff': 'oklch',
-		'matchers': [
-			matcherForValue('oklch($1 $2 $3)'),
-			matcherForValue('oklch($1 $2 $3 / $4)'),
-		],
-	},
-];
-
-const rgbMatchers = [
-	{
-		'supports': 'rgb(0, 0, 0)',
-		'property': 'color',
-		'sniff': 'rgb',
-		'matchers': [
-			matcherForValue('rgb($1, $2, $3, $4)'),
-		],
-	},
-	{
-		'supports': 'rgb(0 0 0 / 0)',
-		'property': 'color',
-		'sniff': 'rgb',
-		'matchers': [
-			matcherForValue('rgb($1 $2 $3)'),
-			matcherForValue('rgb($1 $2 $3 / $4)'),
-		],
-	},
-	{
-		'supports': 'rgba(0 0 0 / 0)',
-		'property': 'color',
-		'sniff': 'rgba',
-		'matchers': [
-			matcherForValue('rgba($1 $2 $3 / $4)'),
-		],
-	},
-];
+import { colorMatchers, hslMatchers, hwbMatchers, labMatchers, lchMatchers, oklabMatchers, oklchMatchers, rgbMatchers } from './color.mjs';
+import { icUnitMatchers } from './font-size.mjs';
 
 fsp.writeFile(
 	'./src/matchers.ts',
 	'export const matchers = ' + JSON.stringify(
 		[
+			// color:
 			...colorMatchers,
 			...hslMatchers,
 			...hwbMatchers,
@@ -186,6 +15,9 @@ fsp.writeFile(
 			...oklabMatchers,
 			...oklchMatchers,
 			...rgbMatchers,
+
+			// font-size:
+			...icUnitMatchers,
 		],
 		null,
 		'\t',

--- a/plugins/postcss-progressive-custom-properties/package.json
+++ b/plugins/postcss-progressive-custom-properties/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "rollup -c ../../rollup/default.js",
+    "build": "node ./generate/matchers.mjs && eslint --fix ./src/matchers.ts && rollup -c ../../rollup/default.js",
     "clean": "node -e \"fs.rmSync('./dist', { recursive: true, force: true });\"",
     "lint": "eslint ./src --ext .js --ext .ts --ext .mjs --no-error-on-unmatched-pattern",
     "prepublishOnly": "npm run clean && npm run build && npm run test",
@@ -33,6 +33,9 @@
     "test:rewrite-expects": "REWRITE_EXPECTS=true node .tape.mjs",
     "test:cli": "bash ./test/cli/test.sh",
     "test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
+  },
+  "dependencies": {
+    "postcss-value-parser": "^4.2.0"
   },
   "peerDependencies": {
     "postcss": "^8.3"

--- a/plugins/postcss-progressive-custom-properties/src/index.ts
+++ b/plugins/postcss-progressive-custom-properties/src/index.ts
@@ -1,4 +1,5 @@
 import type { PluginCreator } from 'postcss';
+import { supportConditionsFromValue } from './support-conditions-from-values';
 
 const creator: PluginCreator<null> = () => {
 	return {
@@ -32,10 +33,15 @@ const creator: PluginCreator<null> = () => {
 					return;
 				}
 
+				const supportConditions = supportConditionsFromValue(decl.value);
+				if (!supportConditions.length) {
+					return;
+				}
+
 				// Any subsequent properties are progressive enhancements.
 				const atSupports = postcss.atRule({
 					name: 'supports',
-					params: `(${decl.prop}: ${decl.value})`,
+					params: supportConditions.join(' and '),
 					source: rule.source,
 					raws: {
 						before: '\n\n',

--- a/plugins/postcss-progressive-custom-properties/src/match.ts
+++ b/plugins/postcss-progressive-custom-properties/src/match.ts
@@ -1,0 +1,34 @@
+export function matches(a, b) {
+	if (a.isVariable && !!b) {
+		return true;
+	}
+
+	if (a.type !== b.type) {
+		return false;
+	}
+
+	if (
+		a.type === 'space' && b.type === 'space' &&
+		a.value.trim() === b.value.trim()
+	) {
+		// do nothing. values are equal, different amounts of spaces are equal
+	} else if (a.value !== b.value) {
+		return false;
+	}
+
+	if (a.nodes && b.nodes) {
+		if (a.nodes.length !== b.nodes.length) {
+			return false;
+		}
+
+		for (let i = 0; i < a.nodes.length; i++) {
+			if (!matches(a.nodes[i], b.nodes[i])) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	return true;
+}

--- a/plugins/postcss-progressive-custom-properties/src/match.ts
+++ b/plugins/postcss-progressive-custom-properties/src/match.ts
@@ -7,12 +7,7 @@ export function matches(a, b) {
 		return false;
 	}
 
-	if (
-		a.type === 'space' && b.type === 'space' &&
-		a.value.trim() === b.value.trim()
-	) {
-		// do nothing. values are equal, different amounts of spaces are equal
-	} else if (a.value !== b.value) {
+	if (doesNotMatchValue(a, b)) {
 		return false;
 	}
 
@@ -31,4 +26,23 @@ export function matches(a, b) {
 	}
 
 	return true;
+}
+
+function doesNotMatchValue(a, b) {
+	if (
+		a.type === 'space' && b.type === 'space' &&
+		a.value.trim() === b.value.trim()
+	) {
+		return false;
+	}
+
+	if (a.dimension && b.dimension) {
+		return a.dimension.unit !== b.dimension.unit;
+	}
+
+	if (a.value !== b.value) {
+		return true;
+	}
+
+	return false;
 }

--- a/plugins/postcss-progressive-custom-properties/src/matchers.ts
+++ b/plugins/postcss-progressive-custom-properties/src/matchers.ts
@@ -1,6 +1,6 @@
 export const matchers = [
 	{
-		'supports': 'color(display-p3 0 0 0)',
+		'supports': 'color(srgb 0 0 0)',
 		'property': 'color',
 		'sniff': 'color',
 		'matchers': [
@@ -80,6 +80,262 @@ export const matchers = [
 					},
 				],
 			},
+		],
+	},
+	{
+		'supports': 'color(srgb-linear 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'srgb-linear',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'srgb-linear',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'color(a98-rgb 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'a98-rgb',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'a98-rgb',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'color(prophoto-rgb 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'prophoto-rgb',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'prophoto-rgb',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'color(display-p3 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
 			{
 				'type': 'function',
 				'value': 'color',
@@ -121,6 +377,255 @@ export const matchers = [
 					{
 						'type': 'word',
 						'value': 'display-p3',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'color(rec2020 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'rec2020',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'rec2020',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'color(xyz-d50 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'xyz-d50',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'xyz-d50',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'color(xyz-d65 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'xyz-d65',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'xyz-d65',
 					},
 					{
 						'type': 'space',
@@ -169,7 +674,7 @@ export const matchers = [
 				'nodes': [
 					{
 						'type': 'word',
-						'isVariable': true,
+						'value': 'xyz',
 					},
 					{
 						'type': 'space',
@@ -203,7 +708,7 @@ export const matchers = [
 				'nodes': [
 					{
 						'type': 'word',
-						'isVariable': true,
+						'value': 'xyz',
 					},
 					{
 						'type': 'space',
@@ -246,6 +751,40 @@ export const matchers = [
 		'property': 'color',
 		'sniff': 'hsl',
 		'matchers': [
+			{
+				'type': 'function',
+				'value': 'hsl',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
 			{
 				'type': 'function',
 				'value': 'hsl',
@@ -726,10 +1265,44 @@ export const matchers = [
 		],
 	},
 	{
-		'supports': 'rgb(0, 0, 0)',
+		'supports': 'rgb(0, 0, 0, 0)',
 		'property': 'color',
 		'sniff': 'rgb',
 		'matchers': [
+			{
+				'type': 'function',
+				'value': 'rgb',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
 			{
 				'type': 'function',
 				'value': 'rgb',

--- a/plugins/postcss-progressive-custom-properties/src/matchers.ts
+++ b/plugins/postcss-progressive-custom-properties/src/matchers.ts
@@ -1,0 +1,877 @@
+export const matchers = [
+	{
+		'supports': 'color(display-p3 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'srgb',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'srgb',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'display-p3',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'value': 'display-p3',
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'color(xyz 0 0 0)',
+		'property': 'color',
+		'sniff': 'color',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'color',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'hsl(0, 0%, 0%)',
+		'property': 'color',
+		'sniff': 'hsl',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'hsl',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'hsl(0 0% 0% / 0)',
+		'property': 'color',
+		'sniff': 'hsl',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'hsl',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'hsl',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'hsla(0 0% 0% / 0)',
+		'property': 'color',
+		'sniff': 'hsla',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'hsla',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'hwb(0 0% 0%)',
+		'property': 'color',
+		'sniff': 'hwb',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'hwb',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'hwb',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'lab(0% 0 0)',
+		'property': 'color',
+		'sniff': 'lab',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'lab',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'lab',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'lch(0% 0 0)',
+		'property': 'color',
+		'sniff': 'lch',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'lch',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'lch',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'oklab(0% 0 0)',
+		'property': 'color',
+		'sniff': 'oklab',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'oklab',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'oklab',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'oklch(0% 0 0)',
+		'property': 'color',
+		'sniff': 'oklch',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'oklch',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'oklch',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'rgb(0, 0, 0)',
+		'property': 'color',
+		'sniff': 'rgb',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'rgb',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': ',',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'rgb(0 0 0 / 0)',
+		'property': 'color',
+		'sniff': 'rgb',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'rgb',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+			{
+				'type': 'function',
+				'value': 'rgb',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+	{
+		'supports': 'rgba(0 0 0 / 0)',
+		'property': 'color',
+		'sniff': 'rgba',
+		'matchers': [
+			{
+				'type': 'function',
+				'value': 'rgba',
+				'nodes': [
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'space',
+						'value': ' ',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+					{
+						'type': 'div',
+						'value': '/',
+					},
+					{
+						'type': 'word',
+						'isVariable': true,
+					},
+				],
+			},
+		],
+	},
+];

--- a/plugins/postcss-progressive-custom-properties/src/matchers.ts
+++ b/plugins/postcss-progressive-custom-properties/src/matchers.ts
@@ -874,4 +874,19 @@ export const matchers = [
 			},
 		],
 	},
+	{
+		'supports': '1ic',
+		'property': 'font-size',
+		'sniff': 'ic',
+		'matchers': [
+			{
+				'type': 'word',
+				'value': '1ic',
+				'dimension': {
+					'number': '1',
+					'unit': 'ic',
+				},
+			},
+		],
+	},
 ];

--- a/plugins/postcss-progressive-custom-properties/src/support-conditions-from-values.ts
+++ b/plugins/postcss-progressive-custom-properties/src/support-conditions-from-values.ts
@@ -16,7 +16,15 @@ export function supportConditionsFromValue(value: string): Array<string> {
 	try {
 		const ast = valueParser(value);
 		ast.walk((node) => {
-			matcherLoop: for (let i = 0; i < relevantMatchers.length; i++) {
+			try {
+				node['dimension'] = valueParser.unit(node.value);
+			} finally {
+				if (node['dimension'] === false) {
+					delete node['dimension'];
+				}
+			}
+
+			for (let i = 0; i < relevantMatchers.length; i++) {
 				const propertyValueMatcher = relevantMatchers[i];
 
 				for (let j = 0; j < propertyValueMatcher.matchers.length; j++) {
@@ -25,7 +33,36 @@ export function supportConditionsFromValue(value: string): Array<string> {
 					// Only one needs to match.
 					if (matches(matcherAST, node)) {
 						supportConditions.push(`(${propertyValueMatcher.property}: ${propertyValueMatcher.supports})`);
-						break matcherLoop;
+						return;
+					}
+				}
+			}
+
+			// custom matchers :
+			if (node.type === 'function' && (node.value === 'conic-gradient' || node.value === 'linear-gradient')) {
+				let components = 0;
+				let seenPrefix = false;
+
+				for (let i = 0; i < node.nodes.length; i++) {
+					const childNode = node.nodes[i];
+					if (childNode.type === 'div' && childNode.value.trim() === ',') {
+						components = 0;
+						seenPrefix = true;
+						continue;
+					}
+
+					if (childNode.type === 'word' || childNode.type === 'function') {
+						components++;
+					}
+
+					if (seenPrefix && components === 3) {
+						if (node.value === 'conic-gradient') {
+							supportConditions.push('(background: conic-gradient(red 0%, red 0deg 1%, red 2deg))');
+							return;
+						}
+
+						supportConditions.push('(background: linear-gradient(0deg, red 0% 1%, red 2%))');
+						return;
 					}
 				}
 			}

--- a/plugins/postcss-progressive-custom-properties/src/support-conditions-from-values.ts
+++ b/plugins/postcss-progressive-custom-properties/src/support-conditions-from-values.ts
@@ -1,0 +1,39 @@
+import valueParser from 'postcss-value-parser';
+import { matchers } from './matchers';
+import { matches } from './match';
+
+export function supportConditionsFromValue(value: string): Array<string> {
+	const supportConditions: Array<string> = [];
+
+	const relevantMatchers = [];
+
+	matchers.forEach((matcher) => {
+		if (value.indexOf(matcher.sniff) > -1) {
+			relevantMatchers.push(matcher);
+		}
+	});
+
+	try {
+		const ast = valueParser(value);
+		ast.walk((node) => {
+			matcherLoop: for (let i = 0; i < relevantMatchers.length; i++) {
+				const propertyValueMatcher = relevantMatchers[i];
+
+				for (let j = 0; j < propertyValueMatcher.matchers.length; j++) {
+					const matcherAST = propertyValueMatcher.matchers[j];
+					// Matchers are ordered from most specific to least.
+					// Only one needs to match.
+					if (matches(matcherAST, node)) {
+						supportConditions.push(`(${propertyValueMatcher.property}: ${propertyValueMatcher.supports})`);
+						break matcherLoop;
+					}
+				}
+			}
+		});
+
+	} catch (_) {
+		/* ignore */
+	}
+
+	return supportConditions;
+}

--- a/plugins/postcss-progressive-custom-properties/test/basic.css
+++ b/plugins/postcss-progressive-custom-properties/test/basic.css
@@ -50,3 +50,25 @@
 	--prop-1: fallback;
 	--prop-1: enhancement-1;
 }
+
+:root {
+	--color-1: red;
+	--color-1: color(srgb 0.64331 0.19245 0.16771);
+
+	--color-2: blue;
+	--color-2: color(srgb 0.64331 0.19245 0.16771 / 50);
+
+	--opacity-50: 0.5;
+	--color-3: purple;
+	--color-3: color(srgb 0.64331 0.19245 0.16771 / var(--opacity-50));
+
+	--point-5: 0.5;
+	--color-4: green;
+	--color-4: color(srgb 0.64331 var(--point-5) 0.16771 / var(--opacity-50));
+
+	--color-5: yellow;
+	--color-5: color(srgb 0.64331   0.19245 0.16771 / calc(1 / 2));
+
+	--color-6: orange;
+	--color-6: color(rec2020 0.64331 0.19245 0.16771);
+}

--- a/plugins/postcss-progressive-custom-properties/test/basic.css
+++ b/plugins/postcss-progressive-custom-properties/test/basic.css
@@ -34,7 +34,7 @@
 	--prop-8: 1px solid oklch(40% 0.234 0.39 / var(--opacity-50));
 
 	--prop-9: red;
-	--prop-9: rgba(1,1,1,1);
+	--prop-9: rgb(1,1,1,1);
 }
 
 .initial {

--- a/plugins/postcss-progressive-custom-properties/test/basic.css
+++ b/plugins/postcss-progressive-custom-properties/test/basic.css
@@ -7,27 +7,31 @@
 	--prop-2: red;
 	--prop-2: linear-gradient(
 		45deg,
-		rgba(255, 255, 255, 0.15) 25%,
+		rgba(255 255 255 / 0.15) 25%,
 		transparent 25%,
 		transparent 50%,
-		rgba(255, 255, 255, 0.15) 50%,
-		rgba(255, 255, 255, 0.15) 75%,
+		rgba(255, 255, 255, 0.15) 45% 50%,
+		color(rec2020 0.64331 0.19245 0.16771) 75%,
 		transparent 75%,
 		transparent
 	);
 
-	/* 2 enhancements */
 	--prop-3: 1px;
-	--prop-3: 1vw;
-	--prop-3: 1ic;
+	--prop-3: 2ic;
+	--prop-4: 1px;
+	--prop-4: 2ica;
+	--prop-5: 1px;
+	--prop-5: 2ic(1);
 
 	/* interleaved */
-	--prop-4: fallback;
-	--prop-5: fallback;
-	--prop-4: enhancement-1;
-	--prop-5: enhancement-1;
-	--prop-4: enhancement-2;
-	--prop-5: enhancement-2;
+	--prop-6: linear-gradient(90deg, black 25%, black 50%, blue 50%, blue 75%);
+	--prop-7: conic-gradient(yellowgreen 40%, gold 0deg, gold 75%, #f06 0deg);
+	--prop-6: linear-gradient(90deg, black 25% 50%, blue 50% 75%);
+	--prop-7: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
+
+	/* multiple values space separated */
+	--prop-8: 1px solid red;
+	--prop-8: 1px solid oklch(40% 0.234 0.39 / var(--opacity-50));
 }
 
 .initial {
@@ -47,8 +51,8 @@
 }
 
 .not-root {
-	--prop-1: fallback;
-	--prop-1: enhancement-1;
+	--color-1: red;
+	--color-1: color(srgb 0.64331 0.19245 0.16771);
 }
 
 :root {

--- a/plugins/postcss-progressive-custom-properties/test/basic.css
+++ b/plugins/postcss-progressive-custom-properties/test/basic.css
@@ -32,6 +32,9 @@
 	/* multiple values space separated */
 	--prop-8: 1px solid red;
 	--prop-8: 1px solid oklch(40% 0.234 0.39 / var(--opacity-50));
+
+	--prop-9: red;
+	--prop-9: rgba(1,1,1,1);
 }
 
 .initial {

--- a/plugins/postcss-progressive-custom-properties/test/basic.expect.css
+++ b/plugins/postcss-progressive-custom-properties/test/basic.expect.css
@@ -19,7 +19,6 @@
 	--prop-8: 1px solid red;
 
 	--prop-9: red;
-	--prop-9: rgba(1,1,1,1);
 }
 
 @supports (color: oklch(0% 0 0)) {
@@ -64,6 +63,12 @@
 @supports (color: oklch(0% 0 0)) {
 :root {
 	--prop-8: 1px solid oklch(40% 0.234 0.39 / var(--opacity-50));
+}
+}
+
+@supports (color: rgb(0, 0, 0, 0)) {
+:root {
+	--prop-9: rgb(1,1,1,1);
 }
 }
 

--- a/plugins/postcss-progressive-custom-properties/test/basic.expect.css
+++ b/plugins/postcss-progressive-custom-properties/test/basic.expect.css
@@ -4,34 +4,63 @@
 
 	/* multi-line */
 	--prop-2: red;
-	--prop-2: linear-gradient(
-		45deg,
-		rgba(255, 255, 255, 0.15) 25%,
-		transparent 25%,
-		transparent 50%,
-		rgba(255, 255, 255, 0.15) 50%,
-		rgba(255, 255, 255, 0.15) 75%,
-		transparent 75%,
-		transparent
-	);
 
-	/* 2 enhancements */
 	--prop-3: 1px;
-	--prop-3: 1vw;
-	--prop-3: 1ic;
+	--prop-4: 1px;
+	--prop-4: 2ica;
+	--prop-5: 1px;
+	--prop-5: 2ic(1);
 
 	/* interleaved */
-	--prop-4: fallback;
-	--prop-5: fallback;
-	--prop-4: enhancement-1;
-	--prop-5: enhancement-1;
-	--prop-4: enhancement-2;
-	--prop-5: enhancement-2;
+	--prop-6: linear-gradient(90deg, black 25%, black 50%, blue 50%, blue 75%);
+	--prop-7: conic-gradient(yellowgreen 40%, gold 0deg, gold 75%, #f06 0deg);
+
+	/* multiple values space separated */
+	--prop-8: 1px solid red;
 }
 
 @supports (color: oklch(0% 0 0)) {
 :root {
 	--prop-1: oklch(40% 0.234 0.39 / var(--opacity-50));
+}
+}
+
+@supports (background: linear-gradient(0deg, red 0% 1%, red 2%)) and (color: rgba(0 0 0 / 0)) and (color: color(xyz 0 0 0)) {
+:root {
+	--prop-2: linear-gradient(
+		45deg,
+		rgba(255 255 255 / 0.15) 25%,
+		transparent 25%,
+		transparent 50%,
+		rgba(255, 255, 255, 0.15) 45% 50%,
+		color(rec2020 0.64331 0.19245 0.16771) 75%,
+		transparent 75%,
+		transparent
+	);
+}
+}
+
+@supports (font-size: 1ic) {
+:root {
+	--prop-3: 2ic;
+}
+}
+
+@supports (background: linear-gradient(0deg, red 0% 1%, red 2%)) {
+:root {
+	--prop-6: linear-gradient(90deg, black 25% 50%, blue 50% 75%);
+}
+}
+
+@supports (background: conic-gradient(red 0%, red 0deg 1%, red 2deg)) {
+:root {
+	--prop-7: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
+}
+}
+
+@supports (color: oklch(0% 0 0)) {
+:root {
+	--prop-8: 1px solid oklch(40% 0.234 0.39 / var(--opacity-50));
 }
 }
 
@@ -52,8 +81,13 @@
 }
 
 .not-root {
-	--prop-1: fallback;
-	--prop-1: enhancement-1;
+	--color-1: red;
+}
+
+@supports (color: color(display-p3 0 0 0)) {
+.not-root {
+	--color-1: color(srgb 0.64331 0.19245 0.16771);
+}
 }
 
 :root {

--- a/plugins/postcss-progressive-custom-properties/test/basic.expect.css
+++ b/plugins/postcss-progressive-custom-properties/test/basic.expect.css
@@ -4,32 +4,6 @@
 
 	/* multi-line */
 	--prop-2: red;
-
-	/* 2 enhancements */
-	--prop-3: 1px;
-
-	/* interleaved */
-	--prop-4: fallback;
-	--prop-5: fallback;
-}
-
-@supports (--prop-1: oklch(40% 0.234 0.39 / var(--opacity-50))) {
-:root {
-	--prop-1: oklch(40% 0.234 0.39 / var(--opacity-50));
-}
-}
-
-@supports (--prop-2: linear-gradient(
-		45deg,
-		rgba(255, 255, 255, 0.15) 25%,
-		transparent 25%,
-		transparent 50%,
-		rgba(255, 255, 255, 0.15) 50%,
-		rgba(255, 255, 255, 0.15) 75%,
-		transparent 75%,
-		transparent
-	)) {
-:root {
 	--prop-2: linear-gradient(
 		45deg,
 		rgba(255, 255, 255, 0.15) 25%,
@@ -40,42 +14,24 @@
 		transparent 75%,
 		transparent
 	);
-}
-}
 
-@supports (--prop-3: 1vw) {
-:root {
+	/* 2 enhancements */
+	--prop-3: 1px;
 	--prop-3: 1vw;
-}
-}
-
-@supports (--prop-3: 1ic) {
-:root {
 	--prop-3: 1ic;
-}
-}
 
-@supports (--prop-4: enhancement-1) {
-:root {
+	/* interleaved */
+	--prop-4: fallback;
+	--prop-5: fallback;
 	--prop-4: enhancement-1;
-}
-}
-
-@supports (--prop-5: enhancement-1) {
-:root {
 	--prop-5: enhancement-1;
-}
-}
-
-@supports (--prop-4: enhancement-2) {
-:root {
 	--prop-4: enhancement-2;
-}
+	--prop-5: enhancement-2;
 }
 
-@supports (--prop-5: enhancement-2) {
+@supports (color: oklch(0% 0 0)) {
 :root {
-	--prop-5: enhancement-2;
+	--prop-1: oklch(40% 0.234 0.39 / var(--opacity-50));
 }
 }
 
@@ -97,10 +53,57 @@
 
 .not-root {
 	--prop-1: fallback;
+	--prop-1: enhancement-1;
 }
 
-@supports (--prop-1: enhancement-1) {
-.not-root {
-	--prop-1: enhancement-1;
+:root {
+	--color-1: red;
+
+	--color-2: blue;
+
+	--opacity-50: 0.5;
+	--color-3: purple;
+
+	--point-5: 0.5;
+	--color-4: green;
+
+	--color-5: yellow;
+
+	--color-6: orange;
+}
+
+@supports (color: color(display-p3 0 0 0)) {
+:root {
+	--color-1: color(srgb 0.64331 0.19245 0.16771);
+}
+}
+
+@supports (color: color(display-p3 0 0 0)) {
+:root {
+	--color-2: color(srgb 0.64331 0.19245 0.16771 / 50);
+}
+}
+
+@supports (color: color(display-p3 0 0 0)) {
+:root {
+	--color-3: color(srgb 0.64331 0.19245 0.16771 / var(--opacity-50));
+}
+}
+
+@supports (color: color(display-p3 0 0 0)) {
+:root {
+	--color-4: color(srgb 0.64331 var(--point-5) 0.16771 / var(--opacity-50));
+}
+}
+
+@supports (color: color(display-p3 0 0 0)) {
+:root {
+	--color-5: color(srgb 0.64331   0.19245 0.16771 / calc(1 / 2));
+}
+}
+
+@supports (color: color(xyz 0 0 0)) {
+:root {
+	--color-6: color(rec2020 0.64331 0.19245 0.16771);
 }
 }

--- a/plugins/postcss-progressive-custom-properties/test/basic.expect.css
+++ b/plugins/postcss-progressive-custom-properties/test/basic.expect.css
@@ -17,6 +17,9 @@
 
 	/* multiple values space separated */
 	--prop-8: 1px solid red;
+
+	--prop-9: red;
+	--prop-9: rgba(1,1,1,1);
 }
 
 @supports (color: oklch(0% 0 0)) {
@@ -25,7 +28,7 @@
 }
 }
 
-@supports (background: linear-gradient(0deg, red 0% 1%, red 2%)) and (color: rgba(0 0 0 / 0)) and (color: color(xyz 0 0 0)) {
+@supports (background: linear-gradient(0deg, red 0% 1%, red 2%)) and (color: rgba(0 0 0 / 0)) and (color: color(rec2020 0 0 0)) {
 :root {
 	--prop-2: linear-gradient(
 		45deg,
@@ -84,7 +87,7 @@
 	--color-1: red;
 }
 
-@supports (color: color(display-p3 0 0 0)) {
+@supports (color: color(srgb 0 0 0)) {
 .not-root {
 	--color-1: color(srgb 0.64331 0.19245 0.16771);
 }
@@ -106,37 +109,37 @@
 	--color-6: orange;
 }
 
-@supports (color: color(display-p3 0 0 0)) {
+@supports (color: color(srgb 0 0 0)) {
 :root {
 	--color-1: color(srgb 0.64331 0.19245 0.16771);
 }
 }
 
-@supports (color: color(display-p3 0 0 0)) {
+@supports (color: color(srgb 0 0 0)) {
 :root {
 	--color-2: color(srgb 0.64331 0.19245 0.16771 / 50);
 }
 }
 
-@supports (color: color(display-p3 0 0 0)) {
+@supports (color: color(srgb 0 0 0)) {
 :root {
 	--color-3: color(srgb 0.64331 0.19245 0.16771 / var(--opacity-50));
 }
 }
 
-@supports (color: color(display-p3 0 0 0)) {
+@supports (color: color(srgb 0 0 0)) {
 :root {
 	--color-4: color(srgb 0.64331 var(--point-5) 0.16771 / var(--opacity-50));
 }
 }
 
-@supports (color: color(display-p3 0 0 0)) {
+@supports (color: color(srgb 0 0 0)) {
 :root {
 	--color-5: color(srgb 0.64331   0.19245 0.16771 / calc(1 / 2));
 }
 }
 
-@supports (color: color(xyz 0 0 0)) {
+@supports (color: color(rec2020 0 0 0)) {
 :root {
 	--color-6: color(rec2020 0.64331 0.19245 0.16771);
 }

--- a/plugins/postcss-progressive-custom-properties/test/example.expect.css
+++ b/plugins/postcss-progressive-custom-properties/test/example.expect.css
@@ -4,7 +4,7 @@
 	/* progressive enhancement */
 }
 
-@supports (--a-color: oklch(40% 0.234 0.39 / var(--opacity-50))) {
+@supports (color: oklch(0% 0 0)) {
 :root {
 	--a-color: oklch(40% 0.234 0.39 / var(--opacity-50));
 }


### PR DESCRIPTION
`@supports (--foo: oklch(0% 0 0))` does not work, so implementing AST matching a bit sooner that I had planned.

This still has the same benefits as the original intention : a single plugin that fixes value and unit fallbacks in custom properties.

But it now generates much smaller and simpler `@supports` statements and they actually work.

Currently covers what we need plus 2 extra cases as examples :
- `css-color-4` (check the diffs in tests for those plugins)
- `double-position-gradients` (this is a more complex case that needs manual handling)
- `ic` unit (unit detection)


This will grow over time as other values and units are needed in plugins.