### PR TITLE
fix: node:vm syntax support in node@14.17.2

### DIFF
--- a/plugins/postcss-trigonometric-functions/src/utils.ts
+++ b/plugins/postcss-trigonometric-functions/src/utils.ts
@@ -1,6 +1,6 @@
 import type { FunctionNode, WordNode, Node } from 'postcss-value-parser';
 import valueParser from 'postcss-value-parser';
-import vm from 'node:vm';
+import vm from 'vm';
 
 export function turnToRad(turn: number): number {
 	return turn * 2 * Math.PI;

--- a/rollup/configs/externals.js
+++ b/rollup/configs/externals.js
@@ -2,7 +2,7 @@ export const externalsForCLI = [
 	'fs',
 	'path',
 	'url',
-	'node:vm',
+	'vm',
 
 	'@csstools/postcss-cascade-layers',
 	'@csstools/postcss-color-function',
@@ -59,7 +59,7 @@ export const externalsForPlugin = [
 	'fs',
 	'path',
 	'url',
-	'node:vm',
+	'vm',
 
 	'postcss',
 	/^postcss-\d\.\d$/,


### PR DESCRIPTION
`node:vm` syntax will throw error `cannot find module node:vm` with node@14.17.2