### PR TITLE
design tokens : unit conversion

### DIFF
--- a/plugins/postcss-design-tokens/.tape.mjs
+++ b/plugins/postcss-design-tokens/.tape.mjs
@@ -5,10 +5,20 @@ import postcssImport from 'postcss-import';
 postcssTape(plugin)({
 	basic: {
 		message: "supports basic usage",
-		options: {},
 		plugins: [
 			postcssImport(),
 			plugin()
+		]
+	},
+	'basic:rootFontSize-20': {
+		message: "supports basic usage with { unitsAndValues { rootFontSize: 20 } }",
+		plugins: [
+			postcssImport(),
+			plugin({
+				unitsAndValues: {
+					rootFontSize: 20
+				}
+			})
 		]
 	},
 	'errors': {

--- a/plugins/postcss-design-tokens/src/data-formats/base/token.ts
+++ b/plugins/postcss-design-tokens/src/data-formats/base/token.ts
@@ -1,3 +1,10 @@
+export interface TokenTransformOptions {
+	pluginOptions?: {
+		rootFontSize?: number;
+	};
+	toUnit?: string;
+}
+
 export interface Token {
-	cssValue(): string
+	cssValue(opts?: TokenTransformOptions): string
 }

--- a/plugins/postcss-design-tokens/src/data-formats/style-dictionary/v3/dereference.ts
+++ b/plugins/postcss-design-tokens/src/data-formats/style-dictionary/v3/dereference.ts
@@ -1,5 +1,6 @@
+import { TokenTransformOptions } from '../../base/token';
 import { toposort } from '../../toposort/toposort';
-import { StyleDictionaryV3TokenValue } from './value';
+import { applyTransformsToValue, StyleDictionaryV3TokenValue } from './value';
 
 export function dereferenceTokenValues(tokens: Map<string, StyleDictionaryV3TokenValue>): Map<string, StyleDictionaryV3TokenValue> {
 	const tainted = new Set<string>();
@@ -53,8 +54,8 @@ export function dereferenceTokenValues(tokens: Map<string, StyleDictionaryV3Toke
 			const currentToken = tokens.get(id);
 
 			currentToken.value = value;
-			currentToken.cssValue = () => {
-				return value ?? '';
+			currentToken.cssValue = (transformOptions: TokenTransformOptions) => {
+				return applyTransformsToValue(value, transformOptions);
 			};
 
 			tokens.set(id, currentToken);
@@ -125,8 +126,8 @@ export function dereferenceTokenValues(tokens: Map<string, StyleDictionaryV3Toke
 			const currentToken = tokens.get(id);
 
 			currentToken.value = value;
-			currentToken.cssValue = () => {
-				return value ?? '';
+			currentToken.cssValue = (transformOptions: TokenTransformOptions) => {
+				return applyTransformsToValue(value, transformOptions);
 			};
 
 			tokens.set(id, currentToken);

--- a/plugins/postcss-design-tokens/src/index.ts
+++ b/plugins/postcss-design-tokens/src/index.ts
@@ -2,11 +2,9 @@ import type { Node, PluginCreator } from 'postcss';
 import { Token } from './data-formats/base/token';
 import { tokensFromImport } from './data-formats/parse-import';
 import { mergeTokens } from './data-formats/token';
+import { pluginOptions } from './options';
 import { onCSSValue } from './values';
 
-type pluginOptions = {
-	is?: Array<string>
-}
 
 const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 	const buildIs = opts?.is ?? [];
@@ -70,7 +68,7 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 						return;
 					}
 
-					const modifiedValue = onCSSValue(tokens, result, decl);
+					const modifiedValue = onCSSValue(tokens, result, decl, opts);
 					if (modifiedValue === decl.value) {
 						return;
 					}

--- a/plugins/postcss-design-tokens/src/options.ts
+++ b/plugins/postcss-design-tokens/src/options.ts
@@ -1,0 +1,6 @@
+export type pluginOptions = {
+	is?: Array<string>
+	unitsAndValues?: {
+		rootFontSize?: number
+	}
+}

--- a/plugins/postcss-design-tokens/test/basic.css
+++ b/plugins/postcss-design-tokens/test/basic.css
@@ -10,4 +10,45 @@
 .card {
 	background-color: design-token('card.background');
 	color: design-token('card.foreground');
+	color: design-token(  'card.foreground');
+	color: design-token('card.foreground'  );
+	color: design-token(
+		/* a foreground color */
+		'card.foreground'
+	);
+	color: design-token(
+		'card.foreground'
+		/* a foreground color */
+	);
+}
+
+.px-to-px {
+	padding-bottom: design-token('space.small' to px);
+	padding-bottom: design-token('space.default' to px);
+	padding-bottom: design-token('space.large' to px);
+}
+
+.px-to-rem {
+	padding-bottom: design-token('space.small' to rem);
+	padding-bottom: design-token('space.default' to rem);
+	padding-bottom: design-token('space.large' to rem);
+}
+
+.rem-to-rem {
+	padding-bottom: design-token('space.small-b' to rem);
+	padding-bottom: design-token('space.default-b' to rem);
+	padding-bottom: design-token('space.large-b' to rem);
+}
+
+.rem-to-px {
+	padding-bottom: design-token('space.small-b' to px);
+	padding-bottom: design-token('space.default-b' to px);
+	padding-bottom: design-token('space.large-b' to px);
+}
+
+.invalid-conversion {
+	color: design-token('card.foreground' to rem);
+	color: design-token('card.foreground' to px);
+	color: design-token('space.lh' to rem);
+	color: design-token('space.lh' to px);
 }

--- a/plugins/postcss-design-tokens/test/basic.rootFontSize-20.expect.css
+++ b/plugins/postcss-design-tokens/test/basic.rootFontSize-20.expect.css
@@ -17,9 +17,9 @@
 	padding-bottom: 32px;
 }
 .px-to-rem {
-	padding-bottom: 0.5rem;
-	padding-bottom: 1.1rem;
-	padding-bottom: 2rem;
+	padding-bottom: 0.4rem;
+	padding-bottom: 0.9rem;
+	padding-bottom: 1.6rem;
 }
 .rem-to-rem {
 	padding-bottom: 0.5rem;
@@ -27,9 +27,9 @@
 	padding-bottom: 2rem;
 }
 .rem-to-px {
-	padding-bottom: 8px;
-	padding-bottom: 18px;
-	padding-bottom: 32px;
+	padding-bottom: 10px;
+	padding-bottom: 22.5px;
+	padding-bottom: 40px;
 }
 .invalid-conversion {
 	color: red;

--- a/plugins/postcss-design-tokens/test/tokens/basic.json
+++ b/plugins/postcss-design-tokens/test/tokens/basic.json
@@ -18,5 +18,28 @@
 	"logical-color": {
 		"foreground": { "value": "{base-color.red}" },
 		"background": { "value": "{base-color.blue}" }
+	},
+	"space": {
+		"small": {
+			"value": "8px"
+		},
+		"default": {
+			"value": "18px"
+		},
+		"large": {
+			"value": "32px"
+		},
+		"small-b": {
+			"value": "0.5rem"
+		},
+		"default-b": {
+			"value": "1.125rem"
+		},
+		"large-b": {
+			"value": "2rem"
+		},
+		"lh": {
+			"value": "1lh"
+		}
 	}
 }


### PR DESCRIPTION
reading : https://www.joshwcomeau.com/css/surprising-truth-about-pixels-and-accessibility/

---------

When values and units are fully determined by designers and/or design tools we take away control from developers.

In some cases this is fine as developers (will soon) have tools to manipulate values in native CSS. (e.g. `calc` or relative color syntax).

But some units are different.
`px` vs. `rem` is meaningful and they aren't equivalent.

Developers should have the freedom and tools to convert values from design tokens to the correct unit for each rule and property.

```css
.unit-conversion {
	padding-bottom: design-token('space.small' to px);
	padding-bottom: design-token('space.small' to rem);
}
```

Without a conversion mechanic designers and developers will have to declare each value twice, once for each unit.

- designers might not know the root font size
- you lose the connection between components/views and used design tokens

```css
.unit-conversion {
	padding-bottom: design-token('space.small.px');
	padding-bottom: design-token('space.small.rem');
}
```

Alternatively designs and developers do nothing and settle on inaccessible results :/

------

I hope this won't explode later into a lot of conversions.
But I think it will be fine as I can only think of `rem` vs. `px` having this complexity.

If there are more units please let me know.