### PR TITLE
css-has-pseudo : base36 encoding

### DIFF
--- a/experimental/css-has-pseudo/CHANGELOG.md
+++ b/experimental/css-has-pseudo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to CSS Has Pseudo
 
+### Unreleased (minor)
+
+- Use base36 encoding to fix support for upper case characters in selectors.
+
 ### 0.2.1 (February 6, 2022)
 
 - Do not leak visitedness via `:has` pseudo-class.

--- a/experimental/css-has-pseudo/src/browser.js
+++ b/experimental/css-has-pseudo/src/browser.js
@@ -2,6 +2,7 @@
 
 import '@mrhenry/core-web/modules/~element-qsa-has.js';
 import extractEncodedSelectors from './encode/extract.mjs';
+import encodeCSS from './encode/encode.mjs';
 
 export default function cssHasPseudo(document, options) {
 	// OPTIONS
@@ -236,10 +237,14 @@ export default function cssHasPseudo(document, options) {
 
 						for (let i = 0; i < hasSelectors.length; i++) {
 							const hasSelector = hasSelectors[i];
+
+							console.log(hasSelector);
+							console.log(encodeCSS(hasSelector));
+
 							observedItems.push({
 								rule: rule,
 								selector: hasSelector,
-								attributeName: encodeURIComponent(hasSelector).replace(/%3A/g, ':').replace(/%5B/g, '[').replace(/%5D/g, ']').replace(/%2C/g, ','), // TODO : needs unit tests.
+								attributeName: encodeCSS(hasSelector),
 								nodes: [],
 							});
 						}

--- a/experimental/css-has-pseudo/src/browser.js
+++ b/experimental/css-has-pseudo/src/browser.js
@@ -237,10 +237,6 @@ export default function cssHasPseudo(document, options) {
 
 						for (let i = 0; i < hasSelectors.length; i++) {
 							const hasSelector = hasSelectors[i];
-
-							console.log(hasSelector);
-							console.log(encodeCSS(hasSelector));
-
 							observedItems.push({
 								rule: rule,
 								selector: hasSelector,

--- a/experimental/css-has-pseudo/src/encode/decode.mjs
+++ b/experimental/css-has-pseudo/src/encode/decode.mjs
@@ -1,21 +1,17 @@
 
 /** Decodes an identifier back into a CSS selector */
 export default function decodeCSS(value) {
-	let out = '';
-
-	for (let i = 0; i < value.length; i++) {
-		const char = value[i];
-
-		switch (char) {
-			case '\\':
-				i++;
-				out += value[i];
-				continue;
-			default:
-				out += char;
-				continue;
-		}
+	if (value.slice(0, 13) !== 'csstools-has-') {
+		return '';
 	}
 
-	return decodeURIComponent(out);
+	value = value.slice(13);
+	let values = value.split('-');
+
+	let result = '';
+	for (let i = 0; i < values.length; i++) {
+		result += String.fromCharCode(parseInt(values[i], 36));
+	}
+
+	return result;
 }

--- a/experimental/css-has-pseudo/src/encode/encode.mjs
+++ b/experimental/css-has-pseudo/src/encode/encode.mjs
@@ -1,62 +1,20 @@
 
 /** Returns the string as an encoded CSS identifier. */
 export default function encodeCSS(value) {
-	let out = '';
-	let current = '';
+	if (value === '') {
+		return '';
+	}
 
-	const flushCurrent = () => {
-		const encoded = encodeURIComponent(current);
-		let encodedCurrent = '';
-		let encodedOut = '';
-
-		const flushEncoded = () => {
-			encodedOut += encodedCurrent;
-			encodedCurrent = '';
-		};
-
-		for (let i = 0; i < encoded.length; i++) {
-			const char = encoded[i];
-
-			switch (char) {
-				case '%':
-					flushEncoded();
-					encodedOut += ( '\\' + char );
-					continue;
-
-				default:
-					encodedCurrent += char;
-					continue;
-			}
-		}
-
-		flushEncoded();
-		out += encodedOut;
-		current = '';
-	};
-
+	let hex;
+	let result = '';
 	for (let i = 0; i < value.length; i++) {
-		const char = value[i];
-
-		switch (char) {
-			case ':':
-			case '[':
-			case ']':
-			case ',':
-			case '(':
-			case ')':
-			case '.':
-			case '*':
-			case '~':
-				flushCurrent();
-				out += ( '\\' + char );
-				continue;
-			default:
-				current += char;
-				continue;
+		hex = value.charCodeAt(i).toString(36);
+		if (i === 0) {
+			result += hex;
+		} else {
+			result += '-' + hex;
 		}
 	}
 
-	flushCurrent();
-
-	return out;
+	return 'csstools-has-' + result;
 }

--- a/experimental/css-has-pseudo/src/encode/extract.mjs
+++ b/experimental/css-has-pseudo/src/encode/extract.mjs
@@ -50,22 +50,7 @@ export default function extractEncodedSelectors(value) {
 				}
 
 				continue;
-			case ':':
-				if (quoted) {
-					continue;
-				}
-
-				if (depth === 1 && (value.slice(i, i + 4) === ':has')) {
-					containsUnescapedUnquotedHasAtDepth1 = true;
-				}
-
-				candidate += value[i];
-				continue;
 			case '\\':
-				if (depth === 1 && quoted === false && (value.slice(i+1, i + 7) === ':has\\(')) {
-					containsUnescapedUnquotedHasAtDepth1 = true;
-				}
-
 				candidate += value[i];
 				candidate += value[i+1];
 				i++;
@@ -86,6 +71,10 @@ export default function extractEncodedSelectors(value) {
 				continue;
 
 			default:
+				if (candidate === '' && depth === 1 && (value.slice(i, i + 13) === 'csstools-has-')) {
+					containsUnescapedUnquotedHasAtDepth1 = true;
+				}
+
 				candidate += char;
 				continue;
 		}

--- a/experimental/css-has-pseudo/src/encode/test.mjs
+++ b/experimental/css-has-pseudo/src/encode/test.mjs
@@ -22,102 +22,102 @@ testEncoderDecoder(
 
 testEncoderDecoder(
 	':has()',
-	'\\:has\\(\\)',
+	'csstools-has-1m-2w-2p-37-14-15',
 );
 
 testEncoderDecoder(
 	':has( )',
-	'\\:has\\(\\%20\\)',
+	'csstools-has-1m-2w-2p-37-14-w-15',
 );
 
 testEncoderDecoder(
 	':has(*)',
-	'\\:has\\(\\*\\)',
+	'csstools-has-1m-2w-2p-37-14-16-15',
 );
 
 testEncoderDecoder(
 	':has(:focus)',
-	'\\:has\\(\\:focus\\)',
+	'csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15',
 );
 
 testEncoderDecoder(
 	':has(~ p)',
-	'\\:has\\(\\~\\%20p\\)',
+	'csstools-has-1m-2w-2p-37-14-3i-w-34-15',
 );
 
 testEncoderDecoder(
 	':has(> p)',
-	'\\:has\\(\\%3E\\%20p\\)',
+	'csstools-has-1m-2w-2p-37-14-1q-w-34-15',
 );
 
 testEncoderDecoder(
 	':has(+ p)',
-	'\\:has\\(\\%2B\\%20p\\)',
+	'csstools-has-1m-2w-2p-37-14-17-w-34-15',
 );
 
 testEncoderDecoder(
 	':has(\\~ p)',
-	'\\:has\\(\\%5C\\~\\%20p\\)',
+	'csstools-has-1m-2w-2p-37-14-2k-3i-w-34-15',
 );
 
 testEncoderDecoder(
 	':has(\\> p)',
-	'\\:has\\(\\%5C\\%3E\\%20p\\)',
+	'csstools-has-1m-2w-2p-37-14-2k-1q-w-34-15',
 );
 
 testEncoderDecoder(
 	':has(\\+ p)',
-	'\\:has\\(\\%5C\\%2B\\%20p\\)',
+	'csstools-has-1m-2w-2p-37-14-2k-17-w-34-15',
 );
 
 testEncoderDecoder(
 	':has(\\,\\(\\)\\[\\]\\:\\. p)\\',
-	'\\:has\\(\\%5C\\,\\%5C\\(\\%5C\\)\\%5C\\[\\%5C\\]\\%5C\\:\\%5C\\.\\%20p\\)\\%5C',
+	'csstools-has-1m-2w-2p-37-14-2k-18-2k-14-2k-15-2k-2j-2k-2l-2k-1m-2k-1a-w-34-15-2k',
 );
 
 testEncoderDecoder(
 	':has(.esc\\\\\\:aped)',
-	'\\:has\\(\\.esc\\%5C\\%5C\\%5C\\:aped\\)',
+	'csstools-has-1m-2w-2p-37-14-1a-2t-37-2r-2k-2k-2k-1m-2p-34-2t-2s-15',
 );
 
 testEncoderDecoder(
 	':has(> [a=":has(.x)"]:hover)',
-	'\\:has\\(\\%3E\\%20\\[a\\%3D\\%22\\:has\\(\\.x\\)\\%22\\]\\:hover\\)',
+	'csstools-has-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-1m-2w-2p-37-14-1a-3c-15-y-2l-1m-2w-33-3a-2t-36-15',
 );
 
 testEncoderDecoder(
 	':has(h1, h2, h3, h4, h5, h6)',
-	'\\:has\\(h1\\,\\%20h2\\,\\%20h3\\,\\%20h4\\,\\%20h5\\,\\%20h6\\)',
+	'csstools-has-1m-2w-2p-37-14-2w-1d-18-w-2w-1e-18-w-2w-1f-18-w-2w-1g-18-w-2w-1h-18-w-2w-1i-15',
 );
 
 testEncoderDecoder(
 	':has(> [\\:has\\(\\%3E\\%20\\.a\\:hover\\)',
-	'\\:has\\(\\%3E\\%20\\[\\%5C\\:has\\%5C\\(\\%5C\\%253E\\%5C\\%2520\\%5C\\.a\\%5C\\:hover\\%5C\\)',
+	'csstools-has-1m-2w-2p-37-14-1q-w-2j-2k-1m-2w-2p-37-2k-14-2k-11-1f-1x-2k-11-1e-1c-2k-1a-2p-2k-1m-2w-33-3a-2t-36-2k-15',
 );
 
 testEncoderDecoder(
 	':has(\\%perc)',
-	'\\:has\\(\\%5C\\%25perc\\)',
+	'csstools-has-1m-2w-2p-37-14-2k-11-34-2t-36-2r-15',
 );
 
 testEncoderDecoder(
 	'foo',
-	'foo',
+	'csstools-has-2u-33-33',
 );
 
 testEncoderDecoder(
 	':has(> [foo="some"])',
-	'\\:has\\(\\%3E\\%20\\[foo\\%3D\\%22some\\%22\\]\\)',
+	'csstools-has-1m-2w-2p-37-14-1q-w-2j-2u-33-33-1p-y-37-33-31-2t-y-2l-15',
 );
 
 testEncoderDecoder(
 	'#d_main:has(#d_checkbox:checked)>#d_subject',
-	'\\%23d_main\\:has\\(\\%23d_checkbox\\:checked\\)\\%3E\\%23d_subject',
+	'csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2r-2w-2t-2r-2z-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38',
 );
 
 testEncoderDecoder(
 	'#something-complex:has(> #d_checkbox:checked [foo="some"] * + [bar^="[baz]"] ~ a[class~="logo"] :has(~ .foo:is(button, input)))',
-	'\\%23something-complex\\:has\\(\\%3E\\%20\\%23d_checkbox\\:checked\\%20\\[foo\\%3D\\%22some\\%22\\]\\%20\\*\\%20\\%2B\\%20\\[bar\\%5E\\%3D\\%22\\[baz\\]\\%22\\]\\%20\\~\\%20a\\[class\\~\\%3D\\%22logo\\%22\\]\\%20\\:has\\(\\~\\%20\\.foo\\:is\\(button\\,\\%20input\\)\\)\\)',
+	'csstools-has-z-37-33-31-2t-38-2w-2x-32-2v-19-2r-33-31-34-30-2t-3c-1m-2w-2p-37-14-1q-w-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2r-2w-2t-2r-2z-2t-2s-w-2j-2u-33-33-1p-y-37-33-31-2t-y-2l-w-16-w-17-w-2j-2q-2p-36-2m-1p-y-2j-2q-2p-3e-2l-y-2l-w-3i-w-2p-2j-2r-30-2p-37-37-3i-1p-y-30-33-2v-33-y-2l-w-1m-2w-2p-37-14-3i-w-1a-2u-33-33-1m-2x-37-14-2q-39-38-38-33-32-18-w-2x-32-34-39-38-15-15-15',
 );
 
 function testExtract(encoded, rules) {
@@ -130,201 +130,26 @@ testExtract(
 );
 
 testExtract(
-	'.a, [\\.x\\:has\\(\\%3E\\%20\\.b\\)][\\.x\\:has\\(\\%3E\\%20\\.b\\)]',
-	['.x:has(> .b)'],
-);
-
-testExtract(
-	'[\\.x\\:has\\(\\%3E\\%20\\.b\\)][\\.x\\:has\\(\\%3E\\%20\\.b\\)], a',
-	['.x:has(> .b)'],
-);
-
-testExtract(
-	'[\\.x\\:has\\(\\%3E\\%20\\.a\\)\\%20\\.b][\\.x\\:has\\(\\%3E\\%20\\.a\\)\\%20\\.b][\\.x\\:has\\(\\%3E\\%20\\.a\\)\\%20\\.b]',
-	['.x:has(> .a) .b'],
-);
-
-testExtract(
-	'[\\.x\\:has\\(\\%3E\\%20\\.\\%F0\\%9F\\%A7\\%91\\%F0\\%9F\\%8F\\%BE\\%E2\\%80\\%8D\\%F0\\%9F\\%8E\\%A4\\)][\\.x\\:has\\(\\%3E\\%20\\.\\%F0\\%9F\\%A7\\%91\\%F0\\%9F\\%8F\\%BE\\%E2\\%80\\%8D\\%F0\\%9F\\%8E\\%A4\\)]',
-	['.x:has(> .🧑🏾‍🎤)'],
-);
-
-testExtract(
-	'[\\.x\\:has\\(\\%3E\\%20\\.a\\:has\\(\\%20\\%2B\\%20\\.b\\)\\)][\\.x\\:has\\(\\%3E\\%20\\.a\\:has\\(\\%20\\%2B\\%20\\.b\\)\\)][\\.x\\:has\\(\\%3E\\%20\\.a\\:has\\(\\%20\\%2B\\%20\\.b\\)\\)]',
-	['.x:has(> .a:has( + .b))'],
-);
-
-testExtract(
-	'[\\:has\\(\\:focus\\)]',
-	[':has(:focus)'],
-);
-
-testExtract(
-	'[\\:is\\(\\:focus\\)]',
-	[],
-);
-
-testExtract(
-	'[[\\:has\\(\\:focus\\)]]',
-	[],
-);
-
-testExtract(
-	'\\[\\:has\\(\\:focus\\)\\]',
-	[],
-);
-
-testExtract(
-	'[attr="foo"]',
-	[],
-);
-
-testExtract(
-	'[\\.x\\:has\\(\\%3E\\%20\\.a\\)][\\.x\\:has\\(\\%3E\\%20\\.a\\)], [\\.x\\:has\\(\\%3E\\%20\\.b\\)][\\.x\\:has\\(\\%3E\\%20\\.b\\)]',
-	['.x:has(> .a)', '.x:has(> .b)'],
-);
-
-testExtract(
-	'[\\.x\\:has\\(\\%3E\\%20\\.a\\)][\\.x\\:has\\(\\%3E\\%20\\.a\\)][\\.x\\:has\\(\\%3E\\%20\\.b\\)][\\.x\\:has\\(\\%3E\\%20\\.b\\)]',
-	['.x:has(> .a)', '.x:has(> .b)'],
-);
-
-testExtract(
-	'[\\.b_subject\\:has\\(\\.b_descendant\\)][\\.b_subject\\:has\\(\\.b_descendant\\)]',
-	['.b_subject:has(.b_descendant)'],
-);
-
-testExtract(
-	'[foo="\\[\\.b_subject\\:has\\(\\.b_descendant\\)\\]\\[\\.b_subject\\:has\\(\\.b_descendant\\)\\]"]',
-	[],
-);
-
-testExtract(
-	'[foo="[\\.b_subject\\:has\\(\\.b_descendant\\)\\]\\[\\.b_subject\\:has\\(\\.b_descendant\\)]"]',
-	[],
-);
-
-testExtract(
-	'"\\"[\\.b_subject\\:has\\(\\.b_descendant\\)][\\.b_subject\\:has\\(\\.b_descendant\\)]"',
-	[],
-);
-
-testExtract(
-	'"\\""[\\.b_subject\\:has\\(\\.b_descendant\\)][\\.b_subject\\:has\\(\\.b_descendant\\)]',
-	['.b_subject:has(.b_descendant)'],
-);
-
-testExtract(
-	'["[[\\.b_subject\\:has\\(\\.b_descendant\\)][\\.b_subject\\:has\\(\\.b_descendant\\)]]"]',
-	[],
-);
-
-testExtract(
-	'[\\:has\\(\\%3E\\%20\\[foo\\%3D\\%22some\\%22\\]\\)]',
+	'.a, [csstools-has-1m-2w-2p-37-14-1q-w-2j-2u-33-33-1p-y-37-33-31-2t-y-2l-15]',
 	[':has(> [foo="some"])'],
 );
 
 testExtract(
-	'"\'\\[\\:has\\(\\:focus\\)\\]',
-	[],
+	'[csstools-has-1m-2w-2p-37-14-1q-w-2j-2u-33-33-1p-y-37-33-31-2t-y-2l-15], a',
+	[':has(> [foo="some"])'],
 );
 
 testExtract(
-	'\\["\'\\:has\\(\\:focus\\)\\]',
-	[],
+	'[csstools-has-1m-2w-2p-37-14-1q-w-2j-2u-33-33-1p-y-37-33-31-2t-y-2l-15][csstools-has-1m-2w-2p-37-14-1q-w-2j-2u-33-33-1p-y-37-33-31-2t-y-2l-15][csstools-has-1m-2w-2p-37-14-1q-w-2j-2u-33-33-1p-y-37-33-31-2t-y-2l-15]',
+	[':has(> [foo="some"])'],
 );
 
 testExtract(
-	'\\:has\\(\\:focus\\)',
-	[],
+	'[' + encodeCSS('.x:has(> .🧑🏾‍🎤)') +']',
+	['.x:has(> .🧑🏾‍🎤)'],
 );
 
 testExtract(
-	'[:has(:focus)]',
-	[':has(:focus)'],
+	'[' + encodeCSS('.x:has(> .a:has( + .b))') + ']',
+	['.x:has(> .a:has( + .b))'],
 );
-
-testExtract(
-	'[:has(:focus)\']\']',
-	[':has(:focus)]'],
-);
-
-testExtract(
-	'[:has(:focus)\'"]\']',
-	[':has(:focus)"]'],
-);
-
-testExtract(
-	'[\'"[\':has(:focus)]',
-	['"[:has(:focus)'],
-);
-
-testExtract(
-	'[:has(:focus)[foo=%22some%22]]',
-	[':has(:focus)[foo="some"]'],
-);
-
-testExtract(
-	'[[:has(:focus)]]',
-	[],
-);
-
-testExtract(
-	'":has(:focus)"',
-	[],
-);
-
-testExtract(
-	'\':has(:focus)\'',
-	[],
-);
-
-testExtract(
-	'[":has(:focus)"]',
-	[],
-);
-
-testExtract(
-	'[\':has(:focus)\']',
-	[],
-);
-
-testExtract(
-	'"\':has(:focus)"\'"',
-	[],
-);
-
-testExtract(
-	'\'":has(:focus)\'"',
-	[],
-);
-
-
-testExtract(
-	':is(:focus)',
-	[],
-);
-
-testExtract(
-	'[:is(:focus)]',
-	[],
-);
-
-testExtract(
-	'[":is(:focus)"]',
-	[],
-);
-
-testExtract(
-	'[\\%23something-complex\\:has\\(\\%3E\\%20\\%23d_checkbox\\:checked\\%20\\[foo\\%3D\\%22some\\%22\\]\\%20\\*\\%20\\%2B\\%20\\[bar\\%5E\\%3D\\%22\\[baz\\]\\%22\\]\\%20\\~\\%20a\\[class\\~\\%3D\\%22logo\\%22\\]\\%20\\:has\\(\\~\\%20\\.foo\\:is\\(button\\,\\%20input\\)\\)\\)]',
-	['#something-complex:has(> #d_checkbox:checked [foo="some"] * + [bar^="[baz]"] ~ a[class~="logo"] :has(~ .foo:is(button, input)))'],
-);
-
-
-// Safari already removes escape sequences in CSS selectors.
-// This is most likely a bug in Safari.
-testExtract(
-	'[.b_subject:has(.b_descendant)][.b_subject:has(.b_descendant)]',
-	['.b_subject:has(.b_descendant)'],
-);
-

--- a/experimental/css-has-pseudo/src/index.ts
+++ b/experimental/css-has-pseudo/src/index.ts
@@ -53,7 +53,7 @@ const creator: PluginCreator<{ preserve?: boolean, specificityMatchingName?: str
 						// We can't leave `:has` untouched as that might cause broken selector lists.
 						// Replacing with the specificity matching name as this should never match anything without `:not()`.
 						node.replaceWith(parser.className({
-							value: '.' + options.specificityMatchingName,
+							value: options.specificityMatchingName,
 						}));
 					}
 

--- a/experimental/css-has-pseudo/test/_browser.html
+++ b/experimental/css-has-pseudo/test/_browser.html
@@ -393,11 +393,11 @@
 			}
 
 			async function testClassChange(element, expectedColor) {
-				element.classList.add('a_test');
+				element.classList.add('a_Test');
 				await rafP(() => {
 					testColor(`add .test to ${element.id}`, expectedColor);
 				});
-				element.classList.remove('a_test');
+				element.classList.remove('a_Test');
 				await rafP(() => {
 					testColor(`remove .test from ${element.id}`, grey);
 				});
@@ -405,7 +405,7 @@
 
 			async function testElementInsertionBefore(beforeElement, expectedColor) {
 				const newElement = document.createElement('div');
-				newElement.classList.add('a_test')
+				newElement.classList.add('a_Test')
 
 				beforeElement.before(newElement);
 				await rafP(() => {
@@ -420,7 +420,7 @@
 
 			async function testElementInsertionAfter(afterElement, expectedColor) {
 				const newElement = document.createElement('div');
-				newElement.classList.add('a_test')
+				newElement.classList.add('a_Test')
 
 				afterElement.after(newElement);
 				await rafP(() => {
@@ -436,7 +436,7 @@
 			async function testTreeInsertionBefore(beforeElement, expectedColor) {
 				const newElement = document.createElement('div');
 				const newChild = document.createElement('div');
-				newChild.classList.add('a_test');
+				newChild.classList.add('a_Test');
 				newElement.appendChild(newChild);
 
 				beforeElement.before(newElement);
@@ -453,7 +453,7 @@
 			async function testTreeInsertionAfter(afterElement, expectedColor) {
 				const newElement = document.createElement('div');
 				const newChild = document.createElement('div');
-				newChild.classList.add('a_test');
+				newChild.classList.add('a_Test');
 				newElement.appendChild(newChild);
 
 				afterElement.after(newElement);

--- a/experimental/css-has-pseudo/test/basic.expect.css
+++ b/experimental/css-has-pseudo/test/basic.expect.css
@@ -1,4 +1,4 @@
-[\:has\(\:focus\)] {
+[csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
 	order: 1;
 }
 
@@ -6,7 +6,7 @@
 	order: 1;
 }
 
-[a\:has\(\%3E\%20img\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(does-not-exist):not(does-not-exist) {
 	order: 2;
 }
 
@@ -14,7 +14,7 @@ a:has(> img) {
 	order: 2;
 }
 
-[h1\:has\(\%2B\%20p\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2w-1d-1m-2w-2p-37-14-17-w-34-15]:not(does-not-exist):not(does-not-exist) {
 	order: 3;
 }
 
@@ -22,7 +22,7 @@ h1:has(+ p) {
 	order: 3;
 }
 
-[h1\:has\(\~\%20p\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2w-1d-1m-2w-2p-37-14-3i-w-34-15]:not(does-not-exist):not(does-not-exist) {
 	order: 4;
 }
 
@@ -30,7 +30,7 @@ h1:has(~ p) {
 	order: 4;
 }
 
-[section\:not\(\:has\(h1\,\%20h2\,\%20h3\,\%20h4\,\%20h5\,\%20h6\)\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-37-2t-2r-38-2x-33-32-1m-32-33-38-14-1m-2w-2p-37-14-2w-1d-18-w-2w-1e-18-w-2w-1f-18-w-2w-1g-18-w-2w-1h-18-w-2w-1i-15-15]:not(does-not-exist):not(does-not-exist) {
 	order: 5;
 }
 
@@ -38,7 +38,7 @@ section:not(:has(h1, h2, h3, h4, h5, h6)) {
 	order: 5;
 }
 
-[body\:has\(\:focus\)]:not(does-not-exist) {
+[csstools-has-2q-33-2s-3d-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]:not(does-not-exist) {
   order: 6;
 }
 
@@ -46,7 +46,7 @@ body:has(:focus) {
   order: 6;
 }
 
-[body\:not\(\:has\(\:focus\)\)]:not(does-not-exist) {
+[csstools-has-2q-33-2s-3d-1m-32-33-38-14-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15-15]:not(does-not-exist) {
   order: 7;
 }
 
@@ -59,7 +59,7 @@ body:not(:has(:focus)) {
 	order: 8;
 }
 
-[\:has\(\.esc\%5C\%5C\%5C\:aped\)] {
+[csstools-has-1m-2w-2p-37-14-1a-2t-37-2r-2k-2k-2k-1m-2p-34-2t-2s-15] {
 	order: 9;
 }
 
@@ -67,7 +67,7 @@ body:not(:has(:focus)) {
 	order: 9;
 }
 
-[\.x\:has\(\%3E\%20\.a\:hover\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 10;
 }
 
@@ -75,7 +75,7 @@ body:not(:has(:focus)) {
 	order: 10;
 }
 
-[\.x\:has\(\%3E\%20\%23a\:hover\)]:not(#does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-z-2p-1m-2w-33-3a-2t-36-15]:not(#does-not-exist):not(.does-not-exist) {
 	order: 11;
 }
 
@@ -83,7 +83,7 @@ body:not(:has(:focus)) {
 	order: 11;
 }
 
-[\.x\:has\(\%3E\%20\[a\]\:hover\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 12;
 }
 
@@ -91,7 +91,7 @@ body:not(:has(:focus)) {
 	order: 12;
 }
 
-[\.x\:has\(\%3E\%20\[a\%3D\%22b\%22\]\:hover\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-2q-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 13;
 }
 
@@ -99,7 +99,7 @@ body:not(:has(:focus)) {
 	order: 13;
 }
 
-[\.x\:has\(\%3E\%20\[a\%3D\%22\:has\(\.x\)\%22\]\:hover\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-1m-2w-2p-37-14-1a-3c-15-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 14;
 }
 
@@ -107,7 +107,7 @@ body:not(:has(:focus)) {
 	order: 14;
 }
 
-[\.x\:has\(\%3E\%20\[\%5C\:has\%5C\(\%5C\%253E\%5C\%2520\%5C\.a\%5C\:hover\%5C\)\]\:hover\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2k-1m-2w-2p-37-2k-14-2k-11-1f-1x-2k-11-1e-1c-2k-1a-2p-2k-1m-2w-33-3a-2t-36-2k-15-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 15;
 }
 
@@ -115,7 +115,7 @@ body:not(:has(:focus)) {
 	order: 15;
 }
 
-[\.x\:has\(\%3E\%20\:\:before\:hover\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-1m-2q-2t-2u-33-36-2t-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(does-not-exist) {
 	order: 16; /* not allowed by spec but encoding should work */
 }
 
@@ -123,7 +123,7 @@ body:not(:has(:focus)) {
 	order: 16; /* not allowed by spec but encoding should work */
 }
 
-[\.x\:has\(\%3E\%20\.a\:has\(\%20\%2B\%20\.b\)\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-2p-37-14-w-17-w-1a-2q-15-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 17;
 }
 
@@ -131,7 +131,7 @@ body:not(:has(:focus)) {
 	order: 17;
 }
 
-[\.x\:has\(\%3E\%20__foo\)]:not(does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2n-2n-2u-33-33-15]:not(does-not-exist) {
 	order: 18;
 }
 
@@ -139,7 +139,7 @@ body:not(:has(:focus)) {
 	order: 18;
 }
 
-[\.x\:has\(\%3E\%20\:--foo\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-19-19-2u-33-33-15]:not(.does-not-exist) {
 	order: 19;
 }
 
@@ -147,7 +147,7 @@ body:not(:has(:focus)) {
 	order: 19;
 }
 
-[\.x\:has\(\%3E\%20\*\)] {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-16-15] {
 	order: 20;
 }
 
@@ -155,7 +155,7 @@ body:not(:has(:focus)) {
 	order: 20;
 }
 
-[\.x\:has\(\%3E\%20\.y\%20\*\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-3d-w-16-15]:not(.does-not-exist) {
 	order: 21;
 }
 
@@ -163,7 +163,7 @@ body:not(:has(:focus)) {
 	order: 21;
 }
 
-[\.a\:not\(\:has\(\%3E\%20\.b\)\)]:not(.does-not-exist) {
+[csstools-has-1a-2p-1m-32-33-38-14-1m-2w-2p-37-14-1q-w-1a-2q-15-15]:not(.does-not-exist) {
 	order: 22;
 }
 
@@ -171,7 +171,7 @@ body:not(:has(:focus)) {
 	order: 22;
 }
 
-[\.x\:has\(\~\%20\.y\:has\(\.g\%20\.h\)\%20\.i\)]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-3i-w-1a-3d-1m-2w-2p-37-14-1a-2v-w-1a-2w-15-w-1a-2x-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 23;
 }
 
@@ -179,7 +179,7 @@ body:not(:has(:focus)) {
 	order: 23;
 }
 
-[\.x\:has\(\%3E\%20\.a\)\%20\~\%20\.x\:has\(\%3E\%20\.b\)]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 24;
 }
 
@@ -187,7 +187,7 @@ body:not(:has(:focus)) {
 	order: 24;
 }
 
-[\.x\:has\(\%3E\%20\.a\)\%20\.b]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-1a-2q]:not(.does-not-exist):not(.does-not-exist) {
 	order: 24;
 }
 
@@ -195,7 +195,7 @@ body:not(:has(:focus)) {
 	order: 24;
 }
 
-[\.x\:has\(\%3E\%20\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c-15]:not(.does-not-exist) {
 	order: 25;
 }
 
@@ -203,7 +203,7 @@ body:not(:has(:focus)) {
 	order: 25;
 }
 
-[\.x\:has\(\%3E\%20\.a\)]:not(.does-not-exist), [\.x\:has\(\%3E\%20\.b\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
 	order: 26;
 }
 
@@ -211,7 +211,7 @@ body:not(:has(:focus)) {
 	order: 26;
 }
 
-[\.x\:has\(\%3E\%20\.a\)\%20\~\%20\.x\:has\(\%3E\%20\.b\)]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 27;
 }
 
@@ -219,7 +219,7 @@ body:not(:has(:focus)) {
 	order: 27;
 }
 
-[\.x\:has\(\%3E\%20\.a\)]:not(.does-not-exist), .b {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), .b {
 	order: 28;
 }
 
@@ -227,7 +227,7 @@ body:not(:has(:focus)) {
 	order: 28;
 }
 
-.a, [\.x\:has\(\%3E\%20\.b\)]:not(.does-not-exist) {
+.a, [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
 	order: 29;
 }
 
@@ -235,7 +235,7 @@ body:not(:has(:focus)) {
 	order: 29;
 }
 
-[\.x\:has\(\%3E\%20\.b\%20\*\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-w-16-15]:not(.does-not-exist) {
 	order: 30;
 }
 
@@ -243,7 +243,7 @@ body:not(:has(:focus)) {
 	order: 30;
 }
 
-[\.x\:has\(\%3E\%20\.\.does-not-exist\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(.does-not-exist) {
 	order: 31;
 }
 
@@ -251,7 +251,7 @@ body:not(:has(:focus)) {
 	order: 31;
 }
 
-[\.x\:has\(\%3E\%20\:link\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-30-2x-32-2z-15]:not(.does-not-exist) {
 	order: 31;
 }
 

--- a/experimental/css-has-pseudo/test/basic.preserve.expect.css
+++ b/experimental/css-has-pseudo/test/basic.preserve.expect.css
@@ -1,28 +1,28 @@
-[\:has\(\:focus\)] {
+[csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
 	order: 1;
 }
 
-[a\:has\(\%3E\%20img\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(does-not-exist):not(does-not-exist) {
 	order: 2;
 }
 
-[h1\:has\(\%2B\%20p\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2w-1d-1m-2w-2p-37-14-17-w-34-15]:not(does-not-exist):not(does-not-exist) {
 	order: 3;
 }
 
-[h1\:has\(\~\%20p\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2w-1d-1m-2w-2p-37-14-3i-w-34-15]:not(does-not-exist):not(does-not-exist) {
 	order: 4;
 }
 
-[section\:not\(\:has\(h1\,\%20h2\,\%20h3\,\%20h4\,\%20h5\,\%20h6\)\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-37-2t-2r-38-2x-33-32-1m-32-33-38-14-1m-2w-2p-37-14-2w-1d-18-w-2w-1e-18-w-2w-1f-18-w-2w-1g-18-w-2w-1h-18-w-2w-1i-15-15]:not(does-not-exist):not(does-not-exist) {
 	order: 5;
 }
 
-[body\:has\(\:focus\)]:not(does-not-exist) {
+[csstools-has-2q-33-2s-3d-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]:not(does-not-exist) {
   order: 6;
 }
 
-[body\:not\(\:has\(\:focus\)\)]:not(does-not-exist) {
+[csstools-has-2q-33-2s-3d-1m-32-33-38-14-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15-15]:not(does-not-exist) {
   order: 7;
 }
 
@@ -31,102 +31,102 @@
 	order: 8;
 }
 
-[\:has\(\.esc\%5C\%5C\%5C\:aped\)] {
+[csstools-has-1m-2w-2p-37-14-1a-2t-37-2r-2k-2k-2k-1m-2p-34-2t-2s-15] {
 	order: 9;
 }
 
-[\.x\:has\(\%3E\%20\.a\:hover\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 10;
 }
 
-[\.x\:has\(\%3E\%20\%23a\:hover\)]:not(#does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-z-2p-1m-2w-33-3a-2t-36-15]:not(#does-not-exist):not(.does-not-exist) {
 	order: 11;
 }
 
-[\.x\:has\(\%3E\%20\[a\]\:hover\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 12;
 }
 
-[\.x\:has\(\%3E\%20\[a\%3D\%22b\%22\]\:hover\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-2q-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 13;
 }
 
-[\.x\:has\(\%3E\%20\[a\%3D\%22\:has\(\.x\)\%22\]\:hover\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-1m-2w-2p-37-14-1a-3c-15-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 14;
 }
 
-[\.x\:has\(\%3E\%20\[\%5C\:has\%5C\(\%5C\%253E\%5C\%2520\%5C\.a\%5C\:hover\%5C\)\]\:hover\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2k-1m-2w-2p-37-2k-14-2k-11-1f-1x-2k-11-1e-1c-2k-1a-2p-2k-1m-2w-33-3a-2t-36-2k-15-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 15;
 }
 
-[\.x\:has\(\%3E\%20\:\:before\:hover\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-1m-2q-2t-2u-33-36-2t-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(does-not-exist) {
 	order: 16; /* not allowed by spec but encoding should work */
 }
 
-[\.x\:has\(\%3E\%20\.a\:has\(\%20\%2B\%20\.b\)\)]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-2p-37-14-w-17-w-1a-2q-15-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 17;
 }
 
-[\.x\:has\(\%3E\%20__foo\)]:not(does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2n-2n-2u-33-33-15]:not(does-not-exist) {
 	order: 18;
 }
 
-[\.x\:has\(\%3E\%20\:--foo\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-19-19-2u-33-33-15]:not(.does-not-exist) {
 	order: 19;
 }
 
-[\.x\:has\(\%3E\%20\*\)] {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-16-15] {
 	order: 20;
 }
 
-[\.x\:has\(\%3E\%20\.y\%20\*\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-3d-w-16-15]:not(.does-not-exist) {
 	order: 21;
 }
 
-[\.a\:not\(\:has\(\%3E\%20\.b\)\)]:not(.does-not-exist) {
+[csstools-has-1a-2p-1m-32-33-38-14-1m-2w-2p-37-14-1q-w-1a-2q-15-15]:not(.does-not-exist) {
 	order: 22;
 }
 
-[\.x\:has\(\~\%20\.y\:has\(\.g\%20\.h\)\%20\.i\)]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-3i-w-1a-3d-1m-2w-2p-37-14-1a-2v-w-1a-2w-15-w-1a-2x-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 23;
 }
 
-[\.x\:has\(\%3E\%20\.a\)\%20\~\%20\.x\:has\(\%3E\%20\.b\)]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 24;
 }
 
-[\.x\:has\(\%3E\%20\.a\)\%20\.b]:not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-1a-2q]:not(.does-not-exist):not(.does-not-exist) {
 	order: 24;
 }
 
-[\.x\:has\(\%3E\%20\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c-15]:not(.does-not-exist) {
 	order: 25;
 }
 
-[\.x\:has\(\%3E\%20\.a\)]:not(.does-not-exist), [\.x\:has\(\%3E\%20\.b\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
 	order: 26;
 }
 
-[\.x\:has\(\%3E\%20\.a\)\%20\~\%20\.x\:has\(\%3E\%20\.b\)]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 27;
 }
 
-[\.x\:has\(\%3E\%20\.a\)]:not(.does-not-exist), .b {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), .b {
 	order: 28;
 }
 
-.a, [\.x\:has\(\%3E\%20\.b\)]:not(.does-not-exist) {
+.a, [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
 	order: 29;
 }
 
-[\.x\:has\(\%3E\%20\.b\%20\*\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-w-16-15]:not(.does-not-exist) {
 	order: 30;
 }
 
-[\.x\:has\(\%3E\%20\.\.does-not-exist\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(.does-not-exist) {
 	order: 31;
 }
 
-[\.x\:has\(\%3E\%20\:link\)]:not(.does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-30-2x-32-2z-15]:not(.does-not-exist) {
 	order: 31;
 }

--- a/experimental/css-has-pseudo/test/basic.specificity-matching-name.expect.css
+++ b/experimental/css-has-pseudo/test/basic.specificity-matching-name.expect.css
@@ -1,4 +1,4 @@
-[\:has\(\:focus\)] {
+[csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
 	order: 1;
 }
 
@@ -6,7 +6,7 @@
 	order: 1;
 }
 
-[a\:has\(\%3E\%20img\)]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
 	order: 2;
 }
 
@@ -14,7 +14,7 @@ a:has(> img) {
 	order: 2;
 }
 
-[h1\:has\(\%2B\%20p\)]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
+[csstools-has-2w-1d-1m-2w-2p-37-14-17-w-34-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
 	order: 3;
 }
 
@@ -22,7 +22,7 @@ h1:has(+ p) {
 	order: 3;
 }
 
-[h1\:has\(\~\%20p\)]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
+[csstools-has-2w-1d-1m-2w-2p-37-14-3i-w-34-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
 	order: 4;
 }
 
@@ -30,7 +30,7 @@ h1:has(~ p) {
 	order: 4;
 }
 
-[section\:not\(\:has\(h1\,\%20h2\,\%20h3\,\%20h4\,\%20h5\,\%20h6\)\)]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
+[csstools-has-37-2t-2r-38-2x-33-32-1m-32-33-38-14-1m-2w-2p-37-14-2w-1d-18-w-2w-1e-18-w-2w-1f-18-w-2w-1g-18-w-2w-1h-18-w-2w-1i-15-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
 	order: 5;
 }
 
@@ -38,7 +38,7 @@ section:not(:has(h1, h2, h3, h4, h5, h6)) {
 	order: 5;
 }
 
-[body\:has\(\:focus\)]:not(other-thing-that-does-not-exist) {
+[csstools-has-2q-33-2s-3d-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]:not(other-thing-that-does-not-exist) {
   order: 6;
 }
 
@@ -46,7 +46,7 @@ body:has(:focus) {
   order: 6;
 }
 
-[body\:not\(\:has\(\:focus\)\)]:not(other-thing-that-does-not-exist) {
+[csstools-has-2q-33-2s-3d-1m-32-33-38-14-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15-15]:not(other-thing-that-does-not-exist) {
   order: 7;
 }
 
@@ -59,7 +59,7 @@ body:not(:has(:focus)) {
 	order: 8;
 }
 
-[\:has\(\.esc\%5C\%5C\%5C\:aped\)] {
+[csstools-has-1m-2w-2p-37-14-1a-2t-37-2r-2k-2k-2k-1m-2p-34-2t-2s-15] {
 	order: 9;
 }
 
@@ -67,7 +67,7 @@ body:not(:has(:focus)) {
 	order: 9;
 }
 
-[\.x\:has\(\%3E\%20\.a\:hover\)]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 10;
 }
 
@@ -75,7 +75,7 @@ body:not(:has(:focus)) {
 	order: 10;
 }
 
-[\.x\:has\(\%3E\%20\%23a\:hover\)]:not(#other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-z-2p-1m-2w-33-3a-2t-36-15]:not(#other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 11;
 }
 
@@ -83,7 +83,7 @@ body:not(:has(:focus)) {
 	order: 11;
 }
 
-[\.x\:has\(\%3E\%20\[a\]\:hover\)]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 12;
 }
 
@@ -91,7 +91,7 @@ body:not(:has(:focus)) {
 	order: 12;
 }
 
-[\.x\:has\(\%3E\%20\[a\%3D\%22b\%22\]\:hover\)]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-2q-y-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 13;
 }
 
@@ -99,7 +99,7 @@ body:not(:has(:focus)) {
 	order: 13;
 }
 
-[\.x\:has\(\%3E\%20\[a\%3D\%22\:has\(\.x\)\%22\]\:hover\)]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-1m-2w-2p-37-14-1a-3c-15-y-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 14;
 }
 
@@ -107,7 +107,7 @@ body:not(:has(:focus)) {
 	order: 14;
 }
 
-[\.x\:has\(\%3E\%20\[\%5C\:has\%5C\(\%5C\%253E\%5C\%2520\%5C\.a\%5C\:hover\%5C\)\]\:hover\)]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2k-1m-2w-2p-37-2k-14-2k-11-1f-1x-2k-11-1e-1c-2k-1a-2p-2k-1m-2w-33-3a-2t-36-2k-15-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 15;
 }
 
@@ -115,7 +115,7 @@ body:not(:has(:focus)) {
 	order: 15;
 }
 
-[\.x\:has\(\%3E\%20\:\:before\:hover\)]:not(.other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-1m-2q-2t-2u-33-36-2t-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
 	order: 16; /* not allowed by spec but encoding should work */
 }
 
@@ -123,7 +123,7 @@ body:not(:has(:focus)) {
 	order: 16; /* not allowed by spec but encoding should work */
 }
 
-[\.x\:has\(\%3E\%20\.a\:has\(\%20\%2B\%20\.b\)\)]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-2p-37-14-w-17-w-1a-2q-15-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 17;
 }
 
@@ -131,7 +131,7 @@ body:not(:has(:focus)) {
 	order: 17;
 }
 
-[\.x\:has\(\%3E\%20__foo\)]:not(other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2n-2n-2u-33-33-15]:not(other-thing-that-does-not-exist) {
 	order: 18;
 }
 
@@ -139,7 +139,7 @@ body:not(:has(:focus)) {
 	order: 18;
 }
 
-[\.x\:has\(\%3E\%20\:--foo\)]:not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-19-19-2u-33-33-15]:not(.other-thing-that-does-not-exist) {
 	order: 19;
 }
 
@@ -147,7 +147,7 @@ body:not(:has(:focus)) {
 	order: 19;
 }
 
-[\.x\:has\(\%3E\%20\*\)] {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-16-15] {
 	order: 20;
 }
 
@@ -155,7 +155,7 @@ body:not(:has(:focus)) {
 	order: 20;
 }
 
-[\.x\:has\(\%3E\%20\.y\%20\*\)]:not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-3d-w-16-15]:not(.other-thing-that-does-not-exist) {
 	order: 21;
 }
 
@@ -163,7 +163,7 @@ body:not(:has(:focus)) {
 	order: 21;
 }
 
-[\.a\:not\(\:has\(\%3E\%20\.b\)\)]:not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-2p-1m-32-33-38-14-1m-2w-2p-37-14-1q-w-1a-2q-15-15]:not(.other-thing-that-does-not-exist) {
 	order: 22;
 }
 
@@ -171,7 +171,7 @@ body:not(:has(:focus)) {
 	order: 22;
 }
 
-[\.x\:has\(\~\%20\.y\:has\(\.g\%20\.h\)\%20\.i\)]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-3i-w-1a-3d-1m-2w-2p-37-14-1a-2v-w-1a-2w-15-w-1a-2x-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 23;
 }
 
@@ -179,7 +179,7 @@ body:not(:has(:focus)) {
 	order: 23;
 }
 
-[\.x\:has\(\%3E\%20\.a\)\%20\~\%20\.x\:has\(\%3E\%20\.b\)]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 24;
 }
 
@@ -187,7 +187,7 @@ body:not(:has(:focus)) {
 	order: 24;
 }
 
-[\.x\:has\(\%3E\%20\.a\)\%20\.b]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-1a-2q]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 24;
 }
 
@@ -195,7 +195,7 @@ body:not(:has(:focus)) {
 	order: 24;
 }
 
-[\.x\:has\(\%3E\%20\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\)]:not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c-15]:not(.other-thing-that-does-not-exist) {
 	order: 25;
 }
 
@@ -203,7 +203,7 @@ body:not(:has(:focus)) {
 	order: 25;
 }
 
-[\.x\:has\(\%3E\%20\.a\)]:not(.other-thing-that-does-not-exist), [\.x\:has\(\%3E\%20\.b\)]:not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.other-thing-that-does-not-exist), [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist) {
 	order: 26;
 }
 
@@ -211,7 +211,7 @@ body:not(:has(:focus)) {
 	order: 26;
 }
 
-[\.x\:has\(\%3E\%20\.a\)\%20\~\%20\.x\:has\(\%3E\%20\.b\)]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 27;
 }
 
@@ -219,7 +219,7 @@ body:not(:has(:focus)) {
 	order: 27;
 }
 
-[\.x\:has\(\%3E\%20\.a\)]:not(.other-thing-that-does-not-exist), .b {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.other-thing-that-does-not-exist), .b {
 	order: 28;
 }
 
@@ -227,7 +227,7 @@ body:not(:has(:focus)) {
 	order: 28;
 }
 
-.a, [\.x\:has\(\%3E\%20\.b\)]:not(.other-thing-that-does-not-exist) {
+.a, [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist) {
 	order: 29;
 }
 
@@ -235,7 +235,7 @@ body:not(:has(:focus)) {
 	order: 29;
 }
 
-[\.x\:has\(\%3E\%20\.b\%20\*\)]:not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-w-16-15]:not(.other-thing-that-does-not-exist) {
 	order: 30;
 }
 
@@ -243,7 +243,7 @@ body:not(:has(:focus)) {
 	order: 30;
 }
 
-[\.x\:has\(\%3E\%20\.\.other-thing-that-does-not-exist\)]:not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-33-38-2w-2t-36-19-38-2w-2x-32-2v-19-38-2w-2p-38-19-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(.other-thing-that-does-not-exist) {
 	order: 31;
 }
 
@@ -251,7 +251,7 @@ body:not(:has(:focus)) {
 	order: 31;
 }
 
-[\.x\:has\(\%3E\%20\:link\)]:not(.other-thing-that-does-not-exist) {
+[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-30-2x-32-2z-15]:not(.other-thing-that-does-not-exist) {
 	order: 31;
 }
 

--- a/experimental/css-has-pseudo/test/browser.css
+++ b/experimental/css-has-pseudo/test/browser.css
@@ -61,27 +61,27 @@ div:has(+ div .c_test) #c_subject {
 }
 
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-in-adjacent-position.html */
-div:has(.a_test)+#a_subject {
+div:has(.a_Test)+#a_subject {
 	background-color: red;
 }
 
-div:has(> .a_test)+#a_subject {
+div:has(> .a_Test)+#a_subject {
 	background-color: green;
 }
 
-div:has(~ .a_test)+#a_subject {
+div:has(~ .a_Test)+#a_subject {
 	background-color: yellow;
 }
 
-div:has(+ .a_test)+#a_subject {
+div:has(+ .a_Test)+#a_subject {
 	background-color: blue;
 }
 
-div:has(~ div .a_test)+#a_subject {
+div:has(~ div .a_Test)+#a_subject {
 	background-color: purple;
 }
 
-div:has(+ div .a_test)+#a_subject {
+div:has(+ div .a_Test)+#a_subject {
 	background-color: pink;
 }
 

--- a/experimental/css-has-pseudo/test/browser.expect.css
+++ b/experimental/css-has-pseudo/test/browser.expect.css
@@ -1,87 +1,87 @@
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-pseudo-class.html */
-[\%23d_main\:has\(input\)\%20div]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-2x-32-34-39-38-15-w-2s-2x-3a]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	color: grey
 }
 
-[\%23d_main\:has\(\%23d_checkbox\:checked\)\%3E\%23d_subject]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2r-2w-2t-2r-2z-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: red
 }
 
-[\%23d_main\:has\(\%23d_option\:checked\)\%3E\%23d_subject]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-33-34-38-2x-33-32-1m-2r-2w-2t-2r-2z-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: red
 }
 
-[\%23d_main\:has\(\%23d_checkbox\:disabled\)\%3E\%23d_subject]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2s-2x-37-2p-2q-30-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: green
 }
 
-[\%23d_main\:has\(\%23d_option\:disabled\)\%3E\%20\:is\(\%23d_subject\,\%20\%23d_subject2\)]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-33-34-38-2x-33-32-1m-2s-2x-37-2p-2q-30-2t-2s-15-1q-w-1m-2x-37-14-z-2s-2n-37-39-2q-2y-2t-2r-38-18-w-z-2s-2n-37-39-2q-2y-2t-2r-38-1e-15]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: green
 }
 
-[\%23d_main\:has\(\%23d_optgroup\:disabled\)\%3E\%23d_subject]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-33-34-38-2v-36-33-39-34-1m-2s-2x-37-2p-2q-30-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: blue
 }
 
-[\%23d_main\:not\(\:has\(\%23d_checkbox\:enabled\)\)\%3E\%23d_subject3]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-2s-2n-31-2p-2x-32-1m-32-33-38-14-1m-2w-2p-37-14-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2t-32-2p-2q-30-2t-2s-15-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38-1f]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: green
 }
 
-[\%23d_main\:not\(\:has\(\%23d_option\:enabled\)\)\%20\:is\(\%23d_subject3\,\%20\%23d_subject4\)]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-2s-2n-31-2p-2x-32-1m-32-33-38-14-1m-2w-2p-37-14-z-2s-2n-33-34-38-2x-33-32-1m-2t-32-2p-2q-30-2t-2s-15-15-w-1m-2x-37-14-z-2s-2n-37-39-2q-2y-2t-2r-38-1f-18-w-z-2s-2n-37-39-2q-2y-2t-2r-38-1g-15]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: green
 }
 
-[\%23d_main\:not\(\:has\(\%23d_optgroup\:enabled\)\)\%3E\%23d_subject3]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-2s-2n-31-2p-2x-32-1m-32-33-38-14-1m-2w-2p-37-14-z-2s-2n-33-34-38-2v-36-33-39-34-1m-2t-32-2p-2q-30-2t-2s-15-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38-1f]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: blue
 }
 
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-in-ancestor-position.html */
-[div\:has\(\.c_test\)\%20\%23c_subject]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: red
 }
 
-[div\:has\(\%3E\%20\.c_test\)\%20\%23c_subject]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1q-w-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: green
 }
 
-[div\:has\(\~\%20\.c_test\)\%20\%23c_subject]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: yellow
 }
 
-[div\:has\(\%2B\%20\.c_test\)\%20\%23c_subject]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: blue
 }
 
-[div\:has\(\~\%20div\%20\.c_test\)\%20\%23c_subject]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-2s-2x-3a-w-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	background-color: purple
 }
 
-[div\:has\(\%2B\%20div\%20\.c_test\)\%20\%23c_subject]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-2s-2x-3a-w-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	background-color: pink
 }
 
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-in-adjacent-position.html */
-[div\:has\(\.a_test\)\%2B\%23a_subject]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: red;
 }
 
-[div\:has\(\%3E\%20\.a_test\)\%2B\%23a_subject]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1q-w-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: green;
 }
 
-[div\:has\(\~\%20\.a_test\)\%2B\%23a_subject]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: yellow;
 }
 
-[div\:has\(\%2B\%20\.a_test\)\%2B\%23a_subject]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: blue;
 }
 
-[div\:has\(\~\%20div\%20\.a_test\)\%2B\%23a_subject]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-2s-2x-3a-w-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	background-color: purple;
 }
 
-[div\:has\(\%2B\%20div\%20\.a_test\)\%2B\%23a_subject]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-2s-2x-3a-w-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	background-color: pink;
 }
 
@@ -95,86 +95,86 @@ main {
 	padding: 5px;
 }
 
-[\.b_subject\:has\(\%3E\%20\.b_child\)]:not(.does-not-exist) {
+[csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-1q-w-1a-2q-2n-2r-2w-2x-30-2s-15]:not(.does-not-exist) {
 	background-color: red;
 }
 
-[\.b_subject\:has\(\.b_descendant\)]:not(.does-not-exist) {
+[csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-1a-2q-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-15]:not(.does-not-exist) {
 	background-color: green;
 }
 
-[\.b_subject\:has\(\[attrname\%3D\%22b_descendant\%22\]\)]:not(.does-not-exist) {
+[csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-2j-2p-38-38-36-32-2p-31-2t-1p-y-2q-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-y-2l-15]:not(.does-not-exist) {
 	background-color: blue;
 }
 
-[\.b_subject\:has\(\%23b_div_descendant\)]:not(#does-not-exist) {
+[csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-z-2q-2n-2s-2x-3a-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-15]:not(#does-not-exist) {
 	background-color: yellow;
 }
 
-[\.b_subject\:has\(b_descendant\)]:not(does-not-exist) {
+[csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-2q-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-15]:not(does-not-exist) {
 	background-color: yellowgreen;
 }
 
-[\%23visited-1\:has\(\:link\)]:not(#does-not-exist) {
+[csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1d-1m-2w-2p-37-14-1m-30-2x-32-2z-15]:not(#does-not-exist) {
 	color: green;
 }
 
-[\%23visited-2\:has\(\.\.does-not-exist\)]:not(#does-not-exist) {
+[csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1e-1m-2w-2p-37-14-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(#does-not-exist) {
 	color: yellow;
 }
 
-[\%23visited-3\:has\(\:link\)]:not(#does-not-exist) {
+[csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1f-1m-2w-2p-37-14-1m-30-2x-32-2z-15]:not(#does-not-exist) {
 	color: yellowgreen;
 }
 
-[\%23visited-4\:has\(\.\.does-not-exist\)]:not(#does-not-exist) {
+[csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1g-1m-2w-2p-37-14-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(#does-not-exist) {
 	color: red;
 }
 
-[\%23main_specificity\%20\:has\(\%23foo\)]:not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t0:PASS;
 }
 
-[\%23main_specificity\%20\:has\(\.foo\)]:not(#does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	--t0:FAIL;
 }
 
-[\%23main_specificity\%20\:has\(span\%23foo\)]:not(#does-not-exist):not(#does-not-exist):not(does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist):not(does-not-exist) {
 	--t1:PASS;
 }
 
-[\%23main_specificity\%20\:has\(\%23foo\)]:not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t1:FAIL;
 }
 
-[\%23main_specificity\%20\:has\(\.bar\,\%20\%23foo\)]:not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2q-2p-36-18-w-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t2:FAIL;
 }
 
-[\%23main_specificity\%20\:has\(\%23foo\,\%20\.bar\)]:not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-z-2u-33-33-18-w-1a-2q-2p-36-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t2:PASS;
 }
 
-[\%23main_specificity\%20\:has\(\.bar\,\%20\%23foo\)]:not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2q-2p-36-18-w-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t3:PASS;
 }
 
-[\%23main_specificity\%20\:has\(\.foo\,\%20\.bar\)]:not(#does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2u-33-33-18-w-1a-2q-2p-36-15]:not(#does-not-exist) {
 	--t3:FAIL;
 }
 
-[\%23main_specificity\%20\:has\(span\%20\%2B\%20span\)]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-w-17-w-37-34-2p-32-15]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	--t4:PASS;
 }
 
-[\%23main_specificity\%20\:has\(span\)]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-15]:not(#does-not-exist):not(does-not-exist) {
 	--t4:FAIL;
 }
 
-[\%23main_specificity\%20\:has\(span\,\%20li\,\%20\%23foo\)]:not(#does-not-exist):not(#does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-18-w-30-2x-18-w-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t5:PASS;
 }
 
-[\%23main_specificity\%20\:has\(span\,\%20li\,\%20p\)]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-18-w-30-2x-18-w-34-15]:not(#does-not-exist):not(does-not-exist) {
 	--t5:FAIL;
 }

--- a/experimental/css-has-pseudo/test/generated-selector-cases.expect.css
+++ b/experimental/css-has-pseudo/test/generated-selector-cases.expect.css
@@ -1,880 +1,880 @@
-[\:has\(\.foo\)\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 0;
 }
 
-[\:has\(\.foo\)\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 1;
 }
 
-[\:has\(\.foo\)\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 2;
 }
 
-[\:has\(\.foo\)\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 3;
 }
 
-[\:has\(\.foo\)\%20\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 4;
 }
 
-[\:has\(\.foo\)\%20\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 5;
 }
 
-[\:has\(\.foo\)\%2B\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 6;
 }
 
-[\:has\(\.foo\)\%2B\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 7;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 8;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 9;
 }
 
-[\:has\(\.foo\)\~\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 10;
 }
 
-[\:has\(\.foo\)\~\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 11;
 }
 
-[\:has\(\.foo\)\%20\~\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 12;
 }
 
-[\:has\(\.foo\)\%20\~\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 13;
 }
 
-[\:has\(\.foo\)\%3E\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 14;
 }
 
-[\:has\(\.foo\)\%3E\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 15;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 16;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 17;
 }
 
-[\:has\(\.foo\)], [\:has\(\.foo\)] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 18;
 }
 
-[\:has\(\.foo\)], [\:has\(\.foo\)] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 19;
 }
 
-[button\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2q-39-38-38-33-32-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 20;
 }
 
-[\:has\(\.foo\)button]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 21;
 }
 
-[button\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2q-39-38-38-33-32-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 22;
 }
 
-[\:has\(\.foo\)\%20button]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 23;
 }
 
-[button\%20\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2q-39-38-38-33-32-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 24;
 }
 
-[\:has\(\.foo\)\%20\%20button]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 25;
 }
 
-[button\%2B\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2q-39-38-38-33-32-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 26;
 }
 
-[\:has\(\.foo\)\%2Bbutton]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 27;
 }
 
-[button\%20\%2B\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2q-39-38-38-33-32-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 28;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20button]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 29;
 }
 
-[button\~\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2q-39-38-38-33-32-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 30;
 }
 
-[\:has\(\.foo\)\~button]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 31;
 }
 
-[button\%20\~\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2q-39-38-38-33-32-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 32;
 }
 
-[\:has\(\.foo\)\%20\~\%20button]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 33;
 }
 
-[button\%3E\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2q-39-38-38-33-32-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 34;
 }
 
-[\:has\(\.foo\)\%3Ebutton]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 35;
 }
 
-[button\%20\%3E\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2q-39-38-38-33-32-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 36;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20button]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 37;
 }
 
-button, [\:has\(\.foo\)] {
+button, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 38;
 }
 
-[\:has\(\.foo\)], button {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], button {
 	order: 39;
 }
 
-[\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 40;
 }
 
-[\:has\(\.foo\)\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 41;
 }
 
-[\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 42;
 }
 
-[\:has\(\.foo\)\%20\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 43;
 }
 
-[\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\%20\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 44;
 }
 
-[\:has\(\.foo\)\%20\%20\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 45;
 }
 
-[\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\%2B\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 46;
 }
 
-[\:has\(\.foo\)\%2B\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 47;
 }
 
-[\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\%20\%2B\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 48;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 49;
 }
 
-[\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\~\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 50;
 }
 
-[\:has\(\.foo\)\~\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 51;
 }
 
-[\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\%20\~\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 52;
 }
 
-[\:has\(\.foo\)\%20\~\%20\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 53;
 }
 
-[\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\%3E\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 54;
 }
 
-[\:has\(\.foo\)\%3E\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 55;
 }
 
-[\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4\%20\%3E\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 56;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20\.\%F0\%9F\%A7\%91\%F0\%9F\%8F\%BE\%E2\%80\%8D\%F0\%9F\%8E\%A4]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 57;
 }
 
-.🧑🏾‍🎤, [\:has\(\.foo\)] {
+.🧑🏾‍🎤, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 58;
 }
 
-[\:has\(\.foo\)], .🧑🏾‍🎤 {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], .🧑🏾‍🎤 {
 	order: 59;
 }
 
-[\.foo\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 60;
 }
 
-[\:has\(\.foo\)\.foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1a-2u-33-33]:not(.does-not-exist) {
 	order: 61;
 }
 
-[\.foo\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 62;
 }
 
-[\:has\(\.foo\)\%20\.foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1a-2u-33-33]:not(.does-not-exist) {
 	order: 63;
 }
 
-[\.foo\%20\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 64;
 }
 
-[\:has\(\.foo\)\%20\%20\.foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1a-2u-33-33]:not(.does-not-exist) {
 	order: 65;
 }
 
-[\.foo\%2B\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 66;
 }
 
-[\:has\(\.foo\)\%2B\.foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1a-2u-33-33]:not(.does-not-exist) {
 	order: 67;
 }
 
-[\.foo\%20\%2B\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 68;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20\.foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1a-2u-33-33]:not(.does-not-exist) {
 	order: 69;
 }
 
-[\.foo\~\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 70;
 }
 
-[\:has\(\.foo\)\~\.foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1a-2u-33-33]:not(.does-not-exist) {
 	order: 71;
 }
 
-[\.foo\%20\~\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 72;
 }
 
-[\:has\(\.foo\)\%20\~\%20\.foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1a-2u-33-33]:not(.does-not-exist) {
 	order: 73;
 }
 
-[\.foo\%3E\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 74;
 }
 
-[\:has\(\.foo\)\%3E\.foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1a-2u-33-33]:not(.does-not-exist) {
 	order: 75;
 }
 
-[\.foo\%20\%3E\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1a-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 76;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20\.foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1a-2u-33-33]:not(.does-not-exist) {
 	order: 77;
 }
 
-.foo, [\:has\(\.foo\)] {
+.foo, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 78;
 }
 
-[\:has\(\.foo\)], .foo {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], .foo {
 	order: 79;
 }
 
-[\%23foo\:has\(\.foo\)]:not(#does-not-exist) {
+[csstools-has-z-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 80;
 }
 
-[\:has\(\.foo\)\%23foo]:not(#does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-z-2u-33-33]:not(#does-not-exist) {
 	order: 81;
 }
 
-[\%23foo\%20\:has\(\.foo\)]:not(#does-not-exist) {
+[csstools-has-z-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 82;
 }
 
-[\:has\(\.foo\)\%20\%23foo]:not(#does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-z-2u-33-33]:not(#does-not-exist) {
 	order: 83;
 }
 
-[\%23foo\%20\%20\:has\(\.foo\)]:not(#does-not-exist) {
+[csstools-has-z-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 84;
 }
 
-[\:has\(\.foo\)\%20\%20\%23foo]:not(#does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-z-2u-33-33]:not(#does-not-exist) {
 	order: 85;
 }
 
-[\%23foo\%2B\:has\(\.foo\)]:not(#does-not-exist) {
+[csstools-has-z-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 86;
 }
 
-[\:has\(\.foo\)\%2B\%23foo]:not(#does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-z-2u-33-33]:not(#does-not-exist) {
 	order: 87;
 }
 
-[\%23foo\%20\%2B\%20\:has\(\.foo\)]:not(#does-not-exist) {
+[csstools-has-z-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 88;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20\%23foo]:not(#does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-z-2u-33-33]:not(#does-not-exist) {
 	order: 89;
 }
 
-[\%23foo\~\:has\(\.foo\)]:not(#does-not-exist) {
+[csstools-has-z-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 90;
 }
 
-[\:has\(\.foo\)\~\%23foo]:not(#does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-z-2u-33-33]:not(#does-not-exist) {
 	order: 91;
 }
 
-[\%23foo\%20\~\%20\:has\(\.foo\)]:not(#does-not-exist) {
+[csstools-has-z-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 92;
 }
 
-[\:has\(\.foo\)\%20\~\%20\%23foo]:not(#does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-z-2u-33-33]:not(#does-not-exist) {
 	order: 93;
 }
 
-[\%23foo\%3E\:has\(\.foo\)]:not(#does-not-exist) {
+[csstools-has-z-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 94;
 }
 
-[\:has\(\.foo\)\%3E\%23foo]:not(#does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-z-2u-33-33]:not(#does-not-exist) {
 	order: 95;
 }
 
-[\%23foo\%20\%3E\%20\:has\(\.foo\)]:not(#does-not-exist) {
+[csstools-has-z-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 96;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20\%23foo]:not(#does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-z-2u-33-33]:not(#does-not-exist) {
 	order: 97;
 }
 
-#foo, [\:has\(\.foo\)] {
+#foo, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 98;
 }
 
-[\:has\(\.foo\)], #foo {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], #foo {
 	order: 99;
 }
 
-[__foo\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2n-2n-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 100;
 }
 
-[\:has\(\.foo\)__foo]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 101;
 }
 
-[__foo\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2n-2n-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 102;
 }
 
-[\:has\(\.foo\)\%20__foo]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 103;
 }
 
-[__foo\%20\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2n-2n-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 104;
 }
 
-[\:has\(\.foo\)\%20\%20__foo]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 105;
 }
 
-[__foo\%2B\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2n-2n-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 106;
 }
 
-[\:has\(\.foo\)\%2B__foo]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 107;
 }
 
-[__foo\%20\%2B\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2n-2n-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 108;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20__foo]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 109;
 }
 
-[__foo\~\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2n-2n-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 110;
 }
 
-[\:has\(\.foo\)\~__foo]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 111;
 }
 
-[__foo\%20\~\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2n-2n-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 112;
 }
 
-[\:has\(\.foo\)\%20\~\%20__foo]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 113;
 }
 
-[__foo\%3E\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2n-2n-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 114;
 }
 
-[\:has\(\.foo\)\%3E__foo]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 115;
 }
 
-[__foo\%20\%3E\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2n-2n-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 116;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20__foo]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 117;
 }
 
-__foo, [\:has\(\.foo\)] {
+__foo, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 118;
 }
 
-[\:has\(\.foo\)], __foo {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], __foo {
 	order: 119;
 }
 
-[\:--foo\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-19-19-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 120;
 }
 
-[\:has\(\.foo\)\:--foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 121;
 }
 
-[\:--foo\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-19-19-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 122;
 }
 
-[\:has\(\.foo\)\%20\:--foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 123;
 }
 
-[\:--foo\%20\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-19-19-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 124;
 }
 
-[\:has\(\.foo\)\%20\%20\:--foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 125;
 }
 
-[\:--foo\%2B\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-19-19-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 126;
 }
 
-[\:has\(\.foo\)\%2B\:--foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 127;
 }
 
-[\:--foo\%20\%2B\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-19-19-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 128;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20\:--foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 129;
 }
 
-[\:--foo\~\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-19-19-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 130;
 }
 
-[\:has\(\.foo\)\~\:--foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 131;
 }
 
-[\:--foo\%20\~\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-19-19-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 132;
 }
 
-[\:has\(\.foo\)\%20\~\%20\:--foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 133;
 }
 
-[\:--foo\%3E\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-19-19-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 134;
 }
 
-[\:has\(\.foo\)\%3E\:--foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 135;
 }
 
-[\:--foo\%20\%3E\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-19-19-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 136;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20\:--foo]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 137;
 }
 
-:--foo, [\:has\(\.foo\)] {
+:--foo, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 138;
 }
 
-[\:has\(\.foo\)], :--foo {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], :--foo {
 	order: 139;
 }
 
-[\[foo\%3D\%22baz\%22\]\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 140;
 }
 
-[\:has\(\.foo\)\[foo\%3D\%22baz\%22\]]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 141;
 }
 
-[\[foo\%3D\%22baz\%22\]\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 142;
 }
 
-[\:has\(\.foo\)\%20\[foo\%3D\%22baz\%22\]]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 143;
 }
 
-[\[foo\%3D\%22baz\%22\]\%20\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 144;
 }
 
-[\:has\(\.foo\)\%20\%20\[foo\%3D\%22baz\%22\]]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 145;
 }
 
-[\[foo\%3D\%22baz\%22\]\%2B\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 146;
 }
 
-[\:has\(\.foo\)\%2B\[foo\%3D\%22baz\%22\]]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 147;
 }
 
-[\[foo\%3D\%22baz\%22\]\%20\%2B\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 148;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20\[foo\%3D\%22baz\%22\]]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 149;
 }
 
-[\[foo\%3D\%22baz\%22\]\~\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 150;
 }
 
-[\:has\(\.foo\)\~\[foo\%3D\%22baz\%22\]]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 151;
 }
 
-[\[foo\%3D\%22baz\%22\]\%20\~\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 152;
 }
 
-[\:has\(\.foo\)\%20\~\%20\[foo\%3D\%22baz\%22\]]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 153;
 }
 
-[\[foo\%3D\%22baz\%22\]\%3E\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 154;
 }
 
-[\:has\(\.foo\)\%3E\[foo\%3D\%22baz\%22\]]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 155;
 }
 
-[\[foo\%3D\%22baz\%22\]\%20\%3E\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 156;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20\[foo\%3D\%22baz\%22\]]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 157;
 }
 
-[foo="baz"], [\:has\(\.foo\)] {
+[foo="baz"], [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 158;
 }
 
-[\:has\(\.foo\)], [foo="baz"] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], [foo="baz"] {
 	order: 159;
 }
 
-[\*\:has\(\.foo\)] {
+[csstools-has-16-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 160;
 }
 
-[\:has\(\.foo\)\*] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-16] {
 	order: 161;
 }
 
-[\*\%20\:has\(\.foo\)] {
+[csstools-has-16-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 162;
 }
 
-[\:has\(\.foo\)\%20\*] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-16] {
 	order: 163;
 }
 
-[\*\%20\%20\:has\(\.foo\)] {
+[csstools-has-16-w-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 164;
 }
 
-[\:has\(\.foo\)\%20\%20\*] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-16] {
 	order: 165;
 }
 
-[\*\%2B\:has\(\.foo\)] {
+[csstools-has-16-17-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 166;
 }
 
-[\:has\(\.foo\)\%2B\*] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-16] {
 	order: 167;
 }
 
-[\*\%20\%2B\%20\:has\(\.foo\)] {
+[csstools-has-16-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 168;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20\*] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-16] {
 	order: 169;
 }
 
-[\*\~\:has\(\.foo\)] {
+[csstools-has-16-3i-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 170;
 }
 
-[\:has\(\.foo\)\~\*] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-16] {
 	order: 171;
 }
 
-[\*\%20\~\%20\:has\(\.foo\)] {
+[csstools-has-16-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 172;
 }
 
-[\:has\(\.foo\)\%20\~\%20\*] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-16] {
 	order: 173;
 }
 
-[\*\%3E\:has\(\.foo\)] {
+[csstools-has-16-1q-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 174;
 }
 
-[\:has\(\.foo\)\%3E\*] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-16] {
 	order: 175;
 }
 
-[\*\%20\%3E\%20\:has\(\.foo\)] {
+[csstools-has-16-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 176;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20\*] {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-16] {
 	order: 177;
 }
 
-*, [\:has\(\.foo\)] {
+*, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 178;
 }
 
-[\:has\(\.foo\)], * {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], * {
 	order: 179;
 }
 
-[\:hover\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-33-3a-2t-36-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 180;
 }
 
-[\:has\(\.foo\)\:hover]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 181;
 }
 
-[\:hover\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-33-3a-2t-36-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 182;
 }
 
-[\:has\(\.foo\)\%20\:hover]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 183;
 }
 
-[\:hover\%20\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-33-3a-2t-36-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 184;
 }
 
-[\:has\(\.foo\)\%20\%20\:hover]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 185;
 }
 
-[\:hover\%2B\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-33-3a-2t-36-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 186;
 }
 
-[\:has\(\.foo\)\%2B\:hover]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 187;
 }
 
-[\:hover\%20\%2B\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-33-3a-2t-36-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 188;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20\:hover]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 189;
 }
 
-[\:hover\~\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-33-3a-2t-36-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 190;
 }
 
-[\:has\(\.foo\)\~\:hover]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 191;
 }
 
-[\:hover\%20\~\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-33-3a-2t-36-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 192;
 }
 
-[\:has\(\.foo\)\%20\~\%20\:hover]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 193;
 }
 
-[\:hover\%3E\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-33-3a-2t-36-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 194;
 }
 
-[\:has\(\.foo\)\%3E\:hover]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 195;
 }
 
-[\:hover\%20\%3E\%20\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-2w-33-3a-2t-36-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 196;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20\:hover]:not(.does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 197;
 }
 
-:hover, [\:has\(\.foo\)] {
+:hover, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 198;
 }
 
-[\:has\(\.foo\)], :hover {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], :hover {
 	order: 199;
 }
 
-[\:\:before\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-1m-1m-2q-2t-2u-33-36-2t-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 200;
 }
 
-[\:has\(\.foo\)\:\:before]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
 	order: 201;
 }
 
-[\:\:before\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 202;
 }
 
-[\:has\(\.foo\)\%20\:\:before]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
 	order: 203;
 }
 
-[\:\:before\%20\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 204;
 }
 
-[\:has\(\.foo\)\%20\%20\:\:before]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
 	order: 205;
 }
 
-[\:\:before\%2B\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-1m-1m-2q-2t-2u-33-36-2t-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 206;
 }
 
-[\:has\(\.foo\)\%2B\:\:before]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
 	order: 207;
 }
 
-[\:\:before\%20\%2B\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 208;
 }
 
-[\:has\(\.foo\)\%20\%2B\%20\:\:before]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
 	order: 209;
 }
 
-[\:\:before\~\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-1m-1m-2q-2t-2u-33-36-2t-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 210;
 }
 
-[\:has\(\.foo\)\~\:\:before]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
 	order: 211;
 }
 
-[\:\:before\%20\~\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 212;
 }
 
-[\:has\(\.foo\)\%20\~\%20\:\:before]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
 	order: 213;
 }
 
-[\:\:before\%3E\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-1m-1m-2q-2t-2u-33-36-2t-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 214;
 }
 
-[\:has\(\.foo\)\%3E\:\:before]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
 	order: 215;
 }
 
-[\:\:before\%20\%3E\%20\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 216;
 }
 
-[\:has\(\.foo\)\%20\%3E\%20\:\:before]:not(does-not-exist) {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
 	order: 217;
 }
 
-::before, [\:has\(\.foo\)] {
+::before, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 218;
 }
 
-[\:has\(\.foo\)], ::before {
+[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], ::before {
 	order: 219;
 }
 
@@ -886,7 +886,7 @@ foo[baz=":has(.foo)"] {
 	order: 221;
 }
 
-[\:not\(\:has\(\.foo\)\)] {
+[csstools-has-1m-32-33-38-14-1m-2w-2p-37-14-1a-2u-33-33-15-15] {
 	order: 222;
 }
 
@@ -894,11 +894,11 @@ foo[baz=":has(.foo)"] {
 	order: 223;
 }
 
-[\:--\:has\(\.foo\)]:not(.does-not-exist) {
+[csstools-has-1m-19-19-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 224;
 }
 
-[__\:has\(\.foo\)]:not(does-not-exist) {
+[csstools-has-2n-2n-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 225;
 }
 

--- a/experimental/css-has-pseudo/test/plugin-order-logical.after.expect.css
+++ b/experimental/css-has-pseudo/test/plugin-order-logical.after.expect.css
@@ -1,6 +1,6 @@
-[\[dir\%3D\%22ltr\%22\]\%20a\:has\(\.b\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px
 }
-[\[dir\%3D\%22rtl\%22\]\%20a\:has\(\.b\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px
 }

--- a/experimental/css-has-pseudo/test/plugin-order-logical.after.preserve.expect.css
+++ b/experimental/css-has-pseudo/test/plugin-order-logical.after.preserve.expect.css
@@ -1,55 +1,55 @@
-[\[dir\%3D\%22ltr\%22\]\%20a\:has\(\.b\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px;
 }
 [dir="ltr"] a:has(.b) {
 	margin-left: 2px;
 }
-[a\:has\(\.b\)\:dir\(ltr\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-30-38-36-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px;
 }
 a:has(.b):dir(ltr) {
 	margin-left: 2px;
 }
-[\[dir\%3D\%22rtl\%22\]\%20a\:has\(\.b\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px;
 }
 [dir="rtl"] a:has(.b) {
 	margin-right: 2px;
 }
-[a\:has\(\.b\)\:dir\(rtl\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-36-38-30-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px;
 }
 a:has(.b):dir(rtl) {
 	margin-right: 2px;
 }
-[dir="ltr"] [a\:has\(\.b\)]:not(does-not-exist) {
+[dir="ltr"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-left: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist):dir(ltr) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
 	margin-left: 2px;
 }
-[dir="rtl"] [a\:has\(\.b\)]:not(does-not-exist) {
+[dir="rtl"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-right: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist):dir(rtl) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
 	margin-right: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-inline-start: 2px;
 }
-[dir="ltr"] [a\:has\(\.b\)]:not(does-not-exist) {
+[dir="ltr"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-left: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist):dir(ltr) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
 	margin-left: 2px;
 }
-[dir="rtl"] [a\:has\(\.b\)]:not(does-not-exist) {
+[dir="rtl"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-right: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist):dir(rtl) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
 	margin-right: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-inline-start: 2px;
 }
 a:has(.b) {

--- a/experimental/css-has-pseudo/test/plugin-order-logical.before.expect.css
+++ b/experimental/css-has-pseudo/test/plugin-order-logical.before.expect.css
@@ -1,6 +1,6 @@
-[\[dir\%3D\%22ltr\%22\]\%20a\:has\(\.b\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px
 }
-[\[dir\%3D\%22rtl\%22\]\%20a\:has\(\.b\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px
 }

--- a/experimental/css-has-pseudo/test/plugin-order-logical.before.preserve.expect.css
+++ b/experimental/css-has-pseudo/test/plugin-order-logical.before.preserve.expect.css
@@ -1,55 +1,55 @@
-[\[dir\%3D\%22ltr\%22\]\%20a\:has\(\.b\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px;
 }
 [dir="ltr"] a:has(.b) {
 	margin-left: 2px;
 }
-[a\:has\(\.b\)\:dir\(ltr\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-30-38-36-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px;
 }
 a:has(.b):dir(ltr) {
 	margin-left: 2px;
 }
-[\[dir\%3D\%22rtl\%22\]\%20a\:has\(\.b\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px;
 }
 [dir="rtl"] a:has(.b) {
 	margin-right: 2px;
 }
-[a\:has\(\.b\)\:dir\(rtl\)]:not(.does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-36-38-30-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px;
 }
 a:has(.b):dir(rtl) {
 	margin-right: 2px;
 }
-[dir="ltr"] [a\:has\(\.b\)]:not(does-not-exist) {
+[dir="ltr"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-left: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist):dir(ltr) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
 	margin-left: 2px;
 }
-[dir="rtl"] [a\:has\(\.b\)]:not(does-not-exist) {
+[dir="rtl"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-right: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist):dir(rtl) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
 	margin-right: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-inline-start: 2px;
 }
-[dir="ltr"] [a\:has\(\.b\)]:not(does-not-exist) {
+[dir="ltr"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-left: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist):dir(ltr) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
 	margin-left: 2px;
 }
-[dir="rtl"] [a\:has\(\.b\)]:not(does-not-exist) {
+[dir="rtl"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-right: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist):dir(rtl) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
 	margin-right: 2px;
 }
-[a\:has\(\.b\)]:not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-inline-start: 2px;
 }
 a:has(.b) {

--- a/experimental/css-has-pseudo/test/plugin-order-nesting.after.expect.css
+++ b/experimental/css-has-pseudo/test/plugin-order-nesting.after.expect.css
@@ -1,12 +1,12 @@
 
-	[a\:has\(\.b\)]:not(does-not-exist) {
+	[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 		order: 1;
 	}
 
-[a\:has\(\%3E\%20img\)\:focus]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
 		order: 2;
 	}
 
-[a\:has\(\%3E\%20img\)\%20\:has\(\%3E\%20\.some\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
 		order: 3;
 	}

--- a/experimental/css-has-pseudo/test/plugin-order-nesting.after.preserve.expect.css
+++ b/experimental/css-has-pseudo/test/plugin-order-nesting.after.preserve.expect.css
@@ -1,5 +1,5 @@
 
-	[a\:has\(\.b\)]:not(does-not-exist) {
+	[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 		order: 1;
 	}
 
@@ -7,7 +7,7 @@ a:has(.b) {
 		order: 1;
 	}
 
-[a\:has\(\%3E\%20img\)\:focus]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
 		order: 2;
 	}
 
@@ -15,7 +15,7 @@ a:has(> img):focus {
 		order: 2;
 	}
 
-[a\:has\(\%3E\%20img\)\%20\:has\(\%3E\%20\.some\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
 		order: 3;
 	}
 

--- a/experimental/css-has-pseudo/test/plugin-order-nesting.before.expect.css
+++ b/experimental/css-has-pseudo/test/plugin-order-nesting.before.expect.css
@@ -1,12 +1,12 @@
 
-	[a\:has\(\.b\)]:not(does-not-exist) {
+	[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 		order: 1;
 	}
 
-[a\:has\(\%3E\%20img\)\:focus]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
 		order: 2;
 	}
 
-[a\:has\(\%3E\%20img\)\%20\:has\(\%3E\%20\.some\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
 		order: 3;
 	}

--- a/experimental/css-has-pseudo/test/plugin-order-nesting.before.preserve.expect.css
+++ b/experimental/css-has-pseudo/test/plugin-order-nesting.before.preserve.expect.css
@@ -1,5 +1,5 @@
 
-	[a\:has\(\.b\)]:not(does-not-exist) {
+	[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 		order: 1;
 	}
 
@@ -7,7 +7,7 @@ a:has(.b) {
 		order: 1;
 	}
 
-[a\:has\(\%3E\%20img\)\:focus]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
 		order: 2;
 	}
 
@@ -15,7 +15,7 @@ a:has(> img):focus {
 		order: 2;
 	}
 
-[a\:has\(\%3E\%20img\)\%20\:has\(\%3E\%20\.some\)]:not(does-not-exist):not(does-not-exist) {
+[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
 		order: 3;
 	}
 


### PR DESCRIPTION
Uses base36 encoding with `-` as a separator. This results in a smaller file size than base36 with fixed length chunks.

There is no limit to what can be encoded this way aside from browser support for the characters being encoded.

`csstools-has-` prefix is added because we need something we can detect.