### PR TITLE
drop node 12 and node 17 from CI

### DIFF
--- a/.github/workflows/test-node-without-workspaces.yml
+++ b/.github/workflows/test-node-without-workspaces.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14]
+        node: [14]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      # Test node 16/17/18 on ubuntu
+      # Test node 16/18 on ubuntu
       # Test node 16 on macos/windows
       # Enable annotations only for node 16 + ubuntu
       matrix:
         os: [ubuntu-latest]
-        node: [16, 17, 18]
+        node: [16, 18]
         include:
         - os: macos-latest
           node: 16


### PR DESCRIPTION
No longer test node 12 as it is no longer supported by node itself.
No longer test node 17 as it isn't an LTS version and it is no longer the most recent version.

I do not want to make it impossible to use these versions by excluding them from the `engines` field in `package.json`. It will take some time for everyone to update.