### PR TITLE
add more tests from wpt and update `querySelector` polyfill

### DIFF
--- a/experimental/css-has-pseudo/CHANGELOG.md
+++ b/experimental/css-has-pseudo/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - Use `@csstools/selector-specificity` for specificity calculations.
+- Update `querySelector(:has())` polyfill, ensuring temporary html attributes are correctly removed.
 - Improve documentation
 
 ### 0.5.0 (April 24, 2022)

--- a/experimental/css-has-pseudo/package.json
+++ b/experimental/css-has-pseudo/package.json
@@ -43,7 +43,7 @@
 		"postcss": "^8.3"
 	},
 	"devDependencies": {
-		"@mrhenry/core-web": "^0.7.0",
+		"@mrhenry/core-web": "^0.7.1",
 		"puppeteer": "^13.6.0"
 	},
 	"scripts": {

--- a/experimental/css-has-pseudo/test/_browser.html
+++ b/experimental/css-has-pseudo/test/_browser.html
@@ -10,7 +10,7 @@
 	<!-- This is the real test stylesheet and has correct CORS attributes and http headers -->
 	<link rel="stylesheet" href="http://localhost:8081/test/browser.expect.css" crossorigin="anonymous">
 	<script src="http://localhost:8082/dist/browser-global.js"></script>
-	<script>cssHasPseudo(document, { observedAttributes: ['attrname'], debug: false, hover: true, forcePolyfill: true });</script>
+	<script>cssHasPseudo(document, { observedAttributes: ['attrname', 'a_test_attr', 'c_test_attr'], debug: false, hover: true, forcePolyfill: true });</script>
 </head>
 <body>
 	<the-fixture id="fixture"></the-fixture>
@@ -252,12 +252,66 @@
 
 				beforeElement.before(newElement);
 				await rafP(() => {
-					testColor(`insert element div.c_test before ${beforeElement.id}`, expectedColor);
+					testColor(`insert element div.test before ${beforeElement.id}`, expectedColor);
+				});
+
+				newElement.classList.remove('c_test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element inserted before ${beforeElement.id}`, grey);
+				});
+
+				newElement.classList.add('c_test');
+				await rafP(() => {
+					testColor(`add the class 'test' again to the element inserted before ${beforeElement.id}`, expectedColor);
 				});
 
 				newElement.remove();
 				await rafP(() => {
-					testColor(`remove element div.c_test before ${beforeElement.id}`, grey);
+					testColor(`remove element div.test before ${beforeElement.id}`, grey);
+				});
+
+				newElement.classList.remove('c_test');
+
+				beforeElement.before(newElement);
+				await rafP(() => {
+					testColor(`insert element div before ${beforeElement.id}`, grey);
+				});
+
+				newElement.classList.add('c_test');
+				await rafP(() => {
+					testColor(`add the class 'test' to the element inserted again before ${beforeElement.id}`, expectedColor);
+				});
+
+				newElement.classList.remove('c_test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element inserted again before ${beforeElement.id}`, grey);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div before ${beforeElement.id}`, grey);
+				});
+
+				newElement.setAttribute('c_test_attr', '');
+
+				beforeElement.before(newElement);
+				await rafP(() => {
+					testColor(`insert element div[test_attr] before ${beforeElement.id}`, expectedColor);
+				});
+
+				newElement.removeAttribute('c_test_attr');
+				await rafP(() => {
+					testColor(`remove attribute div[test_attr] before ${beforeElement.id}`, grey);
+				});
+
+				newElement.setAttribute('c_test_attr', '');
+				await rafP(() => {
+					testColor(`insert attribute div[test_attr] before ${beforeElement.id}`, expectedColor);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div[test_attr] before ${beforeElement.id}`, grey);
 				});
 			}
 
@@ -267,12 +321,66 @@
 
 				afterElement.after(newElement);
 				await rafP(() => {
-					testColor(`insert element div.c_test after ${afterElement.id}`, expectedColor);
+					testColor(`insert element div.test after ${afterElement.id}`, expectedColor);
+				});
+
+				newElement.classList.remove('c_test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element inserted after ${afterElement.id}`, grey);
+				});
+
+				newElement.classList.add('c_test');
+				await rafP(() => {
+					testColor(`add the class 'test' again to the element inserted after ${afterElement.id}`, expectedColor);
 				});
 
 				newElement.remove();
 				await rafP(() => {
-					testColor(`remove element div.c_test after ${afterElement.id}`, grey);
+					testColor(`remove element div.test after ${afterElement.id}`, grey);
+				});
+
+				newElement.classList.remove('c_test');
+
+				afterElement.after(newElement);
+				await rafP(() => {
+					testColor(`insert element div after ${afterElement.id}`, grey);
+				});
+
+				newElement.classList.add('c_test');
+				await rafP(() => {
+					testColor(`add the class 'test' to the element inserted again after ${afterElement.id}`, expectedColor);
+				});
+
+				newElement.classList.remove('c_test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element inserted again after ${afterElement.id}`, grey);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div after ${afterElement.id}`, grey);
+				});
+
+				newElement.setAttribute('c_test_attr', '');
+
+				afterElement.after(newElement);
+				await rafP(() => {
+					testColor(`insert element div[c_test_attr] after ${afterElement.id}`, expectedColor);
+				});
+
+				newElement.removeAttribute('c_test_attr');
+				await rafP(() => {
+					testColor(`remove attribute div[test_attr] before ${afterElement.id}`, grey);
+				});
+
+				newElement.setAttribute('c_test_attr', '');
+				await rafP(() => {
+					testColor(`insert attribute div[test_attr] before ${afterElement.id}`, expectedColor);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div[c_test_attr] after ${afterElement.id}`, grey);
 				});
 			}
 
@@ -284,12 +392,66 @@
 
 				beforeElement.before(newElement);
 				await rafP(() => {
-					testColor(`insert tree div>div.c_test before ${beforeElement.id}`, expectedColor);
+					testColor(`insert tree div>div.test before ${beforeElement.id}`, expectedColor);
+				});
+
+				newChild.classList.remove('c_test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element in the tree inserted before ${beforeElement.id}`, grey);
+				});
+
+				newChild.classList.add('c_test');
+				await rafP(() => {
+					testColor(`add the class 'test' again to the element in the tree inserted before ${beforeElement.id}`, expectedColor);
 				});
 
 				newElement.remove();
 				await rafP(() => {
-					testColor(`remove tree div>div.c_test before ${beforeElement.id}`, grey);
+					testColor(`remove tree div>div.test before ${beforeElement.id}`, grey);
+				});
+
+				newChild.classList.remove('c_test');
+
+				beforeElement.before(newElement);
+				await rafP(() => {
+					testColor(`insert tree div>div before ${beforeElement.id}`, grey);
+				});
+
+				newChild.classList.add('c_test');
+				await rafP(() => {
+					testColor(`add the class 'test' to the element in the tree inserted again before ${beforeElement.id}`, expectedColor);
+				});
+
+				newChild.classList.remove('c_test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element in the tree inserted again before ${beforeElement.id}`, grey);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove tree div>div before ${beforeElement.id}`, grey);
+				});
+
+				newChild.setAttribute('c_test_attr', '');
+
+				beforeElement.before(newElement);
+				await rafP(() => {
+					testColor(`insert element div>div[test_attr] before ${beforeElement.id}`, expectedColor);
+				});
+
+				newChild.removeAttribute('c_test_attr');
+				await rafP(() => {
+					testColor(`remove attribute div[test_attr] before ${beforeElement.id}`, grey);
+				});
+
+				newChild.setAttribute('c_test_attr', '');
+				await rafP(() => {
+					testColor(`insert attribute div[test_attr] before ${beforeElement.id}`, expectedColor);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div>div[test_attr] before ${beforeElement.id}`, grey);
 				});
 			}
 
@@ -301,12 +463,66 @@
 
 				afterElement.after(newElement);
 				await rafP(() => {
-					testColor(`insert tree div>div.c_test after ${afterElement.id}`, expectedColor);
+					testColor(`insert tree div>div.test after ${afterElement.id}`, expectedColor);
+				});
+
+				newChild.classList.remove('c_test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element in the tree inserted after ${afterElement.id}`, grey);
+				});
+
+				newChild.classList.add('c_test');
+				await rafP(() => {
+					testColor(`add the class 'test' again to the element in the tree inserted after ${afterElement.id}`, expectedColor);
 				});
 
 				newElement.remove();
 				await rafP(() => {
-					testColor(`remove tree div>div.c_test after ${afterElement.id}`, grey);
+					testColor(`remove tree div>div.test after ${afterElement.id}`, grey);
+				});
+
+				newChild.classList.remove('c_test');
+
+				afterElement.after(newElement);
+				await rafP(() => {
+					testColor(`insert tree div>div after ${afterElement.id}`, grey);
+				});
+
+				newChild.classList.add('c_test');
+				await rafP(() => {
+					testColor(`add the class 'test' to the element in the tree inserted again after ${afterElement.id}`, expectedColor);
+				});
+
+				newChild.classList.remove('c_test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element in the tree inserted again after ${afterElement.id}`, grey);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove tree div>div after ${afterElement.id}`, grey);
+				});
+
+				newChild.setAttribute('c_test_attr', '');
+
+				afterElement.after(newElement);
+				await rafP(() => {
+					testColor(`insert element div>div[test_attr] after ${afterElement.id}`, expectedColor);
+				});
+
+				newChild.removeAttribute('c_test_attr');
+				await rafP(() => {
+					testColor(`remove attribute div[test_attr] before ${afterElement.id}`, grey);
+				});
+
+				newChild.setAttribute('c_test_attr', '');
+				await rafP(() => {
+					testColor(`insert attribute div[test_attr] before ${afterElement.id}`, expectedColor);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div>div[test_attr] after ${afterElement.id}`, grey);
 				});
 			}
 
@@ -414,9 +630,65 @@
 					testColor(`insert element div.test before ${beforeElement.id}`, expectedColor);
 				});
 
+				newElement.classList.remove('a_Test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element inserted before ${beforeElement.id}`, grey);
+				});
+
+				newElement.classList.add('a_Test');
+				await rafP(() => {
+					testColor(`add the class 'test' again to the element inserted before ${beforeElement.id}`, expectedColor);
+				});
+
 				newElement.remove();
 				await rafP(() => {
 					testColor(`remove element div.test before ${beforeElement.id}`, grey);
+				});
+
+				newElement.classList.remove('a_Test');
+
+				beforeElement.before(newElement);
+				await rafP(() => {
+					testColor(`insert element div before ${beforeElement.id}`, grey);
+				});
+
+				newElement.classList.add('a_Test');
+				await rafP(() => {
+					testColor(`add the class 'test' to the element inserted again before ${beforeElement.id}`, expectedColor);
+				});
+
+				newElement.classList.remove('a_Test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element inserted again before ${beforeElement.id}`, grey);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div before ${beforeElement.id}`, grey);
+				});
+
+				newElement.setAttribute('a_test_attr', '');
+
+				beforeElement.before(newElement);
+				await rafP(() => {
+					testColor(`insert element div[test_attr] before ${beforeElement.id}`, expectedColor);
+				});
+
+				newElement.removeAttribute('a_test_attr');
+
+				await rafP(() => {
+					testColor(`remove attribute div[test_attr] before ${beforeElement.id}`, grey);
+				});
+
+				newElement.setAttribute('a_test_attr', '');
+
+				await rafP(() => {
+					testColor(`insert attribute div[test_attr] before ${beforeElement.id}`, expectedColor);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div[test_attr] before ${beforeElement.id}`, grey);
 				});
 			}
 
@@ -429,9 +701,65 @@
 					testColor(`insert element div.test after ${afterElement.id}`, expectedColor);
 				});
 
+				newElement.classList.remove('a_Test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element inserted after ${afterElement.id}`, grey);
+				});
+
+				newElement.classList.add('a_Test');
+				await rafP(() => {
+					testColor(`add the class 'test' again to the element inserted after ${afterElement.id}`, expectedColor);
+				});
+
 				newElement.remove();
 				await rafP(() => {
 					testColor(`remove element div.test after ${afterElement.id}`, grey);
+				});
+
+				newElement.classList.remove('a_Test');
+
+				afterElement.after(newElement);
+				await rafP(() => {
+					testColor(`insert element div after ${afterElement.id}`, grey);
+				});
+
+				newElement.classList.add('a_Test');
+				await rafP(() => {
+					testColor(`add the class 'test' to the element inserted again after ${afterElement.id}`, expectedColor);
+				});
+
+				newElement.classList.remove('a_Test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element inserted again after ${afterElement.id}`, grey);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div after ${afterElement.id}`, grey);
+				});
+
+				newElement.setAttribute('a_test_attr', '');
+
+				afterElement.after(newElement);
+				await rafP(() => {
+					testColor(`insert element div[test_attr] after ${afterElement.id}`, expectedColor);
+				});
+
+				newElement.removeAttribute('a_test_attr');
+
+				await rafP(() => {
+					testColor(`remove attribute div[test_attr] before ${afterElement.id}`, grey);
+				});
+
+				newElement.setAttribute('a_test_attr', '');
+
+				await rafP(() => {
+					testColor(`insert attribute div[test_attr] before ${afterElement.id}`, expectedColor);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div[test_attr] after ${afterElement.id}`, grey);
 				});
 			}
 
@@ -446,9 +774,65 @@
 					testColor(`insert tree div>div.test before ${beforeElement.id}`, expectedColor);
 				});
 
+				newChild.classList.remove('a_Test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element in the tree inserted before ${beforeElement.id}`, grey);
+				});
+
+				newChild.classList.add('a_Test');
+				await rafP(() => {
+					testColor(`add the class 'test' again to the element in the tree inserted before ${beforeElement.id}`, expectedColor);
+				});
+
 				newElement.remove();
 				await rafP(() => {
 					testColor(`remove tree div>div.test before ${beforeElement.id}`, grey);
+				});
+
+				newChild.classList.remove('a_Test');
+
+				beforeElement.before(newElement);
+				await rafP(() => {
+					testColor(`insert tree div>div before ${beforeElement.id}`, grey);
+				});
+
+				newChild.classList.add('a_Test');
+				await rafP(() => {
+					testColor(`add the class 'test' to the element in the tree inserted again before ${beforeElement.id}`, expectedColor);
+				});
+
+				newChild.classList.remove('a_Test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element in the tree inserted again before ${beforeElement.id}`, grey);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove tree div>div before ${beforeElement.id}`, grey);
+				});
+
+				newChild.setAttribute('a_test_attr', '');
+
+				beforeElement.before(newElement);
+				await rafP(() => {
+					testColor(`insert element div>div[test_attr] before ${beforeElement.id}`, expectedColor);
+				});
+
+				newChild.removeAttribute('a_test_attr');
+
+				await rafP(() => {
+					testColor(`remove attribute div[test_attr] before ${beforeElement.id}`, grey);
+				});
+
+				newChild.setAttribute('a_test_attr', '');
+
+				await rafP(() => {
+					testColor(`insert attribute div[test_attr] before ${beforeElement.id}`, expectedColor);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div>div[test_attr] before ${beforeElement.id}`, grey);
 				});
 			}
 
@@ -463,9 +847,65 @@
 					testColor(`insert tree div>div.test after ${afterElement.id}`, expectedColor);
 				});
 
+				newChild.classList.remove('a_Test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element in the tree inserted after ${afterElement.id}`, grey);
+				});
+
+				newChild.classList.add('a_Test');
+				await rafP(() => {
+					testColor(`add the class 'test' again to the element in the tree inserted after ${afterElement.id}`, expectedColor);
+				});
+
 				newElement.remove();
 				await rafP(() => {
 					testColor(`remove tree div>div.test after ${afterElement.id}`, grey);
+				});
+
+				newChild.classList.remove('a_Test');
+
+				afterElement.after(newElement);
+				await rafP(() => {
+					testColor(`insert tree div>div after ${afterElement.id}`, grey);
+				});
+
+				newChild.classList.add('a_Test');
+				await rafP(() => {
+					testColor(`add the class 'test' to the element in the tree inserted again after ${afterElement.id}`, expectedColor);
+				});
+
+				newChild.classList.remove('a_Test');
+				await rafP(() => {
+					testColor(`remove the class 'test' from the element in the tree inserted again after ${afterElement.id}`, grey);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove tree div>div after ${afterElement.id}`, grey);
+				});
+
+				newChild.setAttribute('a_test_attr', '');
+
+				afterElement.after(newElement);
+				await rafP(() => {
+					testColor(`insert element div>div[test_attr] after ${afterElement.id}`, expectedColor);
+				});
+
+				newChild.removeAttribute('a_test_attr');
+
+				await rafP(() => {
+					testColor(`remove attribute div[test_attr] before ${afterElement.id}`, grey);
+				});
+
+				newChild.setAttribute('a_test_attr', '');
+
+				await rafP(() => {
+					testColor(`insert attribute div[test_attr] before ${afterElement.id}`, expectedColor);
+				});
+
+				newElement.remove();
+				await rafP(() => {
+					testColor(`remove element div>div[test_attr] after ${afterElement.id}`, grey);
 				});
 			}
 
@@ -734,7 +1174,7 @@
 			function testColor(el, color) {
 				var actual = getComputedStyle(el).color;
 				if (actual === color) {
-					throw new Error('nested :has should not be allowed : div#' + el.id + '.color; expected ' + color + ' but got ' + actual);
+					throw new Error('nested :has should not be allowed : div#' + el.id + '.color; did not expected ' + color + ' but got ' + actual + ' anyway.');
 				}
 			}
 

--- a/experimental/css-has-pseudo/test/browser.css
+++ b/experimental/css-has-pseudo/test/browser.css
@@ -36,52 +36,52 @@
 }
 
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-in-ancestor-position.html */
-div:has(.c_test) #c_subject {
+div:has(.c_test, [c_test_attr]) #c_subject {
 	background-color: red
 }
 
-div:has(> .c_test) #c_subject {
+div:has(> .c_test, > [c_test_attr]) #c_subject {
 	background-color: green
 }
 
-div:has(~ .c_test) #c_subject {
+div:has(~ .c_test, ~ [c_test_attr]) #c_subject {
 	background-color: yellow
 }
 
-div:has(+ .c_test) #c_subject {
+div:has(+ .c_test, + [c_test_attr]) #c_subject {
 	background-color: blue
 }
 
-div:has(~ div .c_test) #c_subject {
+div:has(~ div .c_test, ~ div [c_test_attr]) #c_subject {
 	background-color: purple
 }
 
-div:has(+ div .c_test) #c_subject {
+div:has(+ div .c_test, + div [c_test_attr]) #c_subject {
 	background-color: pink
 }
 
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-in-adjacent-position.html */
-div:has(.a_Test)+#a_subject {
+div:has(.a_Test, [a_test_attr])+#a_subject {
 	background-color: red;
 }
 
-div:has(> .a_Test)+#a_subject {
+div:has(> .a_Test, > [a_test_attr])+#a_subject {
 	background-color: green;
 }
 
-div:has(~ .a_Test)+#a_subject {
+div:has(~ .a_Test, ~ [a_test_attr])+#a_subject {
 	background-color: yellow;
 }
 
-div:has(+ .a_Test)+#a_subject {
+div:has(+ .a_Test, + [a_test_attr])+#a_subject {
 	background-color: blue;
 }
 
-div:has(~ div .a_Test)+#a_subject {
+div:has(~ div .a_Test, ~ div [a_test_attr])+#a_subject {
 	background-color: purple;
 }
 
-div:has(+ div .a_Test)+#a_subject {
+div:has(+ div .a_Test, + div [a_test_attr])+#a_subject {
 	background-color: pink;
 }
 

--- a/experimental/css-has-pseudo/test/browser.expect.css
+++ b/experimental/css-has-pseudo/test/browser.expect.css
@@ -36,52 +36,52 @@
 }
 
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-in-ancestor-position.html */
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1a-2r-2n-38-2t-37-38-18-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: red
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1q-w-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1q-w-1a-2r-2n-38-2t-37-38-18-w-1q-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: green
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-1a-2r-2n-38-2t-37-38-18-w-3i-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: yellow
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-1a-2r-2n-38-2t-37-38-18-w-17-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: blue
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-2s-2x-3a-w-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-2s-2x-3a-w-1a-2r-2n-38-2t-37-38-18-w-3i-w-2s-2x-3a-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	background-color: purple
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-2s-2x-3a-w-1a-2r-2n-38-2t-37-38-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-2s-2x-3a-w-1a-2r-2n-38-2t-37-38-18-w-17-w-2s-2x-3a-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	background-color: pink
 }
 
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-in-adjacent-position.html */
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1a-2p-2n-2c-2t-37-38-18-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: red;
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1q-w-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1q-w-1a-2p-2n-2c-2t-37-38-18-w-1q-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: green;
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-1a-2p-2n-2c-2t-37-38-18-w-3i-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: yellow;
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-1a-2p-2n-2c-2t-37-38-18-w-17-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: blue;
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-2s-2x-3a-w-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-2s-2x-3a-w-1a-2p-2n-2c-2t-37-38-18-w-3i-w-2s-2x-3a-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	background-color: purple;
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-2s-2x-3a-w-1a-2p-2n-2c-2t-37-38-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-2s-2x-3a-w-1a-2p-2n-2c-2t-37-38-18-w-17-w-2s-2x-3a-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	background-color: pink;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
 				"postcss-selector-parser": "^6.0.10"
 			},
 			"devDependencies": {
-				"@mrhenry/core-web": "^0.7.0",
+				"@mrhenry/core-web": "^0.7.1",
 				"puppeteer": "^13.6.0"
 			},
 			"engines": {
@@ -106,12 +106,13 @@
 			}
 		},
 		"node_modules/@ampproject/remapping": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.0"
+				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -1898,10 +1899,32 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.0",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
 			"integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -1924,9 +1947,9 @@
 			}
 		},
 		"node_modules/@mrhenry/core-web": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@mrhenry/core-web/-/core-web-0.7.0.tgz",
-			"integrity": "sha512-PzlPFiVCdf1Z3Xmxlzzk47fdRENEjdTQ5PNpb2/a3Agt+ydgvP7+bDFB2qoQrinDsSMj8eLWHGZyyXW4+qSiOA==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@mrhenry/core-web/-/core-web-0.7.1.tgz",
+			"integrity": "sha512-R9oKe34+qJX4BrO1hmk0TR0nZyDFofCm4NzfsoarpXa8kQ+IfZmXEwhUCO6FNvhP128xOR8ZEv1m/2GC7L7poQ==",
 			"dev": true,
 			"dependencies": {
 				"semver": "^7.3.5"
@@ -2349,9 +2372,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.26",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.26.tgz",
-			"integrity": "sha512-z/FG/6DUO7pnze3AE3TBGIjGGKkvCcGcWINe1C7cADY8hKLJPDYpzsNE37uExQ4md5RFtTCvg+M8Mu1Enyeg2A==",
+			"version": "17.0.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
 			"dev": true
 		},
 		"node_modules/@types/resolve": {
@@ -2374,14 +2397,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
-			"integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
+			"integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.20.0",
-				"@typescript-eslint/type-utils": "5.20.0",
-				"@typescript-eslint/utils": "5.20.0",
+				"@typescript-eslint/scope-manager": "5.21.0",
+				"@typescript-eslint/type-utils": "5.21.0",
+				"@typescript-eslint/utils": "5.21.0",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -2422,15 +2445,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
-			"integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
+			"integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.20.0",
-				"@typescript-eslint/types": "5.20.0",
-				"@typescript-eslint/typescript-estree": "5.20.0",
+				"@typescript-eslint/scope-manager": "5.21.0",
+				"@typescript-eslint/types": "5.21.0",
+				"@typescript-eslint/typescript-estree": "5.21.0",
 				"debug": "^4.3.2"
 			},
 			"engines": {
@@ -2450,13 +2473,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
-			"integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
+			"integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.20.0",
-				"@typescript-eslint/visitor-keys": "5.20.0"
+				"@typescript-eslint/types": "5.21.0",
+				"@typescript-eslint/visitor-keys": "5.21.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2467,12 +2490,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
-			"integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
+			"integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "5.20.0",
+				"@typescript-eslint/utils": "5.21.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			},
@@ -2493,9 +2516,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
-			"integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
+			"integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2506,13 +2529,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
-			"integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
+			"integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.20.0",
-				"@typescript-eslint/visitor-keys": "5.20.0",
+				"@typescript-eslint/types": "5.21.0",
+				"@typescript-eslint/visitor-keys": "5.21.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -2548,15 +2571,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
-			"integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
+			"integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.20.0",
-				"@typescript-eslint/types": "5.20.0",
-				"@typescript-eslint/typescript-estree": "5.20.0",
+				"@typescript-eslint/scope-manager": "5.21.0",
+				"@typescript-eslint/types": "5.21.0",
+				"@typescript-eslint/typescript-estree": "5.21.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -2572,12 +2595,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
-			"integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
+			"integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.20.0",
+				"@typescript-eslint/types": "5.21.0",
 				"eslint-visitor-keys": "^3.0.0"
 			},
 			"engines": {
@@ -2589,9 +2612,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2946,9 +2969,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001332",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-			"integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+			"version": "1.0.30001334",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+			"integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3079,12 +3102,12 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.22.2",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.2.tgz",
-			"integrity": "sha512-Fns9lU06ZJ07pdfmPMu7OnkIKGPKDzXKIiuGlSvHHapwqMUF2QnnsWwtueFZtSyZEilP0o6iUeHQwpn7LxtLUw==",
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
+			"integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.20.2",
+				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
 			},
 			"funding": {
@@ -3249,9 +3272,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.118",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.118.tgz",
-			"integrity": "sha512-maZIKjnYDvF7Fs35nvVcyr44UcKNwybr93Oba2n3HkKDFAtk0svERkLN/HyczJDS3Fo4wU9th9fUQd09ZLtj1w=="
+			"version": "1.4.124",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+			"integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -4163,9 +4186,9 @@
 			"dev": true
 		},
 		"node_modules/inquirer": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.2.tgz",
-			"integrity": "sha512-pG7I/si6K/0X7p1qU+rfWnpTE1UIkTONN1wxtzh0d+dHXtT/JG6qBgLxoyHVsQa8cFABxAPh0pD6uUUHiAoaow==",
+			"version": "8.2.4",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+			"integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
 			"dev": true,
 			"dependencies": {
 				"ansi-escapes": "^4.2.1",
@@ -4181,7 +4204,8 @@
 				"rxjs": "^7.5.5",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0",
-				"through": "^2.3.6"
+				"through": "^2.3.6",
+				"wrap-ansi": "^7.0.0"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -4518,6 +4542,12 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
+		"node_modules/lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
+		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -4782,6 +4812,28 @@
 				"encoding": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/node-fetch/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
+		},
+		"node_modules/node-fetch/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+			"dev": true
+		},
+		"node_modules/node-fetch/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"dev": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/node-releases": {
@@ -6053,14 +6105,14 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-			"integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.13.0.tgz",
+			"integrity": "sha512-sgQ99P+fRBM1jAYzN9RTnD/xEWx/7LZgYTCRgmYriSq1wxxqiQPJgXkkLBBuwySDWJ2PP0PnVQyuf4xLUuH4Ng==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
-				"source-map": "~0.7.2",
+				"source-map": "~0.8.0-beta.0",
 				"source-map-support": "~0.5.20"
 			},
 			"bin": {
@@ -6077,10 +6129,13 @@
 			"dev": true
 		},
 		"node_modules/terser/node_modules/source-map": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+			"version": "0.8.0-beta.0",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+			"integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
 			"dev": true,
+			"dependencies": {
+				"whatwg-url": "^7.0.0"
+			},
 			"engines": {
 				"node": ">= 8"
 			}
@@ -6131,10 +6186,13 @@
 			}
 		},
 		"node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-			"dev": true
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
 		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
@@ -6339,19 +6397,20 @@
 			"dev": true
 		},
 		"node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
 			"dev": true
 		},
 		"node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
 			"dev": true,
 			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"node_modules/which": {
@@ -6377,6 +6436,56 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
@@ -7100,12 +7209,13 @@
 	},
 	"dependencies": {
 		"@ampproject/remapping": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.0"
+				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			}
 		},
 		"@babel/code-frame": {
@@ -8240,7 +8350,7 @@
 			"version": "file:experimental/css-has-pseudo",
 			"requires": {
 				"@csstools/selector-specificity": "1.0.0",
-				"@mrhenry/core-web": "^0.7.0",
+				"@mrhenry/core-web": "^0.7.1",
 				"postcss-selector-parser": "^6.0.10",
 				"puppeteer": "^13.6.0"
 			}
@@ -8436,10 +8546,26 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/set-array": "^1.0.0",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"@jridgewell/resolve-uri": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
 			"integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+			"dev": true
+		},
+		"@jridgewell/set-array": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
 			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
@@ -8459,9 +8585,9 @@
 			}
 		},
 		"@mrhenry/core-web": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@mrhenry/core-web/-/core-web-0.7.0.tgz",
-			"integrity": "sha512-PzlPFiVCdf1Z3Xmxlzzk47fdRENEjdTQ5PNpb2/a3Agt+ydgvP7+bDFB2qoQrinDsSMj8eLWHGZyyXW4+qSiOA==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@mrhenry/core-web/-/core-web-0.7.1.tgz",
+			"integrity": "sha512-R9oKe34+qJX4BrO1hmk0TR0nZyDFofCm4NzfsoarpXa8kQ+IfZmXEwhUCO6FNvhP128xOR8ZEv1m/2GC7L7poQ==",
 			"dev": true,
 			"requires": {
 				"semver": "^7.3.5"
@@ -8782,9 +8908,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "17.0.26",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.26.tgz",
-			"integrity": "sha512-z/FG/6DUO7pnze3AE3TBGIjGGKkvCcGcWINe1C7cADY8hKLJPDYpzsNE37uExQ4md5RFtTCvg+M8Mu1Enyeg2A==",
+			"version": "17.0.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
 			"dev": true
 		},
 		"@types/resolve": {
@@ -8807,14 +8933,14 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
-			"integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
+			"integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.20.0",
-				"@typescript-eslint/type-utils": "5.20.0",
-				"@typescript-eslint/utils": "5.20.0",
+				"@typescript-eslint/scope-manager": "5.21.0",
+				"@typescript-eslint/type-utils": "5.21.0",
+				"@typescript-eslint/utils": "5.21.0",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -8835,53 +8961,53 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
-			"integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
+			"integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.20.0",
-				"@typescript-eslint/types": "5.20.0",
-				"@typescript-eslint/typescript-estree": "5.20.0",
+				"@typescript-eslint/scope-manager": "5.21.0",
+				"@typescript-eslint/types": "5.21.0",
+				"@typescript-eslint/typescript-estree": "5.21.0",
 				"debug": "^4.3.2"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
-			"integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
+			"integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.20.0",
-				"@typescript-eslint/visitor-keys": "5.20.0"
+				"@typescript-eslint/types": "5.21.0",
+				"@typescript-eslint/visitor-keys": "5.21.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
-			"integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
+			"integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.20.0",
+				"@typescript-eslint/utils": "5.21.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
-			"integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
+			"integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
-			"integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
+			"integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.20.0",
-				"@typescript-eslint/visitor-keys": "5.20.0",
+				"@typescript-eslint/types": "5.21.0",
+				"@typescript-eslint/visitor-keys": "5.21.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -8901,33 +9027,33 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
-			"integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
+			"integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.20.0",
-				"@typescript-eslint/types": "5.20.0",
-				"@typescript-eslint/typescript-estree": "5.20.0",
+				"@typescript-eslint/scope-manager": "5.21.0",
+				"@typescript-eslint/types": "5.21.0",
+				"@typescript-eslint/typescript-estree": "5.21.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
-			"integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
+			"integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.20.0",
+				"@typescript-eslint/types": "5.21.0",
 				"eslint-visitor-keys": "^3.0.0"
 			}
 		},
 		"acorn": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -9161,9 +9287,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001332",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-			"integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw=="
+			"version": "1.0.30001334",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+			"integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw=="
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -9263,12 +9389,12 @@
 			}
 		},
 		"core-js-compat": {
-			"version": "3.22.2",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.2.tgz",
-			"integrity": "sha512-Fns9lU06ZJ07pdfmPMu7OnkIKGPKDzXKIiuGlSvHHapwqMUF2QnnsWwtueFZtSyZEilP0o6iUeHQwpn7LxtLUw==",
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
+			"integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.20.2",
+				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
@@ -9397,9 +9523,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.118",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.118.tgz",
-			"integrity": "sha512-maZIKjnYDvF7Fs35nvVcyr44UcKNwybr93Oba2n3HkKDFAtk0svERkLN/HyczJDS3Fo4wU9th9fUQd09ZLtj1w=="
+			"version": "1.4.124",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+			"integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -10067,9 +10193,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.2.tgz",
-			"integrity": "sha512-pG7I/si6K/0X7p1qU+rfWnpTE1UIkTONN1wxtzh0d+dHXtT/JG6qBgLxoyHVsQa8cFABxAPh0pD6uUUHiAoaow==",
+			"version": "8.2.4",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+			"integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",
@@ -10085,7 +10211,8 @@
 				"rxjs": "^7.5.5",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0",
-				"through": "^2.3.6"
+				"through": "^2.3.6",
+				"wrap-ansi": "^7.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -10340,6 +10467,12 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
+		},
 		"log-symbols": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -10538,6 +10671,30 @@
 			"dev": true,
 			"requires": {
 				"whatwg-url": "^5.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+					"dev": true
+				},
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+					"dev": true,
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
+					}
+				}
 			}
 		},
 		"node-releases": {
@@ -11536,14 +11693,14 @@
 			}
 		},
 		"terser": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-			"integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.13.0.tgz",
+			"integrity": "sha512-sgQ99P+fRBM1jAYzN9RTnD/xEWx/7LZgYTCRgmYriSq1wxxqiQPJgXkkLBBuwySDWJ2PP0PnVQyuf4xLUuH4Ng==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
-				"source-map": "~0.7.2",
+				"source-map": "~0.8.0-beta.0",
 				"source-map-support": "~0.5.20"
 			},
 			"dependencies": {
@@ -11554,10 +11711,13 @@
 					"dev": true
 				},
 				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-					"dev": true
+					"version": "0.8.0-beta.0",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+					"integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^7.0.0"
+					}
 				}
 			}
 		},
@@ -11598,10 +11758,13 @@
 			}
 		},
 		"tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-			"dev": true
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
 		},
 		"tree-kill": {
 			"version": "1.2.2",
@@ -11762,19 +11925,20 @@
 			"dev": true
 		},
 		"webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
 			"dev": true,
 			"requires": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"which": {
@@ -11791,6 +11955,43 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				}
+			}
 		},
 		"wrappy": {
 			"version": "1.0.2",


### PR DESCRIPTION
A lot more tests for style invalidation were added on WPT.
No fixes were needed for this.

I did find an issue with temporary attributes not being removed in the `querySelector` polyfill. This has been patched upstream and the dependency has been updated here.