### PR TITLE
Fix race condition issue of postcss-custom-properties

### DIFF
--- a/plugins/postcss-custom-properties/src/index.ts
+++ b/plugins/postcss-custom-properties/src/index.ts
@@ -48,14 +48,14 @@ const creator: PluginCreator<PluginOptions> = (opts?: PluginOptions) => {
 	// promise any custom selectors are imported
 	const customPropertiesPromise = getCustomPropertiesFromImports(importFrom);
 
-	let customProperties: Map<string, valuesParser.ParsedValue> = new Map();
-
 	// whether to return synchronous function if no asynchronous operations are requested
 	const canReturnSyncFunction = importFrom.length === 0 && exportTo.length === 0;
 
 	return {
 		postcssPlugin: 'postcss-custom-properties',
 		prepare () {
+			let customProperties: Map<string, valuesParser.ParsedValue> = new Map();
+
 			if (canReturnSyncFunction) {
 				return {
 					Once: (root) => {


### PR DESCRIPTION
This PR fixed #331 . For more background please see that issue.

As I understand the `prepare` function is designed to store context variables for each CSS file, while the plugin function itself should contain some common code across CSS files, like some constant variables only related to `opts`.

In this case the `customProperties` is mutated and read between listeners. So it should be placed in `prepare` rather tha plugin function.

Ref: https://github.com/postcss/postcss/blob/main/docs/writing-a-plugin.md#step-3-find-nodes