### PR TITLE
Clamp upgrading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5138,17 +5138,17 @@
       }
     },
     "node_modules/postcss-clamp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-clamp/-/postcss-clamp-3.0.0.tgz",
-      "integrity": "sha512-QENQMIF/Grw0qX0RzSPJjw+mAiGPIwG2AnsQDIoR/WJ5Q19zLB0NrZX8cH7CzzdDWEerTPGCdep7ItFaAdtItg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-clamp/-/postcss-clamp-4.0.0.tgz",
+      "integrity": "sha512-FsMmeBZtymFN7Jtlnw9is8I4nB+qEEb/qS0ZLTIqcKiwZyHBq44Yhv29Q+VQsTGHYFqIr/s/9tqvNM7j+j1d+g==",
       "dependencies": {
-        "postcss-value-parser": "^4.1.0"
+        "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": ">=7.6.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.5"
+        "postcss": "^8.4.6"
       }
     },
     "node_modules/postcss-color-functional-notation": {
@@ -6436,7 +6436,7 @@
         "css-prefers-color-scheme": "^6.0.3",
         "cssdb": "^6.3.1",
         "postcss-attribute-case-insensitive": "^5.0.0",
-        "postcss-clamp": "^3.0.0",
+        "postcss-clamp": "^4.0.0",
         "postcss-color-functional-notation": "^4.2.2",
         "postcss-color-hex-alpha": "^8.0.3",
         "postcss-color-rebeccapurple": "^7.0.2",
@@ -10573,11 +10573,11 @@
       }
     },
     "postcss-clamp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-clamp/-/postcss-clamp-3.0.0.tgz",
-      "integrity": "sha512-QENQMIF/Grw0qX0RzSPJjw+mAiGPIwG2AnsQDIoR/WJ5Q19zLB0NrZX8cH7CzzdDWEerTPGCdep7ItFaAdtItg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-clamp/-/postcss-clamp-4.0.0.tgz",
+      "integrity": "sha512-FsMmeBZtymFN7Jtlnw9is8I4nB+qEEb/qS0ZLTIqcKiwZyHBq44Yhv29Q+VQsTGHYFqIr/s/9tqvNM7j+j1d+g==",
       "requires": {
-        "postcss-value-parser": "^4.1.0"
+        "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-color-functional-notation": {
@@ -10745,7 +10745,7 @@
         "css-prefers-color-scheme": "^6.0.3",
         "cssdb": "^6.3.1",
         "postcss-attribute-case-insensitive": "^5.0.0",
-        "postcss-clamp": "^3.0.0",
+        "postcss-clamp": "^4.0.0",
         "postcss-color-functional-notation": "^4.2.2",
         "postcss-color-hex-alpha": "^8.0.3",
         "postcss-color-rebeccapurple": "^7.0.2",

--- a/plugin-packs/postcss-preset-env/CHANGELOG.md
+++ b/plugin-packs/postcss-preset-env/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changes to PostCSS Preset Env
 
-### 7.4.0 (February 15, 2022)
+### 7.4.1 (February 17, 2022) 
+
+- Updated `postcss-clamp` to `4.0.0` (major)
+
+### 7.4.0 (February 16, 2022)
 
 - Added `@csstools/color-function` <br/> [Check the plugin README](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-color-function#readme) for usage details.
 - Added `@csstools/oklab-function` <br/> [Check the plugin README](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-oklab-function#readme) for usage details.

--- a/plugin-packs/postcss-preset-env/package.json
+++ b/plugin-packs/postcss-preset-env/package.json
@@ -50,7 +50,7 @@
     "css-prefers-color-scheme": "^6.0.3",
     "cssdb": "^6.3.1",
     "postcss-attribute-case-insensitive": "^5.0.0",
-    "postcss-clamp": "^3.0.0",
+    "postcss-clamp": "^4.0.0",
     "postcss-color-functional-notation": "^4.2.2",
     "postcss-color-hex-alpha": "^8.0.3",
     "postcss-color-rebeccapurple": "^7.0.2",

--- a/plugin-packs/postcss-preset-env/test/basic.autoprefixer.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.autoprefixer.expect.css
@@ -324,6 +324,11 @@
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.autoprefixer.false.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.autoprefixer.false.expect.css
@@ -324,6 +324,11 @@
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.ch38.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch38.expect.css
@@ -244,6 +244,11 @@
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.ch88-ff78-saf10.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch88-ff78-saf10.expect.css
@@ -243,6 +243,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.expect.css
@@ -217,6 +217,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	width: clamp(10%, 2px, 4rem);
 }
 
+.mixed-clamp {
+	grid-template-columns: clamp(22rem, 40%, 32rem) minmax(0, 1fr);
+	margin: clamp(1rem, 2%, 3rem) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.no-is-pseudo.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.no-is-pseudo.expect.css
@@ -217,6 +217,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	width: clamp(10%, 2px, 4rem);
 }
 
+.mixed-clamp {
+	grid-template-columns: clamp(22rem, 40%, 32rem) minmax(0, 1fr);
+	margin: clamp(1rem, 2%, 3rem) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.css
+++ b/plugin-packs/postcss-preset-env/test/basic.css
@@ -177,6 +177,11 @@
 	width: clamp(10%, 2px, 4rem);
 }
 
+.mixed-clamp {
+	grid-template-columns: clamp(22rem, 40%, 32rem) minmax(0, 1fr);
+	margin: clamp(1rem, 2%, 3rem) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.expect.css
@@ -348,6 +348,11 @@
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.ff49.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ff49.expect.css
@@ -240,6 +240,11 @@
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.ff66.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ff66.expect.css
@@ -228,6 +228,11 @@
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.ie10.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ie10.expect.css
@@ -361,6 +361,11 @@
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.nesting.false.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.nesting.false.expect.css
@@ -346,6 +346,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.nesting.true.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.nesting.true.expect.css
@@ -193,6 +193,11 @@
 	width: clamp(10%, 2px, 4rem);
 }
 
+.mixed-clamp {
+	grid-template-columns: clamp(22rem, 40%, 32rem) minmax(0, 1fr);
+	margin: clamp(1rem, 2%, 3rem) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.preserve.true.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.preserve.true.expect.css
@@ -624,6 +624,13 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	width: clamp(10%, 2px, 4rem);
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	grid-template-columns: clamp(22rem, 40%, 32rem) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+	margin: clamp(1rem, 2%, 3rem) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.safari15.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.safari15.expect.css
@@ -193,6 +193,11 @@
 	width: clamp(10%, 2px, 4rem);
 }
 
+.mixed-clamp {
+	grid-template-columns: clamp(22rem, 40%, 32rem) minmax(0, 1fr);
+	margin: clamp(1rem, 2%, 3rem) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.stage0-ff49.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0-ff49.expect.css
@@ -245,6 +245,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.stage0-ff66.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0-ff66.expect.css
@@ -233,6 +233,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.stage0.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0.expect.css
@@ -353,6 +353,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.vendors-1.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.vendors-1.expect.css
@@ -318,6 +318,11 @@
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.vendors-2.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.vendors-2.expect.css
@@ -310,6 +310,11 @@
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;

--- a/plugin-packs/postcss-preset-env/test/basic.vendors-3.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.vendors-3.expect.css
@@ -309,6 +309,11 @@
 	width: max(10%, min(2px, 4rem));
 }
 
+.mixed-clamp {
+	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
+	margin: max(1rem, min(2%, 3rem)) 4vh;
+}
+
 @font-face {
 	font-family: 'A';
 	font-style: normal;


### PR DESCRIPTION
This updates `postcss-clamp` to 4.0.0 which only contains the fix for the issue mentioned at #260 

Fixes #260 