### PR TITLE
color functional notation : percentage values

### DIFF
--- a/plugin-packs/postcss-preset-env/test/basic.autoprefixer.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.autoprefixer.expect.css
@@ -440,11 +440,11 @@
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/basic.autoprefixer.false.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.autoprefixer.false.expect.css
@@ -440,11 +440,11 @@
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/basic.ch38.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch38.expect.css
@@ -360,11 +360,11 @@
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/basic.ch88-ff78-saf10.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch88-ff78-saf10.expect.css
@@ -359,11 +359,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/basic.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.expect.css
@@ -464,11 +464,11 @@
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/basic.ff49.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ff49.expect.css
@@ -356,11 +356,11 @@
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/basic.ie10.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ie10.expect.css
@@ -479,11 +479,11 @@
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/basic.nesting.false.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.nesting.false.expect.css
@@ -462,11 +462,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/basic.preserve.true.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.preserve.true.expect.css
@@ -773,7 +773,6 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
 	prop-1: rgb(0,132,94);
 	prop-1: color(display-p3 0.00000 0.51872 0.36985);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
@@ -785,7 +784,6 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	prop-4: color(display-p3 0.02472 0.01150 0.00574 / -webkit-calc(33 / 22));
 	prop-4: color(display-p3 0.02472 0.01150 0.00574 / -moz-calc(33 / 22));
 	prop-4: color(display-p3 0.02472 0.01150 0.00574 / calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
 	prop-5: rgb(255,255,255);
 	prop-5: color(display-p3 1 1 1 1);
 }

--- a/plugin-packs/postcss-preset-env/test/basic.stage0-ff49.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0-ff49.expect.css
@@ -361,11 +361,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/basic.stage0.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0.expect.css
@@ -469,11 +469,11 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/basic.vendors-1.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.vendors-1.expect.css
@@ -434,11 +434,11 @@
 }
 
 .color-function {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab {

--- a/plugin-packs/postcss-preset-env/test/layers-basic.expect.css
+++ b/plugin-packs/postcss-preset-env/test/layers-basic.expect.css
@@ -679,13 +679,13 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 }
 
 .color-function:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
-	prop-1: rgb(0, 132, 94);
+	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
 	prop-4: rgba(7,3,1,-webkit-calc(33 / 22));
 	prop-4: rgba(7,3,1,-moz-calc(33 / 22));
 	prop-4: rgba(7,3,1,calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
+	prop-5: rgb(255,255,255);
 }
 
 .oklab:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {

--- a/plugin-packs/postcss-preset-env/test/layers-basic.preserve.true.expect.css
+++ b/plugin-packs/postcss-preset-env/test/layers-basic.preserve.true.expect.css
@@ -784,7 +784,6 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 }
 
 .color-function:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
-	prop-1: rgb(0, 132, 94);
 	prop-1: rgb(0,132,94);
 	prop-1: color(display-p3 0.00000 0.51872 0.36985);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
@@ -796,7 +795,6 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	prop-4: color(display-p3 0.02472 0.01150 0.00574 / -webkit-calc(33 / 22));
 	prop-4: color(display-p3 0.02472 0.01150 0.00574 / -moz-calc(33 / 22));
 	prop-4: color(display-p3 0.02472 0.01150 0.00574 / calc(33 / 22));
-	prop-5: rgb(255, 255, 255);
 	prop-5: rgb(255,255,255);
 	prop-5: color(display-p3 1 1 1 1);
 }

--- a/plugins/postcss-color-functional-notation/CHANGELOG.md
+++ b/plugins/postcss-color-functional-notation/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changes to PostCSS Color Functional Notation
 
+### Unreleased
+
+- Handle modern channel values in legacy notation (comma separated)
+
+```css
+.color {
+  color: rgba(0, 255, 0, 50%);
+}
+
+/* becomes */
+
+.color {
+  color: rgba(0, 255, 0, 0.5);
+}
+```
+
 ### 4.2.2 (February 5, 2022)
 
 - Improved `es module` and `commonjs` compatibility

--- a/plugins/postcss-color-functional-notation/src/on-css-function.ts
+++ b/plugins/postcss-color-functional-notation/src/on-css-function.ts
@@ -3,10 +3,11 @@ import type { FunctionNode, Dimension, Node, DivNode, WordNode, SpaceNode } from
 
 function onCSSFunction(node: FunctionNode) {
 	const value = node.value;
-	let rawNodes = node.nodes;
-	if (value === 'rgb' || value === 'hsl') {
-		rawNodes = convertOldSyntaxToNewSyntaxBeforeTransform(rawNodes);
+	if (!needsConversion(value === 'rgb' || value === 'rgba', node.nodes)) {
+		return;
 	}
+
+	const rawNodes = convertOldSyntaxToNewSyntaxBeforeTransform(node.nodes);
 
 	const relevantNodes = rawNodes.slice().filter((x) => {
 		return x.type !== 'comment' && x.type !== 'space';
@@ -348,4 +349,43 @@ function convertOldSyntaxToNewSyntaxBeforeTransform(nodes: Array<Node>): Array<N
 	}
 
 	return nodes;
+}
+
+function needsConversion(isRGB: boolean, nodes: Array<Node>) {
+	let hasCommas = false;
+	let hasPercentageAlpha = false;
+	let isRGB_AndHasAnyPercentageValue = false;
+
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i];
+		if (node.type === 'word' && node.value === 'from') {
+			// Too modern, not handled by this plugin
+			return false;
+		}
+
+		if (node.type === 'div' && node.value === ',') {
+			hasCommas = true;
+			continue;
+		}
+
+		if (isRGB && node.type === 'word' && node.value.endsWith('%')) {
+			isRGB_AndHasAnyPercentageValue = true;
+			continue;
+		}
+
+		if (i === (nodes.length - 1) && node.type === 'word' && node.value.endsWith('%')) {
+			hasPercentageAlpha = true;
+			continue;
+		}
+	}
+
+	if (hasCommas && (hasPercentageAlpha || isRGB_AndHasAnyPercentageValue)) {
+		return true;
+	}
+
+	if (hasCommas) {
+		return false;
+	}
+
+	return true;
 }

--- a/plugins/postcss-color-functional-notation/src/on-css-function.ts
+++ b/plugins/postcss-color-functional-notation/src/on-css-function.ts
@@ -356,8 +356,12 @@ function needsConversion(isRGB: boolean, nodes: Array<Node>) {
 	let hasPercentageAlpha = false;
 	let isRGB_AndHasAnyPercentageValue = false;
 
-	for (let i = 0; i < nodes.length; i++) {
-		const node = nodes[i];
+	const relevantNodes = nodes.slice().filter((x) => {
+		return x.type !== 'comment' && x.type !== 'space';
+	});
+
+	for (let i = 0; i < relevantNodes.length; i++) {
+		const node = relevantNodes[i];
 		if (node.type === 'word' && node.value === 'from') {
 			// Too modern, not handled by this plugin
 			return false;

--- a/plugins/postcss-color-functional-notation/test/basic.css
+++ b/plugins/postcss-color-functional-notation/test/basic.css
@@ -71,3 +71,26 @@
 	color: hsl(120 100% 50% / 50%);
 	color: hsl(120, 100%, 50%, 0);
 }
+
+.test-legacy-notation-with-modern-components--rgb {
+	color: rgb(50%, 34, 34);
+	color: rgb(178, 10%, 34);
+	color: rgb(178, 34, 10%);
+}
+
+.test-legacy-notation-with-modern-components--rgba {
+	color: rgba(50%, 34, 34, 1);
+	color: rgba(178, 10%, 34, 1);
+	color: rgba(178, 34, 10%, 1);
+	color: rgba(178, 34, 34, 100%);
+}
+
+.test-legacy-notation-with-modern-components--hsla {
+	color: hsla(120, 100%, 50%, 100%);
+}
+
+.test-ignore {
+	/* this plugin shouldn't format */
+	color: rgba(0,0,0,0.1); /* spaceless */
+	color: rgba(0, 0, 0, 0.2); /* with spaces */
+}

--- a/plugins/postcss-color-functional-notation/test/basic.expect.css
+++ b/plugins/postcss-color-functional-notation/test/basic.expect.css
@@ -64,10 +64,33 @@
 
 .rgb-with-alpha {
 	color: rgba(178, 34, 34, 0.5);
-	color: rgba(0, 0, 0, 0);
+	color: rgb(0, 0, 0, 0);
 }
 
 .hsl-with-alpha {
 	color: hsla(120, 100%, 50%, 0.5);
-	color: hsla(120, 100%, 50%, 0);
+	color: hsl(120, 100%, 50%, 0);
+}
+
+.test-legacy-notation-with-modern-components--rgb {
+	color: rgb(127, 34, 34);
+	color: rgb(178, 25, 34);
+	color: rgb(178, 34, 25);
+}
+
+.test-legacy-notation-with-modern-components--rgba {
+	color: rgba(127, 34, 34, 1);
+	color: rgba(178, 25, 34, 1);
+	color: rgba(178, 34, 25, 1);
+	color: rgba(178, 34, 34, 1);
+}
+
+.test-legacy-notation-with-modern-components--hsla {
+	color: hsla(120, 100%, 50%, 1);
+}
+
+.test-ignore {
+	/* this plugin shouldn't format */
+	color: rgba(0,0,0,0.1); /* spaceless */
+	color: rgba(0, 0, 0, 0.2); /* with spaces */
 }

--- a/plugins/postcss-color-functional-notation/test/basic.preserve-true.expect.css
+++ b/plugins/postcss-color-functional-notation/test/basic.preserve-true.expect.css
@@ -101,13 +101,42 @@
 .rgb-with-alpha {
 	color: rgba(178, 34, 34, 0.5);
 	color: rgb(70% 13.5% 13.5% / 50%);
-	color: rgba(0, 0, 0, 0);
 	color: rgb(0, 0, 0, 0);
 }
 
 .hsl-with-alpha {
 	color: hsla(120, 100%, 50%, 0.5);
 	color: hsl(120 100% 50% / 50%);
-	color: hsla(120, 100%, 50%, 0);
 	color: hsl(120, 100%, 50%, 0);
+}
+
+.test-legacy-notation-with-modern-components--rgb {
+	color: rgb(127, 34, 34);
+	color: rgb(50%, 34, 34);
+	color: rgb(178, 25, 34);
+	color: rgb(178, 10%, 34);
+	color: rgb(178, 34, 25);
+	color: rgb(178, 34, 10%);
+}
+
+.test-legacy-notation-with-modern-components--rgba {
+	color: rgba(127, 34, 34, 1);
+	color: rgba(50%, 34, 34, 1);
+	color: rgba(178, 25, 34, 1);
+	color: rgba(178, 10%, 34, 1);
+	color: rgba(178, 34, 25, 1);
+	color: rgba(178, 34, 10%, 1);
+	color: rgba(178, 34, 34, 1);
+	color: rgba(178, 34, 34, 100%);
+}
+
+.test-legacy-notation-with-modern-components--hsla {
+	color: hsla(120, 100%, 50%, 1);
+	color: hsla(120, 100%, 50%, 100%);
+}
+
+.test-ignore {
+	/* this plugin shouldn't format */
+	color: rgba(0,0,0,0.1); /* spaceless */
+	color: rgba(0, 0, 0, 0.2); /* with spaces */
 }

--- a/plugins/postcss-color-functional-notation/test/variables.css
+++ b/plugins/postcss-color-functional-notation/test/variables.css
@@ -9,3 +9,10 @@
 	--fifty: 50%;
 	--firebrick-var: hsl(40 var(--fifty) 34.5% / var(--opacity-50));
 }
+
+:root {
+	/* Not expected to be handled here at the moment, but might be needed in the future */
+	--rgba-functional-notation-percentage-alpha: rgba(0, 0, 0, 100%);
+
+	--hsla-functional-notation-percentage-alpha: hsla(0, 0%, 0%, 100%);
+}

--- a/plugins/postcss-color-functional-notation/test/variables.expect.css
+++ b/plugins/postcss-color-functional-notation/test/variables.expect.css
@@ -9,3 +9,10 @@
 	--fifty: 50%;
 	--firebrick-var: hsl(40 var(--fifty) 34.5% / var(--opacity-50));
 }
+
+:root {
+	/* Not expected to be handled here at the moment, but might be needed in the future */
+	--rgba-functional-notation-percentage-alpha: rgba(0, 0, 0, 1);
+
+	--hsla-functional-notation-percentage-alpha: hsla(0, 0%, 0%, 1);
+}

--- a/plugins/postcss-color-functional-notation/test/variables.preserve-true.expect.css
+++ b/plugins/postcss-color-functional-notation/test/variables.preserve-true.expect.css
@@ -21,3 +21,25 @@
 	--firebrick-rgb-a50-var: rgb(40% 68.8 34.5 / var(--opacity-50));
 }
 }
+
+:root {
+	/* Not expected to be handled here at the moment, but might be needed in the future */
+	--rgba-functional-notation-percentage-alpha: rgba(0, 0, 0, 1);
+
+	--hsla-functional-notation-percentage-alpha: hsla(0, 0%, 0%, 1);
+}
+
+@supports (color: rgb(0 0 0 / 0.5)) and (color: hsl(0 0% 0% / 0.5)) {
+
+:root {
+	--rgba-functional-notation-percentage-alpha: rgba(0, 0, 0, 100%);
+}
+}
+
+@supports (color: rgb(0 0 0 / 0.5)) and (color: hsl(0 0% 0% / 0.5)) {
+
+:root {
+
+	--hsla-functional-notation-percentage-alpha: hsla(0, 0%, 0%, 100%);
+}
+}

--- a/plugins/postcss-progressive-custom-properties/test/basic.css
+++ b/plugins/postcss-progressive-custom-properties/test/basic.css
@@ -124,3 +124,9 @@
 		plum
 	);
 }
+
+:root {
+	/* Not expected to be handled here at the moment, but might be needed in the future */
+	--color-functional-notation-percentage-alpha: rgba(0, 0, 0, 1);
+	--color-functional-notation-percentage-alpha: rgba(0, 0, 0, 100%);
+}

--- a/plugins/postcss-progressive-custom-properties/test/basic.expect.css
+++ b/plugins/postcss-progressive-custom-properties/test/basic.expect.css
@@ -269,3 +269,9 @@
 	);
 }
 }
+
+:root {
+	/* Not expected to be handled here at the moment, but might be needed in the future */
+	--color-functional-notation-percentage-alpha: rgba(0, 0, 0, 1);
+	--color-functional-notation-percentage-alpha: rgba(0, 0, 0, 100%);
+}


### PR DESCRIPTION
Modern browsers support using modern channel values in the legacy (comma separated) syntax.
Older browsers obviously do not support this :)