### PR TITLE
add deprecation notices

### DIFF
--- a/plugin-packs/postcss-preset-env/.tape.mjs
+++ b/plugin-packs/postcss-preset-env/.tape.mjs
@@ -363,6 +363,7 @@ postcssTape(plugin)({
 	},
 	'import': {
 		message: 'supports { importFrom: { customMedia, customProperties, customSelectors, environmentVariables } } usage',
+		warnings: 2,
 		options: {
 			importFrom: {
 				customMedia: {
@@ -383,6 +384,7 @@ postcssTape(plugin)({
 	},
 	'import:ch87': {
 		message: 'supports { browsers: "chrome >= 87", importFrom: { customMedia, customProperties, customSelectors, environmentVariables } } usage',
+		warnings: 2,
 		options: {
 			browsers: 'chrome >= 87',
 			importFrom: {
@@ -404,6 +406,7 @@ postcssTape(plugin)({
 	},
 	'import:ch87:array': {
 		message: 'supports { browsers: "chrome >= 87", importFrom: [{ customMedia, customProperties, customSelectors, environmentVariables }] } usage',
+		warnings: 2,
 		options: {
 			browsers: 'chrome >= 87',
 			importFrom: [{
@@ -433,6 +436,7 @@ postcssTape(plugin)({
 	},
 	'basic:export': {
 		message: 'supports { stage: 0 } usage',
+		warnings: 1,
 		options: {
 			stage: 0,
 			exportTo: [

--- a/plugins/postcss-custom-properties/.tape.cjs
+++ b/plugins/postcss-custom-properties/.tape.cjs
@@ -4,6 +4,7 @@ const plugin = require('postcss-custom-properties');
 postcssTape(plugin)({
 	'basic:import-cjs': {
 		message: 'supports { importFrom: "test/import-properties{-2}?.cjs" } usage',
+		warnings: 1,
 		options: {
 			importFrom: [
 				'test/import-properties.cjs',
@@ -15,6 +16,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-css-js': {
 		message: 'supports { importFrom: "test/import-properties{-2}?.{css|js}" } usage',
+		warnings: 1,
 		options: {
 			importFrom: [
 				'test/import-properties.js',

--- a/plugins/postcss-custom-properties/.tape.mjs
+++ b/plugins/postcss-custom-properties/.tape.mjs
@@ -16,6 +16,7 @@ postcssTape(plugin)({
 	},
 	'basic:import': {
 		message: 'supports { importFrom: { customProperties: { ... } } } usage',
+		warnings: 1,
 		options: {
 			importFrom: {
 				customProperties: {
@@ -30,6 +31,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-fn': {
 		message: 'supports { importFrom() } usage',
+		warnings: 1,
 		options: {
 			importFrom() {
 				return {
@@ -48,6 +50,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-fn-promise': {
 		message: 'supports { async importFrom() } usage',
+		warnings: 1,
 		options: {
 			importFrom() {
 				return new Promise(resolve => {
@@ -67,6 +70,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-json': {
 		message: 'supports { importFrom: "test/import-properties.json" } usage',
+		warnings: 1,
 		options: {
 			importFrom: 'test/import-properties.json'
 		},
@@ -75,6 +79,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-cjs': {
 		message: 'supports { importFrom: "test/import-properties{-2}?.cjs" } usage',
+		warnings: 1,
 		options: {
 			importFrom: [
 				'test/import-properties.cjs',
@@ -86,6 +91,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-mjs': {
 		message: 'supports { importFrom: "test/import-properties{-2}?.mjs" } usage',
+		warnings: 1,
 		options: {
 			importFrom: [
 				'test/import-properties.mjs',
@@ -97,6 +103,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-css': {
 		message: 'supports { importFrom: "test/import-properties{-2}?.css" } usage',
+		warnings: 1,
 		options: {
 			importFrom: [
 				'test/import-properties.css',
@@ -108,6 +115,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-css-js': {
 		message: 'supports { importFrom: "test/import-properties{-2}?.{css|js}" } usage',
+		warnings: 1,
 		options: {
 			importFrom: [
 				'test/import-properties.js',
@@ -119,6 +127,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-css-pcss': {
 		message: 'supports { importFrom: "test/import-properties.{p}?css" } usage',
+		warnings: 1,
 		options: {
 			importFrom: [
 				'test/import-properties.pcss',
@@ -130,6 +139,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-css-from': {
 		message: 'supports { importFrom: { from: "test/import-properties.css" } } usage',
+		warnings: 1,
 		options: {
 			importFrom: [
 				{ from: 'test/import-properties.css' },
@@ -141,6 +151,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-css-from-type': {
 		message: 'supports { importFrom: [ { from: "test/import-properties.css", type: "css" } ] } usage',
+		warnings: 1,
 		options: {
 			importFrom: [
 				{ from: 'test/import-properties.css', type: 'css' },
@@ -152,6 +163,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-override': {
 		message: 'importFrom with { preserve: false } should override root properties',
+		warnings: 1,
 		options: {
 			preserve: false,
 			importFrom: {
@@ -170,6 +182,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-override:inverse': {
 		message: 'importFrom with { preserve: false, overrideImportFromWithRoot: true  } should override importFrom properties',
+		warnings: 1,
 		options: {
 			preserve: false,
 			overrideImportFromWithRoot: true,
@@ -189,6 +202,7 @@ postcssTape(plugin)({
 	},
 	'basic:export': {
 		message: 'supports { exportTo: { customProperties: { ... } } } usage',
+		warnings: 1,
 		options: {
 			exportTo: (global.__exportPropertiesObject = global.__exportPropertiesObject || {
 				customProperties: null
@@ -204,6 +218,7 @@ postcssTape(plugin)({
 	},
 	'basic:export-fn': {
 		message: 'supports { exportTo() } usage',
+		warnings: 1,
 		options: {
 			exportTo(customProperties) {
 				if (customProperties['--color'] !== 'rgb(255, 0, 0)') {
@@ -216,6 +231,7 @@ postcssTape(plugin)({
 	},
 	'basic:export-fn-promise': {
 		message: 'supports { async exportTo() } usage',
+		warnings: 1,
 		options: {
 			exportTo(customProperties) {
 				return new Promise((resolve, reject) => {
@@ -232,6 +248,7 @@ postcssTape(plugin)({
 	},
 	'basic:export-scss': {
 		message: 'supports { exportTo: "test/export-properties.scss" } usage',
+		warnings: 1,
 		options: {
 			exportTo: 'test/export-properties.scss'
 		},
@@ -251,6 +268,7 @@ postcssTape(plugin)({
 	},
 	'basic:export-json': {
 		message: 'supports { exportTo: "test/export-properties.json" } usage',
+		warnings: 1,
 		options: {
 			exportTo: 'test/export-properties.json'
 		},
@@ -270,6 +288,7 @@ postcssTape(plugin)({
 	},
 	'basic:export-js': {
 		message: 'supports { exportTo: "test/export-properties.js" } usage',
+		warnings: 1,
 		options: {
 			exportTo: 'test/export-properties.js'
 		},
@@ -289,6 +308,7 @@ postcssTape(plugin)({
 	},
 	'basic:export-mjs': {
 		message: 'supports { exportTo: "test/export-properties.mjs" } usage',
+		warnings: 1,
 		options: {
 			exportTo: 'test/export-properties.mjs'
 		},
@@ -308,6 +328,7 @@ postcssTape(plugin)({
 	},
 	'basic:export-css': {
 		message: 'supports { exportTo: "test/export-properties.css" } usage',
+		warnings: 1,
 		options: {
 			exportTo: 'test/export-properties.css'
 		},
@@ -327,6 +348,7 @@ postcssTape(plugin)({
 	},
 	'basic:export-css-to': {
 		message: 'supports { exportTo: { to: "test/export-properties.css" } } usage',
+		warnings: 1,
 		options: {
 			exportTo: { to: 'test/export-properties.css' }
 		},
@@ -346,6 +368,7 @@ postcssTape(plugin)({
 	},
 	'basic:export-css-to-type': {
 		message: 'supports { exportTo: { to: "test/export-properties.css", type: "css" } } usage',
+		warnings: 1,
 		options: {
 			exportTo: { to: 'test/export-properties.css', type: 'css' }
 		},
@@ -366,7 +389,8 @@ postcssTape(plugin)({
 	'basic:import-is-empty': {
 		message: 'supports { importFrom: {} } usage',
 		options: {
-			importFrom: {}
+			importFrom: {},
+			disableDeprecationNotice: true
 		}
 	},
 	'import': {

--- a/plugins/postcss-custom-properties/CHANGELOG.md
+++ b/plugins/postcss-custom-properties/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to PostCSS Custom Properties
 
+### Unreleased (patch)
+
+- Add deprecation notice for `importFrom` and `exportTo`
+
+[see the discussion](https://github.com/csstools/postcss-plugins/discussions/192)
+
 ### 12.1.4 (January 31, 2022)
 
 - Fix `.mjs` in `importFrom` when using `export default`

--- a/plugins/postcss-custom-properties/README.md
+++ b/plugins/postcss-custom-properties/README.md
@@ -187,6 +187,13 @@ See example exports written to [CSS](test/export-properties.css),
 [JS](test/export-properties.js), [MJS](test/export-properties.mjs),
 [JSON](test/export-properties.json) and [SCSS](test/export-properties.scss).
 
+### disableDeprecationNotice
+
+Silence the deprecation notice that is printed to the console when using `importFrom` or `exportTo`.
+
+> "importFrom" and "exportTo" will be removed in a future version of postcss-custom-properties.
+> Check the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192
+
 [cli-img]: https://github.com/csstools/postcss-plugins/actions/workflows/test.yml/badge.svg
 [cli-url]: https://github.com/csstools/postcss-plugins/actions/workflows/test.yml?query=workflow/test
 [css-img]: https://cssdb.org/images/badges/custom-properties.svg

--- a/plugins/postcss-custom-properties/src/index.ts
+++ b/plugins/postcss-custom-properties/src/index.ts
@@ -91,7 +91,7 @@ const creator: PluginCreator<PluginOptions> = (opts?: PluginOptions) => {
 					},
 					OnceExit: (root, { result }) => {
 						if (!disableDeprecationNotice && (importFrom.length > 0 || exportTo.length > 0)) {
-							root.warn(result, '"importFrom" and "exportTo" will be removed in a future version of postcss-custom-properties.\nCheck the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192');
+							root.warn(result, '"importFrom" and "exportTo" will be removed in a future version of postcss-custom-properties.\nWe are looking for insights and anecdotes on how these features are used so that we can design the best alternative.\nPlease let us know if our proposal will work for you.\nVisit the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192');
 						}
 
 						customProperties.clear();

--- a/plugins/postcss-env-function/.tape.cjs
+++ b/plugins/postcss-env-function/.tape.cjs
@@ -8,6 +8,7 @@ postcssTape(plugin)({
 	'basic:import': {
 		message: 'supports { importFrom: { environmentVariables: { ... } } } usage',
 		options: {
+			disableDeprecationNotice: true,
 			importFrom: {
 				environmentVariables: {
 					'--some-custom-padding': '20px',
@@ -18,6 +19,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-fn': {
 		message: 'supports { importFrom() } usage',
+		warnings: 1,
 		options: {
 			importFrom() {
 				return {
@@ -33,6 +35,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-fn-promise': {
 		message: 'supports { async importFrom() } usage',
+		warnings: 1,
 		options: {
 			importFrom() {
 				return new Promise(resolve => {
@@ -50,6 +53,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-json': {
 		message: 'supports { importFrom: "test/import-variables.json" } usage',
+		warnings: 1,
 		options: {
 			importFrom: 'test/import-variables.json'
 		},
@@ -58,6 +62,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-js': {
 		message: 'supports { importFrom: "test/import-variables.js" } usage',
+		warnings: 1,
 		options: {
 			importFrom: 'test/import-variables.js'
 		},
@@ -66,6 +71,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-cjs': {
 		message: 'supports { importFrom: "test/import-variables.cjs" } usage',
+		warnings: 1,
 		options: {
 			importFrom: 'test/import-variables.cjs'
 		},
@@ -74,6 +80,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-js-from': {
 		message: 'supports { importFrom: { from: "test/import-variables.js" } } usage',
+		warnings: 1,
 		options: {
 			importFrom: { from: 'test/import-variables.js' }
 		},
@@ -82,6 +89,7 @@ postcssTape(plugin)({
 	},
 	'basic:import-js-from-type': {
 		message: 'supports { importFrom: [ { from: "test/import-variables.js", type: "js" } ] } usage',
+		warnings: 1,
 		options: {
 			importFrom: [ { from: 'test/import-variables.js', type: 'js' } ]
 		},

--- a/plugins/postcss-env-function/CHANGELOG.md
+++ b/plugins/postcss-env-function/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to PostCSS Environment Variables
 
+### Unreleased (patch)
+
+- Add deprecation notice for `postcss-env-function`
+
+[see the discussion](https://github.com/csstools/postcss-plugins/discussions/192)
+
 ### 4.0.5 (February 5, 2022)
 
 - Improved `es module` and `commonjs` compatibility

--- a/plugins/postcss-env-function/README.md
+++ b/plugins/postcss-env-function/README.md
@@ -133,7 +133,7 @@ Not all valid [declaration value names] are accepted.
 
 Silence the deprecation notice that is printed to the console when using `importFrom``.
 
-> "importFrom" will be removed in a future version of postcss-env-function.
+> postcss-env-function is deprecated and will be removed.
 > Check the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192
 
 [cli-url]: https://github.com/csstools/postcss-plugins/actions/workflows/test.yml?query=workflow/test

--- a/plugins/postcss-env-function/README.md
+++ b/plugins/postcss-env-function/README.md
@@ -129,6 +129,13 @@ See example imports written in [JS](test/import-variables.js) and [JSON](test/im
 Currently only valid [custom property names] (beginning with `--`) are accepted.
 Not all valid [declaration value names] are accepted.
 
+### disableDeprecationNotice
+
+Silence the deprecation notice that is printed to the console when using `importFrom``.
+
+> "importFrom" will be removed in a future version of postcss-env-function.
+> Check the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192
+
 [cli-url]: https://github.com/csstools/postcss-plugins/actions/workflows/test.yml?query=workflow/test
 [css-url]: https://cssdb.org/#environment-variables
 [discord]: https://discord.gg/bUadyRwkJS

--- a/plugins/postcss-env-function/src/index.js
+++ b/plugins/postcss-env-function/src/index.js
@@ -62,7 +62,7 @@ export default function creator(opts) {
 
 				if (!disableDeprecationNotice && !didWarn) {
 					didWarn = true;
-					decl.warn(result, 'postcss-env-function is deprecated and will be removed.\nCheck the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192');
+					decl.warn(result, 'postcss-env-function is deprecated and will be removed.\nWe are looking for insights and anecdotes on how these features are used so that we can design the best alternative.\nPlease let us know if our proposal will work for you.\nVisit the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192');
 				}
 			}
 		},

--- a/plugins/postcss-env-function/src/index.js
+++ b/plugins/postcss-env-function/src/index.js
@@ -11,6 +11,8 @@ export default function creator(opts) {
 
 	// promise any environment variables are imported
 	const environmentVariablesPromise = importEnvironmentVariablesFromSources(importFrom);
+	const disableDeprecationNotice = 'disableDeprecationNotice' in Object(opts) ? Boolean(opts.disableDeprecationNotice) : false;
+	let didWarn = false;
 
 	return {
 		postcssPlugin: 'postcss-env-fn',
@@ -32,6 +34,11 @@ export default function creator(opts) {
 
 			if (replacedValue !== atRule.params) {
 				atRule.params = replacedValue;
+
+				if (!disableDeprecationNotice && !didWarn) {
+					didWarn= true;
+					atRule.warn(result, 'postcss-env-function is deprecated and will be removed.\nCheck the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192');
+				}
 			}
 		},
 		async Declaration(decl, { result }) {
@@ -52,6 +59,11 @@ export default function creator(opts) {
 
 			if (replacedValue !== decl.value) {
 				decl.value = replacedValue;
+
+				if (!disableDeprecationNotice && !didWarn) {
+					didWarn = true;
+					decl.warn(result, 'postcss-env-function is deprecated and will be removed.\nCheck the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192');
+				}
 			}
 		},
 	};


### PR DESCRIPTION
see : https://github.com/csstools/postcss-plugins/discussions/192

- `postcss-env-function` is fully deprecated. It might come back in a different form in the future, but at the moment there is no spec for author defined values here.
- `postcss-custom-properties` only has deprecation warnings when using `importFrom` or `exportTo`.

_custom media and custom selectors are not housed in this repo._
