### PR TITLE
cascade layers : use only simple selectors

### DIFF
--- a/plugin-packs/postcss-preset-env/test/layers-basic.css
+++ b/plugin-packs/postcss-preset-env/test/layers-basic.css
@@ -38,7 +38,7 @@
 			order: 5;
 
 			@layer D {
-				is-layer: C.D;
+				is-layer: C_D;
 				order: 5.1;
 			}
 		}

--- a/plugin-packs/postcss-preset-env/test/layers-basic.expect.css
+++ b/plugin-packs/postcss-preset-env/test/layers-basic.expect.css
@@ -1,7 +1,7 @@
 
 
-		.test-nesting-rules p:not(#\##\##\##\##\##\#) {
-				is-layer: C.D;
+		.test-nesting-rules p:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+				is-layer: C_D;
 				-webkit-box-ordinal-group: 6;
 				-webkit-order: 5.1;
 				   -moz-box-ordinal-group: 6;
@@ -9,23 +9,23 @@
 				        order: 5.1
 		}
 
-:root:not(#\##\##\##\##\##\##\##\#) {
+:root:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		--order: 1;
 	}
 
-.test-custom-property-fallbacks:not(#\##\##\##\##\##\##\##\#) {
+.test-custom-property-fallbacks:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		--firebrick: rgb(179, 35, 35);
 	}
 
 @supports (color: color(display-p3 0 0 0)){
-.test-custom-property-fallbacks:not(#\##\##\##\##\##\##\##\#) {
+.test-custom-property-fallbacks:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		--firebrick: color(display-p3 0.64331 0.19245 0.16771);
 	}
 }
 
-.test-custom-properties:not(#\##\##\##\##\##\##\##\#) {
+.test-custom-properties:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		-webkit-box-ordinal-group: var(--order);
 		-webkit-order: var(--order);
@@ -34,7 +34,7 @@
 		        order: var(--order);
 	}
 
-.test-image-set-function:not(#\##\##\##\##\##\##\##\#) {
+.test-image-set-function:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		background-image: url(img/test.png);
 		background-image: -webkit-image-set(url(img/test.png) 1x, url(img/test-2x.png) 2x);
@@ -48,20 +48,20 @@
 
 @media (-webkit-min-device-pixel-ratio: 2), (min--moz-device-pixel-ratio: 2), (-o-min-device-pixel-ratio: 2/1), (min-resolution: 192dpi){
 
-	.test-image-set-function:not(#\##\##\##\##\##\##\##\#) {
+	.test-image-set-function:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		background-image: url(img/test-2x.png);
 	}
 }
 
-[dir="ltr"] .test-logical-properties-and-values:not(#\##\##\##\##\##\##\##\#){
+[dir="ltr"] .test-logical-properties-and-values:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#){
 		margin: 1px 4px 3px 2px
 }
 
-[dir="rtl"] .test-logical-properties-and-values:not(#\##\##\##\##\##\##\##\#){
+[dir="rtl"] .test-logical-properties-and-values:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#){
 		margin: 1px 2px 3px 4px
 }
 
-.test-logical-properties-and-values:not(#\##\##\##\##\##\##\##\#) {
+.test-logical-properties-and-values:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		-webkit-box-ordinal-group: 4;
 		-webkit-order: 3;
@@ -72,7 +72,7 @@
 		padding-bottom: 5px;
 	}
 
-.test-nesting-rules:not(#\##\##\##\##\##\##\##\#) {
+.test-nesting-rules:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		-webkit-box-ordinal-group: 5;
 		-webkit-order: 4;
@@ -81,7 +81,7 @@
 		        order: 4;
 	}
 
-.test-nesting-rules p:not(#\##\##\##\##\##\##\##\#) {
+.test-nesting-rules p:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 			is-layer: C;
 			-webkit-box-ordinal-group: 6;
 			-webkit-order: 5;
@@ -90,7 +90,7 @@
 			        order: 5
 		}
 
-.test-nesting-rules:not(#\##\##\##\##\##\##\##\#) {
+.test-nesting-rules:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 
 		is-layer: C;
 		-webkit-box-ordinal-group: 7;
@@ -100,8 +100,8 @@
 		        order: 6;
 	}
 
-.test-nesting-rules:not(#\##\##\##\##\##\##\##\##\##\##\##\#),
-#test-is-pseudo:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-nesting-rules:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),
+#test-is-pseudo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 8;
 	-webkit-order: 7;
 	   -moz-box-ordinal-group: 8;
@@ -109,7 +109,7 @@
 	        order: 7;
 }
 
-.test-nesting-rules + p:not(#\##\##\##\##\##\##\##\##\##\##\##\#), #test-is-pseudo + p:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-nesting-rules + p:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#), #test-is-pseudo + p:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 9;
 		-webkit-order: 8;
 		   -moz-box-ordinal-group: 9;
@@ -117,8 +117,8 @@
 		        order: 8;
 	}
 
-.test-nesting-rules:not(#\##\##\##\##\##\##\##\##\##\##\##\#),
-#test-is-pseudo:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-nesting-rules:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),
+#test-is-pseudo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 
 	-webkit-box-ordinal-group: 10;
 
@@ -132,7 +132,7 @@
 }
 
 @media (max-width: 30em) {
-	.test-custom-media-queries:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+	.test-custom-media-queries:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 11;
 		-webkit-order: 10;
 		   -moz-box-ordinal-group: 11;
@@ -153,27 +153,27 @@
 }
 
 @media (color-index: 48) {
-	body:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+	body:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		background-color: black;
 		color: white;
 	}
 }
 
 @media (color: 48842621) {
-	body:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+	body:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		background-color: black;
 		color: white;
 	}
 }
 
 @media (prefers-color-scheme: dark) {
-	body:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+	body:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		background-color: black;
 		color: white;
 	}
 }
 
-h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h3.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h4.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h5.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h6.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+h1.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),h2.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),h3.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),h4.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),h5.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),h6.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group:13;
 	-webkit-order:12;
 	   -moz-box-ordinal-group:13;
@@ -181,7 +181,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order:12;
 }
 
-.test-case-insensitive-attributes[frame=hsides]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=Hsides]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSides]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSides]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIdes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIdes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIdes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIdes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsiDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsiDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSiDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSiDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsidEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsidEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSidEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSidEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIdEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIdEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIdEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIdEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsiDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsiDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSiDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSiDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsideS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsideS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSideS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSideS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIdeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIdeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIdeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIdeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsiDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsiDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSiDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSiDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsidES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsidES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSidES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSidES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIdES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIdES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIdES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIdES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsiDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsiDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSiDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSiDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-case-insensitive-attributes[frame=hsides]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=Hsides]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSides]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSides]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIdes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIdes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIdes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIdes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsiDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsiDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSiDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSiDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsidEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsidEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSidEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSidEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIdEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIdEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIdEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIdEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsiDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsiDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSiDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSiDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsideS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsideS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSideS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSideS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIdeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIdeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIdeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIdeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsiDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsiDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSiDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSiDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsidES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsidES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSidES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSidES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIdES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIdES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIdES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIdES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsiDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsiDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSiDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSiDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 14;
 	-webkit-order: 13;
 	   -moz-box-ordinal-group: 14;
@@ -189,7 +189,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 13;
 }
 
-.test-rebeccapurple-color:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-rebeccapurple-color:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	color: #639;
 	-webkit-box-ordinal-group: 15;
 	-webkit-order: 14;
@@ -198,7 +198,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 14;
 }
 
-.test-hexadecimal-alpha-notation:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-hexadecimal-alpha-notation:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: rgba(243,243,243,0.95294);
 	color: rgba(0,0,0,0.2);
 	-webkit-box-ordinal-group: 16;
@@ -208,7 +208,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 15;
 }
 
-.test-color-functional-notation:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-color-functional-notation:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	color: rgba(178, 34, 34, 0.5);
 	-webkit-box-ordinal-group: 17;
 	-webkit-order: 16;
@@ -217,7 +217,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 16;
 }
 
-.test-lab-function:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-lab-function:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: rgb(179, 35, 35);
 	background-color: color(display-p3 0.64331 0.19245 0.16771);
 	color: rgba(179, 34, 35, 0.5);
@@ -229,7 +229,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 17;
 }
 
-.test-system-ui-font-family:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-system-ui-font-family:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
 	-webkit-box-ordinal-group: 19;
 	-webkit-order: 18;
@@ -238,7 +238,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 18;
 }
 
-.test-font-variant-property:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-font-variant-property:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-font-feature-settings: "smcp";
 	   -moz-font-feature-settings: "smcp";
 	        font-feature-settings: "smcp";
@@ -250,7 +250,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 19;
 }
 
-.test-all-property:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-all-property:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-animation: none 0s ease 0s 1 normal none running;
 	   -moz-animation: none 0s ease 0s 1 normal none running;
 	     -o-animation: none 0s ease 0s 1 normal none running;
@@ -392,7 +392,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 20;
 }
 
-.test-matches-pseudo-class:matches( .special,:first-child):not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-matches-pseudo-class:matches( .special,:first-child):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 22;
 	-webkit-order: 21;
 	   -moz-box-ordinal-group: 22;
@@ -400,7 +400,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 21;
 }
 
-.test-not-pseudo-class:not(:first-child):not(.special):not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-not-pseudo-class:not(:first-child):not(.special):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 23;
 	-webkit-order: 22;
 	   -moz-box-ordinal-group: 23;
@@ -408,7 +408,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 22;
 }
 
-.test-any-link-pseudo-class:link:not(#\##\##\##\##\##\##\##\##\##\##\##\#), .test-any-link-pseudo-class:visited:not(#\##\##\##\##\##\##\##\##\##\##\##\#), area.test-any-link-pseudo-class[href]:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-any-link-pseudo-class:link:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#), .test-any-link-pseudo-class:visited:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#), area.test-any-link-pseudo-class[href]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 24;
 	-webkit-order: 23;
 	   -moz-box-ordinal-group: 24;
@@ -416,18 +416,18 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 23;
 }
 
-.test-any-link-pseudo-class:-webkit-any-link:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-any-link-pseudo-class:-webkit-any-link:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 24;
 	-webkit-order: 23;
 	        order: 23;
 }
 
-.test-any-link-pseudo-class:-moz-any-link:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-any-link-pseudo-class:-moz-any-link:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-moz-box-ordinal-group: 24;
 	     order: 23;
 }
 
-.test-any-link-pseudo-class:any-link:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-any-link-pseudo-class:any-link:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 24;
 	-webkit-order: 23;
 	   -moz-box-ordinal-group: 24;
@@ -435,7 +435,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 23;
 }
 
-[dir="rtl"] .test-dir-pseudo-class:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+[dir="rtl"] .test-dir-pseudo-class:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 25;
 	-webkit-order: 24;
 	   -moz-box-ordinal-group: 25;
@@ -443,7 +443,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 24;
 }
 
-.test-overflow-wrap-property:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-overflow-wrap-property:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 26;
 	-webkit-order: 25;
 	   -moz-box-ordinal-group: 26;
@@ -452,7 +452,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	word-wrap: break-word;
 }
 
-.test-focus-visible-pseudo-class.focus-visible:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-focus-visible-pseudo-class.focus-visible:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 27;
 	-webkit-order: 26;
 	   -moz-box-ordinal-group: 27;
@@ -460,7 +460,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 26;
 }
 
-.test-focus-visible-pseudo-class:focus-visible:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-focus-visible-pseudo-class:focus-visible:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 27;
 	-webkit-order: 26;
 	   -moz-box-ordinal-group: 27;
@@ -468,28 +468,28 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 26;
 }
 
-.test-double-position-gradients:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-double-position-gradients:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg,gold 75%, #f06 0deg);
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank]:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-blank-pseudo-class[blank]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: yellow;
 }
 
-.test-blank-pseudo-class:blank:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-blank-pseudo-class:blank:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: yellow;
 }
 
-.test-has-pseudo-class[\:has\(.inner-class\)]:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-has-pseudo-class[\:has\(.inner-class\)]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: yellow;
 }
 
-.test-has-pseudo-class:has(.inner-class):not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-has-pseudo-class:has(.inner-class):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: yellow;
 }
 
-.a:focus:not(#\##\##\##\#) {
+.a:focus:not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 28;
 		-webkit-order: 27;
 		   -moz-box-ordinal-group: 28;
@@ -497,7 +497,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 27;
 	}
 
-.a:hover:not(#\##\##\##\#) {
+.a:hover:not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 28;
 		-webkit-order: 27;
 		   -moz-box-ordinal-group: 28;
@@ -505,7 +505,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 27;
 	}
 
-.b:focus:not(#\##\##\##\#) {
+.b:focus:not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 28;
 		-webkit-order: 27;
 		   -moz-box-ordinal-group: 28;
@@ -513,7 +513,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 27;
 	}
 
-.b:hover:not(#\##\##\##\#) {
+.b:hover:not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 28;
 		-webkit-order: 27;
 		   -moz-box-ordinal-group: 28;
@@ -521,7 +521,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 27;
 	}
 
-.a.c > .b + .d:not(#\##\##\##\#) {
+.a.c > .b + .d:not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 29;
 		-webkit-order: 28;
 		   -moz-box-ordinal-group: 29;
@@ -529,46 +529,46 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 28;
 	}
 
-.test-hwb-function:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-hwb-function:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: rgba(0, 195, 255, .5);
 }
 
-.test-opacity-percent:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-opacity-percent:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	opacity: 0.42;
 }
 
-.clamp-same-unit:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.clamp-same-unit:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	width: max(10px, min(64px, 80px));
 }
 
-.complex-clamp:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.complex-clamp:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	width: max(-webkit-calc(100% - 10px), min(min(10px, 100%), max(40px, 4em)));
 	width: max(-moz-calc(100% - 10px), min(min(10px, 100%), max(40px, 4em)));
 	width: max(calc(100% - 10px), min(min(10px, 100%), max(40px, 4em)));
 }
 
-.clamp-different-units:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.clamp-different-units:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	width: max(10%, min(2px, 4rem));
 }
 
-.mixed-clamp:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.mixed-clamp:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
 	margin: max(1rem, min(2%, 3rem)) 4vh;
 }
 
-.calc-clamp:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.calc-clamp:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	margin: 0 40px 0 -webkit-calc(-1 * max(32px, min(16vw, 64px)));
 	margin: 0 40px 0 -moz-calc(-1 * max(32px, min(16vw, 64px)));
 	margin: 0 40px 0 calc(-1 * max(32px, min(16vw, 64px)));
 }
 
-.multiple-calc-clamp:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.multiple-calc-clamp:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	margin: -webkit-calc(-1 * max(1px, min(2vw, 3px))) -webkit-calc(-1 * max(4px, min(5vw, 6px)));
 	margin: -moz-calc(-1 * max(1px, min(2vw, 3px))) -moz-calc(-1 * max(4px, min(5vw, 6px)));
 	margin: calc(-1 * max(1px, min(2vw, 3px))) calc(-1 * max(4px, min(5vw, 6px)));
 }
 
-.nested-clamp:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.nested-clamp:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	font-size: max(max(1rem, min(2vw, 3rem)), min(4vw, 5rem));
 }
 
@@ -580,42 +580,42 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	src: url(a) format("woff2");
 }
 
-.block-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.block-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: block;
 	display: block flow;
 }
 
-.block-flow-root:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.block-flow-root:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: flow-root;
 	display: block flow-root;
 }
 
-.inline-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: inline;
 	display: inline flow;
 }
 
-.inline-flow-root:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-flow-root:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: inline-block;
 	display: inline flow-root;
 }
 
-.run-in-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.run-in-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: run-in;
 	display: run-in flow;
 }
 
-.list-item-block-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.list-item-block-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: list-item;
 	display: list-item block flow;
 }
 
-.inline-flow-list-item:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-flow-list-item:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: inline list-item;
 	display: inline flow list-item;
 }
 
-.block-flex:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.block-flex:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: -webkit-box;
 	display: -webkit-flex;
 	display: -moz-box;
@@ -624,7 +624,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	display: block flex;
 }
 
-.inline-flex:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-flex:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: -webkit-inline-box;
 	display: -webkit-inline-flex;
 	display: -moz-inline-box;
@@ -633,52 +633,52 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	display: inline flex;
 }
 
-.block-grid:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.block-grid:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: grid;
 	display: block grid;
 }
 
-.inline-grid:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-grid:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: inline-grid;
 	display: inline grid;
 }
 
-.inline-ruby:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-ruby:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: ruby;
 	display: inline ruby;
 }
 
-.block-table:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.block-table:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: table;
 	display: block table;
 }
 
-.inline-table:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-table:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: inline-table;
 	display: inline table;
 }
 
-.table-cell-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.table-cell-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: table-cell;
 	display: table-cell flow;
 }
 
-.table-caption-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.table-caption-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: table-caption;
 	display: table-caption flow;
 }
 
-.ruby-base-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.ruby-base-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: ruby-base;
 	display: ruby-base flow;
 }
 
-.ruby-text-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.ruby-text-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: ruby-text;
 	display: ruby-text flow;
 }
 
-.color-function:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.color-function:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	prop-1: rgb(0,132,94);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
 	prop-3: rgba(7,3,1,1);
@@ -688,7 +688,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	prop-5: rgb(255,255,255);
 }
 
-.oklab:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.oklab:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	color-1: rgb(73, 71, 69);
 	color-1: color(display-p3 0.28515 0.27983 0.27246);
 	color-2: rgba(121, 34, 67, 1);
@@ -714,7 +714,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	color-12: color(display-p3 0.45207 0.66555 0.91656);
 }
 
-.oklch:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.oklch:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	color-1: rgb(126, 37, 15);
 	color-1: color(display-p3 0.45368 0.16978 0.09411);
 	color-2: rgba(126, 37, 15, 1);
@@ -754,7 +754,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	color-17: oklch(60% 0.1250 0.785398unknown);
 }
 
-.ic-unit:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.ic-unit:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	--value-2ic: 'something';
 	text-indent: 2em;
 	content: var(--value-2ic);
@@ -769,12 +769,12 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	padding: 2    ic;
 }
 
-.unset:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.unset:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	clip: auto;
 	clip: initial;
 }
 
-.mod:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.mod:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	padding: 8px 3px 1px -webkit-calc(3px + 50%);
 	padding: 8px 3px 1px -moz-calc(3px + 50%);
 	padding: 8px 3px 1px calc(3px + 50%);
@@ -786,7 +786,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	width: 2px;
 }
 
-.rem:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.rem:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	padding: 8px 3px 1px -webkit-calc(3px + 50%);
 	padding: 8px 3px 1px -moz-calc(3px + 50%);
 	padding: 8px 3px 1px calc(3px + 50%);
@@ -797,7 +797,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        transform: rotate(-50deg);
 }
 
-.round:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.round:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	top: 3px;
 	right: 3px;
 	bottom: 3px;

--- a/plugin-packs/postcss-preset-env/test/layers-basic.preserve.true.expect.css
+++ b/plugin-packs/postcss-preset-env/test/layers-basic.preserve.true.expect.css
@@ -1,7 +1,7 @@
 
 
-		.test-nesting-rules p:not(#\##\##\##\##\##\#) {
-				is-layer: C.D;
+		.test-nesting-rules p:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+				is-layer: C_D;
 				-webkit-box-ordinal-group: 6;
 				-webkit-order: 5.1;
 				   -moz-box-ordinal-group: 6;
@@ -9,29 +9,29 @@
 				        order: 5.1
 		}
 
-:root:not(#\##\##\##\##\##\##\##\#) {
+:root:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		--order: 1;
 	}
 
-.test-custom-property-fallbacks:not(#\##\##\##\##\##\##\##\#) {
+.test-custom-property-fallbacks:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		--firebrick: rgb(179, 35, 35);
 	}
 
 @supports (color: color(display-p3 0 0 0)){
-.test-custom-property-fallbacks:not(#\##\##\##\##\##\##\##\#) {
+.test-custom-property-fallbacks:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		--firebrick: color(display-p3 0.64331 0.19245 0.16771);
 	}
 }
 
 @supports (color: lab(0% 0 0)){
-.test-custom-property-fallbacks:not(#\##\##\##\##\##\##\##\#) {
+.test-custom-property-fallbacks:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		--firebrick: lab(40% 56.6 39);
 	}
 }
 
-.test-custom-properties:not(#\##\##\##\##\##\##\##\#) {
+.test-custom-properties:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		-webkit-box-ordinal-group: var(--order);
 		-webkit-order: var(--order);
@@ -40,7 +40,7 @@
 		        order: var(--order);
 	}
 
-.test-image-set-function:not(#\##\##\##\##\##\##\##\#) {
+.test-image-set-function:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		background-image: url(img/test.png);
 		background-image: -webkit-image-set(url(img/test.png) 1x, url(img/test-2x.png) 2x);
@@ -54,28 +54,28 @@
 
 @media (-webkit-min-device-pixel-ratio: 2), (min--moz-device-pixel-ratio: 2), (-o-min-device-pixel-ratio: 2/1), (min-resolution: 192dpi){
 
-	.test-image-set-function:not(#\##\##\##\##\##\##\##\#) {
+	.test-image-set-function:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		background-image: url(img/test-2x.png);
 	}
 }
 
-[dir="ltr"] .test-logical-properties-and-values:not(#\##\##\##\##\##\##\##\#){
+[dir="ltr"] .test-logical-properties-and-values:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#){
 		margin: 1px 4px 3px 2px
 }
 
-.test-logical-properties-and-values:dir(ltr):not(#\##\##\##\##\##\##\##\#){
+.test-logical-properties-and-values:dir(ltr):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#){
 		margin: 1px 4px 3px 2px
 }
 
-[dir="rtl"] .test-logical-properties-and-values:not(#\##\##\##\##\##\##\##\#){
+[dir="rtl"] .test-logical-properties-and-values:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#){
 		margin: 1px 2px 3px 4px
 }
 
-.test-logical-properties-and-values:dir(rtl):not(#\##\##\##\##\##\##\##\#){
+.test-logical-properties-and-values:dir(rtl):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#){
 		margin: 1px 2px 3px 4px
 }
 
-.test-logical-properties-and-values:not(#\##\##\##\##\##\##\##\#) {
+.test-logical-properties-and-values:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		margin: logical 1px 2px 3px 4px;
 		-webkit-box-ordinal-group: 4;
@@ -88,7 +88,7 @@
 		padding-block: 5px;
 	}
 
-.test-nesting-rules:not(#\##\##\##\##\##\##\##\#) {
+.test-nesting-rules:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		is-layer: C;
 		-webkit-box-ordinal-group: 5;
 		-webkit-order: 4;
@@ -97,7 +97,7 @@
 		        order: 4;
 	}
 
-.test-nesting-rules p:not(#\##\##\##\##\##\##\##\#) {
+.test-nesting-rules p:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 			is-layer: C;
 			-webkit-box-ordinal-group: 6;
 			-webkit-order: 5;
@@ -106,7 +106,7 @@
 			        order: 5
 		}
 
-.test-nesting-rules:not(#\##\##\##\##\##\##\##\#) {
+.test-nesting-rules:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 
 		is-layer: C;
 		-webkit-box-ordinal-group: 7;
@@ -116,8 +116,8 @@
 		        order: 6;
 	}
 
-.test-nesting-rules:not(#\##\##\##\##\##\##\##\##\##\##\##\#),
-#test-is-pseudo:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-nesting-rules:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),
+#test-is-pseudo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 8;
 	-webkit-order: 7;
 	   -moz-box-ordinal-group: 8;
@@ -125,7 +125,7 @@
 	        order: 7;
 }
 
-.test-nesting-rules + p:not(#\##\##\##\##\##\##\##\##\##\##\##\#), #test-is-pseudo + p:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-nesting-rules + p:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#), #test-is-pseudo + p:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 9;
 		-webkit-order: 8;
 		   -moz-box-ordinal-group: 9;
@@ -133,8 +133,8 @@
 		        order: 8;
 	}
 
-.test-nesting-rules:not(#\##\##\##\##\##\##\##\##\##\##\##\#),
-#test-is-pseudo:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-nesting-rules:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),
+#test-is-pseudo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 
 	-webkit-box-ordinal-group: 10;
 
@@ -150,7 +150,7 @@
 @custom-media --narrow-window (max-width: 30em);
 
 @media (max-width: 30em) {
-	.test-custom-media-queries:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+	.test-custom-media-queries:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 11;
 		-webkit-order: 10;
 		   -moz-box-ordinal-group: 11;
@@ -160,7 +160,7 @@
 }
 
 @media (--narrow-window) {
-	.test-custom-media-queries:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+	.test-custom-media-queries:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 11;
 		-webkit-order: 10;
 		   -moz-box-ordinal-group: 11;
@@ -183,28 +183,28 @@
 @custom-media --dark-mode (prefers-color-scheme: dark);
 
 @media (color-index: 48) {
-	body:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+	body:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		background-color: black;
 		color: white;
 	}
 }
 
 @media (color: 48842621) {
-	body:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+	body:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		background-color: black;
 		color: white;
 	}
 }
 
 @media (prefers-color-scheme: dark) {
-	body:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+	body:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		background-color: black;
 		color: white;
 	}
 }
 
 @media (--dark-mode) {
-	body:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+	body:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		background-color: black;
 		color: white;
 	}
@@ -212,7 +212,7 @@
 
 @custom-selector :--heading h1, h2, h3, h4, h5, h6;
 
-h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h3.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h4.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h5.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h6.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+h1.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),h2.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),h3.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),h4.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),h5.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),h6.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group:13;
 	-webkit-order:12;
 	   -moz-box-ordinal-group:13;
@@ -220,7 +220,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order:12;
 }
 
-.test-custom-selectors:--heading:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-custom-selectors:--heading:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group:13;
 	-webkit-order:12;
 	   -moz-box-ordinal-group:13;
@@ -228,7 +228,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order:12;
 }
 
-.test-case-insensitive-attributes[frame=hsides]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=Hsides]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSides]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSides]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIdes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIdes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIdes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIdes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsiDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsiDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSiDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSiDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIDes]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsidEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsidEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSidEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSidEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIdEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIdEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIdEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIdEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsiDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsiDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSiDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSiDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIDEs]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsideS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsideS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSideS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSideS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIdeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIdeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIdeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIdeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsiDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsiDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSiDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSiDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIDeS]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsidES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsidES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSidES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSidES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIdES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIdES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIdES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIdES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsiDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsiDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSiDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSiDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hsIDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HsIDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=hSIDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#),.test-case-insensitive-attributes[frame=HSIDES]:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-case-insensitive-attributes[frame=hsides]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=Hsides]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSides]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSides]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIdes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIdes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIdes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIdes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsiDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsiDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSiDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSiDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIDes]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsidEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsidEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSidEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSidEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIdEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIdEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIdEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIdEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsiDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsiDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSiDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSiDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIDEs]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsideS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsideS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSideS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSideS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIdeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIdeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIdeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIdeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsiDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsiDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSiDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSiDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIDeS]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsidES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsidES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSidES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSidES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIdES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIdES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIdES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIdES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsiDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsiDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSiDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSiDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hsIDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HsIDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=hSIDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#),.test-case-insensitive-attributes[frame=HSIDES]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 14;
 	-webkit-order: 13;
 	   -moz-box-ordinal-group: 14;
@@ -236,7 +236,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 13;
 }
 
-.test-rebeccapurple-color:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-rebeccapurple-color:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	color: #639;
 	color: rebeccapurple;
 	-webkit-box-ordinal-group: 15;
@@ -246,7 +246,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 14;
 }
 
-.test-hexadecimal-alpha-notation:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-hexadecimal-alpha-notation:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: rgba(243,243,243,0.95294);
 	background-color: #f3f3f3f3;
 	color: rgba(0,0,0,0.2);
@@ -258,7 +258,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 15;
 }
 
-.test-color-functional-notation:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-color-functional-notation:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	color: rgba(178, 34, 34, 0.5);
 	color: rgb(70% 13.5% 13.5% / 50%);
 	-webkit-box-ordinal-group: 17;
@@ -268,7 +268,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 16;
 }
 
-.test-lab-function:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-lab-function:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: rgb(179, 35, 35);
 	background-color: color(display-p3 0.64331 0.19245 0.16771);
 	background-color: lab(40% 56.6 39);
@@ -282,7 +282,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 17;
 }
 
-.test-system-ui-font-family:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-system-ui-font-family:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
 	-webkit-box-ordinal-group: 19;
 	-webkit-order: 18;
@@ -291,7 +291,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 18;
 }
 
-.test-font-variant-property:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-font-variant-property:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-font-feature-settings: "smcp";
 	   -moz-font-feature-settings: "smcp";
 	        font-feature-settings: "smcp";
@@ -303,7 +303,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 19;
 }
 
-.test-all-property:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-all-property:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-animation: none 0s ease 0s 1 normal none running;
 	   -moz-animation: none 0s ease 0s 1 normal none running;
 	     -o-animation: none 0s ease 0s 1 normal none running;
@@ -445,7 +445,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 20;
 }
 
-.test-matches-pseudo-class:matches( .special,:first-child):not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-matches-pseudo-class:matches( .special,:first-child):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 22;
 	-webkit-order: 21;
 	   -moz-box-ordinal-group: 22;
@@ -453,7 +453,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 21;
 }
 
-.test-not-pseudo-class:not(:first-child):not(.special):not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-not-pseudo-class:not(:first-child):not(.special):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 23;
 	-webkit-order: 22;
 	   -moz-box-ordinal-group: 23;
@@ -461,7 +461,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 22;
 }
 
-.test-any-link-pseudo-class:link:not(#\##\##\##\##\##\##\##\##\##\##\##\#), .test-any-link-pseudo-class:visited:not(#\##\##\##\##\##\##\##\##\##\##\##\#), area.test-any-link-pseudo-class[href]:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-any-link-pseudo-class:link:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#), .test-any-link-pseudo-class:visited:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#), area.test-any-link-pseudo-class[href]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 24;
 	-webkit-order: 23;
 	   -moz-box-ordinal-group: 24;
@@ -469,18 +469,18 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 23;
 }
 
-.test-any-link-pseudo-class:-webkit-any-link:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-any-link-pseudo-class:-webkit-any-link:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 24;
 	-webkit-order: 23;
 	        order: 23;
 }
 
-.test-any-link-pseudo-class:-moz-any-link:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-any-link-pseudo-class:-moz-any-link:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-moz-box-ordinal-group: 24;
 	     order: 23;
 }
 
-.test-any-link-pseudo-class:any-link:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-any-link-pseudo-class:any-link:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 24;
 	-webkit-order: 23;
 	   -moz-box-ordinal-group: 24;
@@ -488,7 +488,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 23;
 }
 
-[dir="rtl"] .test-dir-pseudo-class:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+[dir="rtl"] .test-dir-pseudo-class:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 25;
 	-webkit-order: 24;
 	   -moz-box-ordinal-group: 25;
@@ -496,7 +496,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 24;
 }
 
-.test-dir-pseudo-class:dir(rtl):not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-dir-pseudo-class:dir(rtl):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 25;
 	-webkit-order: 24;
 	   -moz-box-ordinal-group: 25;
@@ -504,7 +504,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 24;
 }
 
-.test-overflow-wrap-property:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-overflow-wrap-property:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 26;
 	-webkit-order: 25;
 	   -moz-box-ordinal-group: 26;
@@ -513,7 +513,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	word-wrap: break-word;
 }
 
-.test-focus-visible-pseudo-class.focus-visible:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-focus-visible-pseudo-class.focus-visible:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 27;
 	-webkit-order: 26;
 	   -moz-box-ordinal-group: 27;
@@ -521,7 +521,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 26;
 }
 
-.test-focus-visible-pseudo-class:focus-visible:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-focus-visible-pseudo-class:focus-visible:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	-webkit-box-ordinal-group: 27;
 	-webkit-order: 26;
 	   -moz-box-ordinal-group: 27;
@@ -529,28 +529,28 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        order: 26;
 }
 
-.test-double-position-gradients:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-double-position-gradients:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg,gold 75%, #f06 0deg);
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank]:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-blank-pseudo-class[blank]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: yellow;
 }
 
-.test-blank-pseudo-class:blank:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-blank-pseudo-class:blank:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: yellow;
 }
 
-.test-has-pseudo-class[\:has\(.inner-class\)]:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-has-pseudo-class[\:has\(.inner-class\)]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: yellow;
 }
 
-.test-has-pseudo-class:has(.inner-class):not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-has-pseudo-class:has(.inner-class):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: yellow;
 }
 
-.a:focus:not(#\##\##\##\#) {
+.a:focus:not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 28;
 		-webkit-order: 27;
 		   -moz-box-ordinal-group: 28;
@@ -558,7 +558,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 27;
 	}
 
-.a:hover:not(#\##\##\##\#) {
+.a:hover:not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 28;
 		-webkit-order: 27;
 		   -moz-box-ordinal-group: 28;
@@ -566,7 +566,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 27;
 	}
 
-.b:focus:not(#\##\##\##\#) {
+.b:focus:not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 28;
 		-webkit-order: 27;
 		   -moz-box-ordinal-group: 28;
@@ -574,7 +574,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 27;
 	}
 
-.b:hover:not(#\##\##\##\#) {
+.b:hover:not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 28;
 		-webkit-order: 27;
 		   -moz-box-ordinal-group: 28;
@@ -582,7 +582,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 27;
 	}
 
-:is(.a, .b):is(:focus, :hover):not(#\##\##\##\#) {
+:is(.a, .b):is(:focus, :hover):not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 28;
 		-webkit-order: 27;
 		   -moz-box-ordinal-group: 28;
@@ -590,7 +590,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 27;
 	}
 
-.a.c > .b + .d:not(#\##\##\##\#) {
+.a.c > .b + .d:not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 29;
 		-webkit-order: 28;
 		   -moz-box-ordinal-group: 29;
@@ -598,7 +598,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 28;
 	}
 
-:is(.a > .b) + :is(.c > .d):not(#\##\##\##\#) {
+:is(.a > .b) + :is(.c > .d):not(#\#):not(#\#):not(#\#):not(#\#) {
 		-webkit-box-ordinal-group: 29;
 		-webkit-order: 28;
 		   -moz-box-ordinal-group: 29;
@@ -606,22 +606,22 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 		        order: 28;
 	}
 
-.test-hwb-function:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-hwb-function:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	background-color: rgba(0, 195, 255, .5);
 	background-color: hwb(194 0% 0% / .5);
 }
 
-.test-opacity-percent:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.test-opacity-percent:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	opacity: 0.42;
 	opacity: 42%;
 }
 
-.clamp-same-unit:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.clamp-same-unit:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	width: max(10px, min(64px, 80px));
 	width: clamp(10px, 64px, 80px);
 }
 
-.complex-clamp:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.complex-clamp:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	width: max(-webkit-calc(100% - 10px), min(min(10px, 100%), max(40px, 4em)));
 	width: max(-moz-calc(100% - 10px), min(min(10px, 100%), max(40px, 4em)));
 	width: max(calc(100% - 10px), min(min(10px, 100%), max(40px, 4em)));
@@ -630,19 +630,19 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	width: clamp(calc(100% - 10px), min(10px, 100%), max(40px, 4em));
 }
 
-.clamp-different-units:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.clamp-different-units:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	width: max(10%, min(2px, 4rem));
 	width: clamp(10%, 2px, 4rem);
 }
 
-.mixed-clamp:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.mixed-clamp:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr);
 	grid-template-columns: clamp(22rem, 40%, 32rem) minmax(0, 1fr);
 	margin: max(1rem, min(2%, 3rem)) 4vh;
 	margin: clamp(1rem, 2%, 3rem) 4vh;
 }
 
-.calc-clamp:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.calc-clamp:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	margin: 0 40px 0 -webkit-calc(-1 * max(32px, min(16vw, 64px)));
 	margin: 0 40px 0 -moz-calc(-1 * max(32px, min(16vw, 64px)));
 	margin: 0 40px 0 calc(-1 * max(32px, min(16vw, 64px)));
@@ -651,7 +651,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	margin: 0 40px 0 calc(-1 * clamp(32px, 16vw, 64px));
 }
 
-.multiple-calc-clamp:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.multiple-calc-clamp:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	margin: -webkit-calc(-1 * max(1px, min(2vw, 3px))) -webkit-calc(-1 * max(4px, min(5vw, 6px)));
 	margin: -moz-calc(-1 * max(1px, min(2vw, 3px))) -moz-calc(-1 * max(4px, min(5vw, 6px)));
 	margin: calc(-1 * max(1px, min(2vw, 3px))) calc(-1 * max(4px, min(5vw, 6px)));
@@ -669,7 +669,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	margin: calc(-1 * clamp(1px, 2vw, 3px)) calc(-1 * clamp(4px, 5vw, 6px));
 }
 
-.nested-clamp:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.nested-clamp:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	font-size: max(max(1rem, min(2vw, 3rem)), min(4vw, 5rem));
 	font-size: max(clamp(1rem, 2vw, 3rem), min(4vw, 5rem));
 	font-size: max(1rem, min(2vw, 3rem));
@@ -685,42 +685,42 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	src: url(a) format(woff2);
 }
 
-.block-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.block-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: block;
 	display: block flow;
 }
 
-.block-flow-root:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.block-flow-root:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: flow-root;
 	display: block flow-root;
 }
 
-.inline-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: inline;
 	display: inline flow;
 }
 
-.inline-flow-root:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-flow-root:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: inline-block;
 	display: inline flow-root;
 }
 
-.run-in-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.run-in-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: run-in;
 	display: run-in flow;
 }
 
-.list-item-block-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.list-item-block-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: list-item;
 	display: list-item block flow;
 }
 
-.inline-flow-list-item:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-flow-list-item:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: inline list-item;
 	display: inline flow list-item;
 }
 
-.block-flex:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.block-flex:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: -webkit-box;
 	display: -webkit-flex;
 	display: -moz-box;
@@ -729,7 +729,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	display: block flex;
 }
 
-.inline-flex:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-flex:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: -webkit-inline-box;
 	display: -webkit-inline-flex;
 	display: -moz-inline-box;
@@ -738,52 +738,52 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	display: inline flex;
 }
 
-.block-grid:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.block-grid:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: grid;
 	display: block grid;
 }
 
-.inline-grid:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-grid:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: inline-grid;
 	display: inline grid;
 }
 
-.inline-ruby:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-ruby:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: ruby;
 	display: inline ruby;
 }
 
-.block-table:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.block-table:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: table;
 	display: block table;
 }
 
-.inline-table:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.inline-table:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: inline-table;
 	display: inline table;
 }
 
-.table-cell-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.table-cell-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: table-cell;
 	display: table-cell flow;
 }
 
-.table-caption-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.table-caption-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: table-caption;
 	display: table-caption flow;
 }
 
-.ruby-base-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.ruby-base-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: ruby-base;
 	display: ruby-base flow;
 }
 
-.ruby-text-flow:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.ruby-text-flow:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	display: ruby-text;
 	display: ruby-text flow;
 }
 
-.color-function:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.color-function:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	prop-1: rgb(0,132,94);
 	prop-1: color(display-p3 0.00000 0.51872 0.36985);
 	prop-2: 'color(display-p3 0.02472 0.01150 0.00574 / 1)';
@@ -799,7 +799,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	prop-5: color(display-p3 1 1 1 1);
 }
 
-.oklab:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.oklab:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	color-1: rgb(73, 71, 69);
 	color-1: color(display-p3 0.28515 0.27983 0.27246);
 	color-1: oklab(40% 0.001236 0.0039);
@@ -836,7 +836,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	color-12: oklab(72.322% -0.0465 -0.1150);
 }
 
-.oklch:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.oklch:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	color-1: rgb(126, 37, 15);
 	color-1: color(display-p3 0.45368 0.16978 0.09411);
 	color-1: oklch(40% 0.1268735435 34.568626);
@@ -894,7 +894,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	color-17: oklch(60% 0.1250 0.785398unknown);
 }
 
-.ic-unit:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.ic-unit:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	--value-2ic: 'something';
 	text-indent: 2em;
 	text-indent: 2ic;
@@ -916,12 +916,12 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	padding: 2    ic;
 }
 
-.unset:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.unset:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	clip: initial;
 	clip: unset;
 }
 
-.mod:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.mod:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	padding: 8px 3px 1px -webkit-calc(3px + 50%);
 	padding: 8px 3px 1px -moz-calc(3px + 50%);
 	padding: 8px 3px 1px calc(3px + 50%);
@@ -943,7 +943,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	width: mod(mod(-18px, 5px), 5px);
 }
 
-.rem:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.rem:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	padding: 8px 3px 1px -webkit-calc(3px + 50%);
 	padding: 8px 3px 1px -moz-calc(3px + 50%);
 	padding: 8px 3px 1px calc(3px + 50%);
@@ -962,7 +962,7 @@ h1.test-custom-selectors:not(#\##\##\##\##\##\##\##\##\##\##\##\#),h2.test-custo
 	        transform: rotate(rem(-140deg, -90deg));
 }
 
-.round:not(#\##\##\##\##\##\##\##\##\##\##\##\#) {
+.round:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	top: 3px;
 	top: round(2.5px, 1px);
 	right: 3px;

--- a/plugins/postcss-cascade-layers/CHANGELOG.md
+++ b/plugins/postcss-cascade-layers/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changes to PostCSS Cascade Layers
 
+### Unreleased
+
+- Use only simple `:not(#\#)` selectors to adjust specificity.
+
 ### 1.0.1 (May 17, 2022)
 
- - Process CSS after most other plugins to ensure correct analysis and transformation of sugary CSS.
- - Fix selector order with `:before` and other pseudo elements.
+- Process CSS after most other plugins to ensure correct analysis and transformation of sugary CSS.
+- Fix selector order with `:before` and other pseudo elements.
 
 ### 1.0.0 (May 12, 2022)
 

--- a/plugins/postcss-cascade-layers/README.md
+++ b/plugins/postcss-cascade-layers/README.md
@@ -46,8 +46,8 @@ for `@layer A, B, C`:
 | layer | specificity adjustment | selector |
 | ------ | ----------- | --- |
 | `A` | 0 | N/A |
-| `B` | 3 | `:not(#/##/##/#)` |
-| `C` | 6 | `:not(#/##/##/##/##/##/#)` |
+| `B` | 3 | `:not(#/#):not(#/#):not(#/#)` |
+| `C` | 6 | `:not(#/#):not(#/#):not(#/#):not(#/#):not(#/#):not(#/#)` |
 
 This approach lets more important (later) layers always override less important (earlier) layers.<br>
 And layers have enough room internally so that each selector works and overrides as expected.

--- a/plugins/postcss-cascade-layers/docs/README.md
+++ b/plugins/postcss-cascade-layers/docs/README.md
@@ -37,8 +37,8 @@ for `@layer A, B, C`:
 | layer | specificity adjustment | selector |
 | ------ | ----------- | --- |
 | `A` | 0 | N/A |
-| `B` | 3 | `:not(#/##/##/#)` |
-| `C` | 6 | `:not(#/##/##/##/##/##/#)` |
+| `B` | 3 | `:not(#/#):not(#/#):not(#/#)` |
+| `C` | 6 | `:not(#/#):not(#/#):not(#/#):not(#/#):not(#/#):not(#/#)` |
 
 This approach lets more important (later) layers always override less important (earlier) layers.<br>
 And layers have enough room internally so that each selector works and overrides as expected.

--- a/plugins/postcss-cascade-layers/src/adjust-selector-specificity.ts
+++ b/plugins/postcss-cascade-layers/src/adjust-selector-specificity.ts
@@ -20,8 +20,8 @@ function generateNot(specificity: number) {
 
 	let list = '';
 	for (let i = 0; i < specificity; i++) {
-		list += '#\\#'; // something short but still very uncommon
+		list += ':not(#\\#)'; // something short but still very uncommon
 	}
 
-	return `:not(${list})`;
+	return list;
 }

--- a/plugins/postcss-cascade-layers/test/anon-layer.expect.css
+++ b/plugins/postcss-cascade-layers/test/anon-layer.expect.css
@@ -7,14 +7,14 @@ target:not(#\#) {
 		color: orange;
 	}
 
-target:not(#\##\#) {
+target:not(#\#):not(#\#) {
 		color: yellow;
 	}
 
-target:not(#\##\##\#) {
+target:not(#\#):not(#\#):not(#\#) {
 		color: green;
 	}
 
-target:not(#\##\##\##\#) {
+target:not(#\#):not(#\#):not(#\#):not(#\#) {
 	color: purple;
 }

--- a/plugins/postcss-cascade-layers/test/atrules.expect.css
+++ b/plugins/postcss-cascade-layers/test/atrules.expect.css
@@ -15,7 +15,7 @@
 		system: extends three;
 	}
 
-#target:not(#\##\##\##\##\##\##\##\#) {
+#target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	animation: anim 1s paused;
 }
 
@@ -23,7 +23,7 @@
 	from { background-color: green; }
 }
 
-#target:not(#\##\##\##\##\##\##\##\#)::before {
+#target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::before {
 	content: counter(dont-care, custom-counter-style);
 }
 

--- a/plugins/postcss-cascade-layers/test/basic.expect.css
+++ b/plugins/postcss-cascade-layers/test/basic.expect.css
@@ -3,14 +3,14 @@
 		color: red;
 	}
 
-#foo #bar target:not(#\##\##\#)::before {
+#foo #bar target:not(#\#):not(#\#):not(#\#)::before {
 		color: green;
 	}
 
-target:not(#\##\##\##\##\##\#) {
+target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	color: purple;
 }
 
-target:not(#\##\##\##\##\##\#):before {
+target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):before {
 	color: pink;
 }

--- a/plugins/postcss-cascade-layers/test/important.expect.css
+++ b/plugins/postcss-cascade-layers/test/important.expect.css
@@ -15,7 +15,7 @@
 		background-color: blue;
 	}
 
-.foo:not(#\##\#) {
+.foo:not(#\#):not(#\#) {
 		color: pink !important;
 	}
 
@@ -23,7 +23,7 @@
 		background-color: pink;
 	}
 
-.bar:not(#\##\#) {
+.bar:not(#\#):not(#\#) {
 		color: green !important;
 	}
 
@@ -35,7 +35,7 @@
 	color: orange !important;
 }
 
-.foo:not(#\##\#) {
+.foo:not(#\#):not(#\#) {
 	background-color: orange;
 }
 
@@ -43,6 +43,6 @@
 	color: purple !important;
 }
 
-.bar:not(#\##\#) {
+.bar:not(#\#):not(#\#) {
 	background-color: green;
 }

--- a/plugins/postcss-cascade-layers/test/nested-complex.expect.css
+++ b/plugins/postcss-cascade-layers/test/nested-complex.expect.css
@@ -16,19 +16,19 @@
 }
 
 @media screen {
-	target:not(#\##\##\##\##\##\##\#) {
+	target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		layered: no;
 		order: 3;
 	}
 }
 
 @media screen {
-		target:not(#\##\##\##\##\#) {
+		target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 			order: 6;
 		}
 
 		@media screen {
-			target:not(#\##\##\##\##\#) {
+			target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 				order: 7;
 			}
 		}
@@ -37,12 +37,12 @@
 @media screen {
 
 		@media screen {
-				target:not(#\##\##\#) {
+				target:not(#\#):not(#\#):not(#\#) {
 					order: 8;
 				}
 
 				@media screen {
-					target:not(#\##\##\#) {
+					target:not(#\#):not(#\#):not(#\#) {
 						order: 9;
 					}
 				}
@@ -54,7 +54,7 @@
 		@media screen {
 
 				@media screen {
-						target:not(#\##\#) {
+						target:not(#\#):not(#\#) {
 							order: 10;
 						}
 				}
@@ -62,7 +62,7 @@
 }
 
 @media screen {
-	target:not(#\##\##\##\##\##\##\#) {
+	target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		layered: no;
 		order: 5;
 	}

--- a/plugins/postcss-cascade-layers/test/nested.expect.css
+++ b/plugins/postcss-cascade-layers/test/nested.expect.css
@@ -28,31 +28,31 @@ i:not(#\#) {
 		color: red;
 	}
 
-target:not(#\##\##\#) {
+target:not(#\#):not(#\#):not(#\#) {
 			color: yellow;
 		}
 
-target:not(#\##\##\##\##\##\#) {
+target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 			color: yellow;
 		}
 
 @media (prefers-color-scheme: dark) {
-		h1:not(#\##\##\##\##\##\##\#) {
+		h1:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 			color: red;
 			background: black;
 		}
 	}
 
 @media (prefers-color-scheme: dark) {
-			target:not(#\##\##\##\##\##\#) {
+			target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 				color: lime;
 			}
 	}
 
-target:not(#\##\##\##\##\##\##\##\#) {
+target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 			color: yellow;
 		}
 
-target:not(#\##\##\##\##\##\##\##\##\#) {
+target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		color: red;
 	}

--- a/plugins/postcss-cascade-layers/test/specificity-buckets-a.expect.css
+++ b/plugins/postcss-cascade-layers/test/specificity-buckets-a.expect.css
@@ -1,4 +1,4 @@
-#foo:not(#\##\##\##\#) {
+#foo:not(#\#):not(#\#):not(#\#):not(#\#) {
 	bucket: 1;
 }
 
@@ -6,6 +6,6 @@
 		bucket: 2;
 	}
 
-#foo:not(#\##\#) {
+#foo:not(#\#):not(#\#) {
 		bucket: 3;
 	}

--- a/plugins/postcss-cascade-layers/test/specificity-buckets-b.expect.css
+++ b/plugins/postcss-cascade-layers/test/specificity-buckets-b.expect.css
@@ -1,4 +1,4 @@
-foo:not(#\##\##\##\##\##\##\##\#) {
+foo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 	bucket: 1;
 }
 
@@ -18,18 +18,18 @@ foo {
 		bucket: 2;
 	}
 
-foo:not(#\##\##\##\#) {
+foo:not(#\#):not(#\#):not(#\#):not(#\#) {
 		bucket: 3;
 	}
 
-#foo:not(#\##\##\##\#) {
+#foo:not(#\#):not(#\#):not(#\#):not(#\#) {
 		bucket: 3;
 	}
 
-#foo #fooz:not(#\##\##\##\#) {
+#foo #fooz:not(#\#):not(#\#):not(#\#):not(#\#) {
 		bucket: 3;
 	}
 
-#foo #fooz #foos:not(#\##\##\##\#) {
+#foo #fooz #foos:not(#\#):not(#\#):not(#\#):not(#\#) {
 		bucket: 3;
 	}

--- a/plugins/postcss-cascade-layers/test/unlayered-styles.expect.css
+++ b/plugins/postcss-cascade-layers/test/unlayered-styles.expect.css
@@ -7,14 +7,14 @@ target:not(#\#) {
 		color: green;
 	}
 
-a:not(#\##\#) {
+a:not(#\#):not(#\#) {
 	color: purple;
 }
 
-target:not(#\##\#) {
+target:not(#\#):not(#\#) {
   color: green;
 }
 
-span h1:not(#\##\#), span p:not(#\##\#) {
+span h1:not(#\#):not(#\#), span p:not(#\#):not(#\#) {
   color:red;
 }

--- a/plugins/postcss-cascade-layers/test/warnings.expect.css
+++ b/plugins/postcss-cascade-layers/test/warnings.expect.css
@@ -13,7 +13,7 @@
 		}
 }
 
-.foo:not(#\##\#) {
+.foo:not(#\#):not(#\#) {
 		color: pink;
 	}
 

--- a/plugins/postcss-cascade-layers/test/warnings.with-postcss-import.expect.css
+++ b/plugins/postcss-cascade-layers/test/warnings.with-postcss-import.expect.css
@@ -6,13 +6,13 @@
 		color: revert-layer;
 	}/* [postcss-cascade-layers]: handling different layer orders in conditional rules is unsupported by this plugin and will cause style differences between browser versions. */
 @media (min-width: 10px) {
-		.foo:not(#\##\#) {
+		.foo:not(#\#):not(#\#) {
 			color: red;
 		}
 }
-.foo:not(#\##\##\#) {
+.foo:not(#\#):not(#\#):not(#\#) {
 		color: pink;
 	}
-.foo:not(#\##\#) {
+.foo:not(#\#):not(#\#) {
 		color: red;
 	}


### PR DESCRIPTION
Older browsers don't have support for compound selectors in `:not()`.
I incorrectly assumed that non-complex selectors were ok.

CI will fail because I haven't updated preset-env tests.
Will do so after : https://github.com/csstools/postcss-plugins/pull/386