### PR TITLE
fix #329

### DIFF
--- a/plugins/postcss-custom-properties/CHANGELOG.md
+++ b/plugins/postcss-custom-properties/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to PostCSS Custom Properties
 
+### Unreleased (patch)
+
+- Fix `var()` fallback value downgrades with value lists.
+
 ### 12.1.5 (March 19, 2022)
 
 - Add deprecation notice for `importFrom` and `exportTo`

--- a/plugins/postcss-custom-properties/src/lib/transform-value-ast.ts
+++ b/plugins/postcss-custom-properties/src/lib/transform-value-ast.ts
@@ -19,7 +19,7 @@ export default function transformValueAST(root, customProperties) {
 				} else if (fallbacks.length) {
 					// No match, but fallback available
 					if (index > -1) {
-						root.nodes.splice(index, 1, ...fallbacks);
+						root.nodes.splice(index, 1, ...child.nodes.slice(child.nodes.indexOf(fallbacks[0])));
 					}
 
 					transformValueAST(root, customProperties);

--- a/plugins/postcss-custom-properties/test/basic.css
+++ b/plugins/postcss-custom-properties/test/basic.css
@@ -134,3 +134,7 @@ html {
 .test-unicode {
 	color: var(--✅-size);
 }
+
+.test {
+	font-family: var(--font, "Helvetica Neue", Arial, sans-serif);
+}

--- a/plugins/postcss-custom-properties/test/basic.expect.css
+++ b/plugins/postcss-custom-properties/test/basic.expect.css
@@ -154,3 +154,8 @@ html {
 	color: 2em;
 	color: var(--✅-size);
 }
+
+.test {
+	font-family: "Helvetica Neue", Arial, sans-serif;
+	font-family: var(--font, "Helvetica Neue", Arial, sans-serif);
+}

--- a/plugins/postcss-custom-properties/test/basic.import-is-empty.expect.css
+++ b/plugins/postcss-custom-properties/test/basic.import-is-empty.expect.css
@@ -154,3 +154,8 @@ html {
 	color: 2em;
 	color: var(--✅-size);
 }
+
+.test {
+	font-family: "Helvetica Neue", Arial, sans-serif;
+	font-family: var(--font, "Helvetica Neue", Arial, sans-serif);
+}

--- a/plugins/postcss-custom-properties/test/basic.import-override.expect.css
+++ b/plugins/postcss-custom-properties/test/basic.import-override.expect.css
@@ -105,3 +105,7 @@
 .test-unicode {
 	color: 2em;
 }
+
+.test {
+	font-family: "Helvetica Neue", Arial, sans-serif;
+}

--- a/plugins/postcss-custom-properties/test/basic.import-override.inverse.expect.css
+++ b/plugins/postcss-custom-properties/test/basic.import-override.inverse.expect.css
@@ -105,3 +105,7 @@
 .test-unicode {
 	color: 2em;
 }
+
+.test {
+	font-family: "Helvetica Neue", Arial, sans-serif;
+}

--- a/plugins/postcss-custom-properties/test/basic.import.expect.css
+++ b/plugins/postcss-custom-properties/test/basic.import.expect.css
@@ -155,3 +155,8 @@ html {
 	color: 2em;
 	color: var(--✅-size);
 }
+
+.test {
+	font-family: "Helvetica Neue", Arial, sans-serif;
+	font-family: var(--font, "Helvetica Neue", Arial, sans-serif);
+}

--- a/plugins/postcss-custom-properties/test/basic.preserve.expect.css
+++ b/plugins/postcss-custom-properties/test/basic.preserve.expect.css
@@ -105,3 +105,7 @@
 .test-unicode {
 	color: 2em;
 }
+
+.test {
+	font-family: "Helvetica Neue", Arial, sans-serif;
+}


### PR DESCRIPTION
`const [propertyNode, ...fallbacks] = child.nodes.filter((node) => node.type !== 'div');`

`fallbacks` doesn't contain any space or comma nodes