### PR TITLE
fix selector order in pseudo :is

### DIFF
--- a/plugins/postcss-is-pseudo-class/.tape.mjs
+++ b/plugins/postcss-is-pseudo-class/.tape.mjs
@@ -19,7 +19,7 @@ postcssTape(plugin)({
 	},
 	'basic:oncomplex:warning': {
 		message: "supports basic usage with { onComplexSelector: 'warning' }",
-		warnings: 11,
+		warnings: 10,
 		options: {
 			onComplexSelector: 'warning'
 		}

--- a/plugins/postcss-is-pseudo-class/CHANGELOG.md
+++ b/plugins/postcss-is-pseudo-class/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to PostCSS Is Pseudo Class
 
+### Unreleased (patch)
+
+- Preserve selector order as much as possible. Fixes issues where pseudo elements `::before` were moved.
+
 ### 2.0.0 (January 31, 2022)
 
 - Remove `skip` flag in `onComplexSelectors` option.

--- a/plugins/postcss-is-pseudo-class/src/split-selectors/compound-selector-order.ts
+++ b/plugins/postcss-is-pseudo-class/src/split-selectors/compound-selector-order.ts
@@ -39,10 +39,7 @@ export function sortCompoundSelector(node) {
 	if (!node || !node.nodes) {
 		return;
 	}
-	// compound selectors with nesting can be written with tag selectors as later parts.
-	// for example : `&h1`
-	//
-	// simply concating with parent selectors can lead to :
+	// simply concatenating with selectors can lead to :
 	// `.fooh1`
 	//
 	// applying a sort where tag selectors are first will result in :
@@ -92,14 +89,6 @@ export function sortCompoundSelector(node) {
 		}
 
 		if (a.type === b.type) {
-			if (a.value < b.value) {
-				return -1;
-			}
-
-			if (a.value > b.value) {
-				return 1;
-			}
-
 			return 0;
 		}
 

--- a/plugins/postcss-is-pseudo-class/test/basic.css
+++ b/plugins/postcss-is-pseudo-class/test/basic.css
@@ -93,3 +93,11 @@ foo[baz=":is(.some, .other)"], .ok {
 .invalid-is:is {
 	order: 24;
 }
+
+:is(a, button):is(:hover::before, :focus) {
+	order: 25;
+}
+
+:is(a, button):is(:hover, :focus)::before {
+	order: 26;
+}

--- a/plugins/postcss-is-pseudo-class/test/basic.does-not-exist.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/basic.does-not-exist.expect.css
@@ -214,7 +214,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 14;
 }
 
-:focus:is(.alpha ~ .delta) > .beta + .beta {
+:is(.alpha ~ .delta):focus > .beta + .beta {
 	order: 15;
 }
 
@@ -266,7 +266,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 19;
 }
 
-.alpha.pre:is(.one > .two) {
+.pre.alpha:is(.one > .two) {
 	order: 20;
 }
 
@@ -292,4 +292,36 @@ a:not(.something-random) {
 
 .invalid-is:is {
 	order: 24;
+}
+
+a:hover::before {
+	order: 25;
+}
+
+a:focus:not(something-random) {
+	order: 25;
+}
+
+button:hover::before {
+	order: 25;
+}
+
+button:focus:not(something-random) {
+	order: 25;
+}
+
+a:hover::before {
+	order: 26;
+}
+
+a:focus::before {
+	order: 26;
+}
+
+button:hover::before {
+	order: 26;
+}
+
+button:focus::before {
+	order: 26;
 }

--- a/plugins/postcss-is-pseudo-class/test/basic.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/basic.expect.css
@@ -214,7 +214,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 14;
 }
 
-:focus:is(.alpha ~ .delta) > .beta + .beta {
+:is(.alpha ~ .delta):focus > .beta + .beta {
 	order: 15;
 }
 
@@ -266,7 +266,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 19;
 }
 
-.alpha.pre:is(.one > .two) {
+.pre.alpha:is(.one > .two) {
 	order: 20;
 }
 
@@ -292,4 +292,36 @@ a:not(.does-not-exist) {
 
 .invalid-is:is {
 	order: 24;
+}
+
+a:hover::before {
+	order: 25;
+}
+
+a:focus:not(does-not-exist) {
+	order: 25;
+}
+
+button:hover::before {
+	order: 25;
+}
+
+button:focus:not(does-not-exist) {
+	order: 25;
+}
+
+a:hover::before {
+	order: 26;
+}
+
+a:focus::before {
+	order: 26;
+}
+
+button:hover::before {
+	order: 26;
+}
+
+button:focus::before {
+	order: 26;
 }

--- a/plugins/postcss-is-pseudo-class/test/basic.oncomplex.warning.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/basic.oncomplex.warning.expect.css
@@ -214,7 +214,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 14;
 }
 
-:focus:is(.alpha ~ .delta) > .beta + .beta {
+:is(.alpha ~ .delta):focus > .beta + .beta {
 	order: 15;
 }
 
@@ -266,7 +266,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 19;
 }
 
-.alpha.pre:is(.one > .two) {
+.pre.alpha:is(.one > .two) {
 	order: 20;
 }
 
@@ -292,4 +292,36 @@ a:not(.does-not-exist) {
 
 .invalid-is:is {
 	order: 24;
+}
+
+a:hover::before {
+	order: 25;
+}
+
+a:focus:not(does-not-exist) {
+	order: 25;
+}
+
+button:hover::before {
+	order: 25;
+}
+
+button:focus:not(does-not-exist) {
+	order: 25;
+}
+
+a:hover::before {
+	order: 26;
+}
+
+a:focus::before {
+	order: 26;
+}
+
+button:hover::before {
+	order: 26;
+}
+
+button:focus::before {
+	order: 26;
 }

--- a/plugins/postcss-is-pseudo-class/test/basic.preserve.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/basic.preserve.expect.css
@@ -254,7 +254,7 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 14;
 }
 
-:focus:is(.alpha ~ .delta) > .beta + .beta {
+:is(.alpha ~ .delta):focus > .beta + .beta {
 	order: 15;
 }
 
@@ -322,10 +322,6 @@ foo[baz=":is(.some, .other)"], .ok {
 	order: 19;
 }
 
-.alpha.pre:is(.one > .two) {
-	order: 20;
-}
-
 .pre.alpha:is(.one > .two) {
 	order: 20;
 }
@@ -360,4 +356,44 @@ a:not(.does-not-exist) {
 
 .invalid-is:is {
 	order: 24;
+}
+
+a:hover::before {
+	order: 25;
+}
+
+a:focus:not(does-not-exist) {
+	order: 25;
+}
+
+button:hover::before {
+	order: 25;
+}
+
+button:focus:not(does-not-exist) {
+	order: 25;
+}
+
+:is(a, button):is(:hover::before, :focus) {
+	order: 25;
+}
+
+a:hover::before {
+	order: 26;
+}
+
+a:focus::before {
+	order: 26;
+}
+
+button:hover::before {
+	order: 26;
+}
+
+button:focus::before {
+	order: 26;
+}
+
+:is(a, button):is(:hover, :focus)::before {
+	order: 26;
 }

--- a/plugins/postcss-is-pseudo-class/test/generated-selector-class-function-cases.expect.css
+++ b/plugins/postcss-is-pseudo-class/test/generated-selector-class-function-cases.expect.css
@@ -2,6 +2,10 @@
 	order: 0;
 }
 
+.some.other {
+	order: 0;
+}
+
 .other.some {
 	order: 0;
 }
@@ -18,6 +22,10 @@
 	order: 1;
 }
 
+.some.other {
+	order: 1;
+}
+
 .other.some {
 	order: 1;
 }
@@ -31,6 +39,10 @@
 }
 
 .some.some {
+	order: 2;
+}
+
+.some.other {
 	order: 2;
 }
 
@@ -890,11 +902,11 @@ button {
 	order: 59;
 }
 
-.some.🧑🏾‍🎤 {
+.🧑🏾‍🎤.some {
 	order: 60;
 }
 
-.other.🧑🏾‍🎤 {
+.🧑🏾‍🎤.other {
 	order: 60;
 }
 
@@ -1230,11 +1242,11 @@ button {
 	order: 90;
 }
 
-.foo.some {
+.some.foo {
 	order: 91;
 }
 
-.foo.other {
+.other.foo {
 	order: 91;
 }
 

--- a/plugins/postcss-nesting/src/lib/merge-selectors/compound-selector-order.js
+++ b/plugins/postcss-nesting/src/lib/merge-selectors/compound-selector-order.js
@@ -50,10 +50,7 @@ export function sortCompoundSelectorsInsideComplexSelector(node, wrapWithIsPseud
 }
 
 export function sortCompoundSelector(node) {
-	// compound selectors with nesting can be written with tag selectors as later parts.
-	// for example : `&h1`
-	//
-	// simply concating with parent selectors can lead to :
+	// simply concatenating with selectors can lead to :
 	// `.fooh1`
 	//
 	// applying a sort where tag selectors are first will result in :

--- a/plugins/postcss-nesting/test/basic.css
+++ b/plugins/postcss-nesting/test/basic.css
@@ -109,3 +109,9 @@ a {
 		}
 	}
 }
+
+.a:hover, .b:focus {
+	&::before, &::after {
+		order: 51;
+	}
+}

--- a/plugins/postcss-nesting/test/basic.expect.css
+++ b/plugins/postcss-nesting/test/basic.expect.css
@@ -124,3 +124,7 @@ a b[a="a&b"] {
 .a.c:before, .b.c:before, .a.d:before, .b.d:before {
 			order: 41;
 		}
+
+.a:hover::before, .b:focus::before, .a:hover::after, .b:focus::after {
+		order: 51;
+	}

--- a/plugins/postcss-nesting/test/basic.no-is-pseudo-selector.expect.css
+++ b/plugins/postcss-nesting/test/basic.no-is-pseudo-selector.expect.css
@@ -124,3 +124,7 @@ a b[a="a&b"] {
 .a.c:before, .b.c:before, .a.d:before, .b.d:before {
 			order: 41;
 		}
+
+.a:hover::before, .b:focus::before, .a:hover::after, .b:focus::after {
+		order: 51;
+	}

--- a/plugins/postcss-pseudo-class-any-link/src/compound-selector-order.js
+++ b/plugins/postcss-pseudo-class-any-link/src/compound-selector-order.js
@@ -39,10 +39,7 @@ export function sortCompoundSelector(node) {
 	if (!node || !node.nodes) {
 		return;
 	}
-	// compound selectors with nesting can be written with tag selectors as later parts.
-	// for example : `&h1`
-	//
-	// simply concating with parent selectors can lead to :
+	// simply concatenating with selectors can lead to :
 	// `.fooh1`
 	//
 	// applying a sort where tag selectors are first will result in :


### PR DESCRIPTION
Pseudo elements ordering appears important : https://github.com/w3c/csswg-drafts/issues/7085#issue-1149016131

With re-ordering in compound selectors we broke this in `:is()`

-----

Before this change : 

```css
:is(a, button):is(:hover::before, :focus) {
	order: 25;
}

/* becomes */

button::before:hover {
	order: 26;
}
```

After this change :

```css
:is(a, button):is(:hover::before, :focus) {
	order: 25;
}

/* becomes */

button:hover::before {
	order: 26;
}
```

Also added a test in nesting to prevent introducing the same bug in the future and clarified a few comments.