### PR TITLE
postcss-tape : update error message for broken source maps

### DIFF
--- a/packages/postcss-tape/src/index.ts
+++ b/packages/postcss-tape/src/index.ts
@@ -266,7 +266,7 @@ export default function runner(currentPlugin: PluginCreator<unknown>) {
 				} catch (err) {
 					hasErrors = true;
 
-					const helpText = '\nThis is most likely a newly created PostCSS AST Node without a value for "source".\nsee : https://postcss.org/api/#node-source';
+					const helpText = '\nThis is most likely a newly created PostCSS AST Node without a value for "source".\nsee :\n- https://github.com/postcss/postcss/blob/main/docs/guidelines/plugin.md#24-set-nodesource-for-new-nodes\n- https://postcss.org/api/#node-source';
 					if (emitGitHubAnnotations) {
 						console.log(formatGitHubActionAnnotation(
 							`${testCaseLabel}\n\nbroken source map: ${JSON.stringify(result.map.toJSON().sources)}\n${helpText}`,

--- a/packages/postcss-tape/src/index.ts
+++ b/packages/postcss-tape/src/index.ts
@@ -266,15 +266,16 @@ export default function runner(currentPlugin: PluginCreator<unknown>) {
 				} catch (err) {
 					hasErrors = true;
 
+					const helpText = '\nThis is most likely a newly created PostCSS AST Node without setting a value for "source".\nsee : https://postcss.org/api/#node-source';
 					if (emitGitHubAnnotations) {
 						console.log(formatGitHubActionAnnotation(
-							`${testCaseLabel}\n\nbroken source map: ${JSON.stringify(result.map.toJSON().sources)}`,
+							`${testCaseLabel}\n\nbroken source map: ${JSON.stringify(result.map.toJSON().sources)}\n${helpText}`,
 							'error',
 							{ file: testFilePath, line: 1, col: 1 },
 						));
 					} else {
 						failureSummary.add(testCaseLabel);
-						console.error(`\n${testCaseLabel}\n\nbroken source map: ${JSON.stringify(result.map.toJSON().sources)}\n\n${dashesSeparator}`);
+						console.error(`\n${testCaseLabel}\n\nbroken source map: ${JSON.stringify(result.map.toJSON().sources)}\n${helpText}\n\n${dashesSeparator}`);
 					}
 				}
 			}

--- a/packages/postcss-tape/src/index.ts
+++ b/packages/postcss-tape/src/index.ts
@@ -266,7 +266,7 @@ export default function runner(currentPlugin: PluginCreator<unknown>) {
 				} catch (err) {
 					hasErrors = true;
 
-					const helpText = '\nThis is most likely a newly created PostCSS AST Node without setting a value for "source".\nsee : https://postcss.org/api/#node-source';
+					const helpText = '\nThis is most likely a newly created PostCSS AST Node without a value for "source".\nsee : https://postcss.org/api/#node-source';
 					if (emitGitHubAnnotations) {
 						console.log(formatGitHubActionAnnotation(
 							`${testCaseLabel}\n\nbroken source map: ${JSON.stringify(result.map.toJSON().sources)}\n${helpText}`,

--- a/packages/postcss-tape/test-self/basic.broken-sourcemap.expect.log
+++ b/packages/postcss-tape/test-self/basic.broken-sourcemap.expect.log
@@ -3,7 +3,7 @@ basic:broken-sourcemap
 
 broken source map: ["basic.css","<no source>"]
 
-This is most likely a newly created PostCSS AST Node without setting a value for "source".
+This is most likely a newly created PostCSS AST Node without a value for "source".
 see : https://postcss.org/api/#node-source
 
 ----------------------------------------

--- a/packages/postcss-tape/test-self/basic.broken-sourcemap.expect.log
+++ b/packages/postcss-tape/test-self/basic.broken-sourcemap.expect.log
@@ -4,7 +4,9 @@ basic:broken-sourcemap
 broken source map: ["basic.css","<no source>"]
 
 This is most likely a newly created PostCSS AST Node without a value for "source".
-see : https://postcss.org/api/#node-source
+see :
+- https://github.com/postcss/postcss/blob/main/docs/guidelines/plugin.md#24-set-nodesource-for-new-nodes
+- https://postcss.org/api/#node-source
 
 ----------------------------------------
 

--- a/packages/postcss-tape/test-self/basic.broken-sourcemap.expect.log
+++ b/packages/postcss-tape/test-self/basic.broken-sourcemap.expect.log
@@ -3,6 +3,9 @@ basic:broken-sourcemap
 
 broken source map: ["basic.css","<no source>"]
 
+This is most likely a newly created PostCSS AST Node without setting a value for "source".
+see : https://postcss.org/api/#node-source
+
 ----------------------------------------
 
 unexpected failures:


### PR DESCRIPTION
```

basic:broken-sourcemap

broken source map: ["basic.css","<no source>"]

This is most likely a newly created PostCSS AST Node without a value for "source".
see :
- https://github.com/postcss/postcss/blob/main/docs/guidelines/plugin.md#24-set-nodesource-for-new-nodes
- https://postcss.org/api/#node-source

----------------------------------------

unexpected failures:
  - basic:broken-sourcemap

```