### PR TITLE
Add `compare()` function to `selector-specificity`

### DIFF
--- a/packages/selector-specificity/README.md
+++ b/packages/selector-specificity/README.md
@@ -32,7 +32,7 @@ To compare or otherwise manipulate lists of selectors you need to call `selector
 The package exports a utility function to compare two specificities.
 
 ```js
-import selectorSpecificity, { compare } from '@csstools/selector-specificity';
+import { selectorSpecificity , compare } from '@csstools/selector-specificity';
 
 const s1 = selectorSpecificity(ast1);
 const s2 = selectorSpecificity(ast2);

--- a/packages/selector-specificity/README.md
+++ b/packages/selector-specificity/README.md
@@ -27,6 +27,22 @@ console.log(specificity.c); // 0
 _`selectorSpecificity` takes a single selector, not a list of selectors (not : `a, b, c`).
 To compare or otherwise manipulate lists of selectors you need to call `selectorSpecificity` on each part._
 
+### Comparing
+
+The package exports a utility function to compare two specificities.
+
+```js
+import selectorSpecificity, { compare } from '@csstools/selector-specificity';
+
+const s1 = selectorSpecificity(ast1);
+const s2 = selectorSpecificity(ast2);
+compare(s1, s2); // -1, 0, 1
+```
+
+- if `s1 < s2` then `compare(s1, s2)` returns a negative number (`< 0`)
+- if `s1 > s2` then `compare(s1, s2)` returns a positive number (`> 0`)
+- if `s1 === s2` then `compare(s1, s2)` returns zero (`=== 0`)
+
 ## Prior Art
 
 - [keeganstreet/specificity](https://github.com/keeganstreet/specificity)

--- a/packages/selector-specificity/README.md
+++ b/packages/selector-specificity/README.md
@@ -36,7 +36,7 @@ import selectorSpecificity, { compare } from '@csstools/selector-specificity';
 
 const s1 = selectorSpecificity(ast1);
 const s2 = selectorSpecificity(ast2);
-compare(s1, s2); // -1, 0, 1
+compare(s1, s2); // -1 | 0 | 1
 ```
 
 - if `s1 < s2` then `compare(s1, s2)` returns a negative number (`< 0`)

--- a/packages/selector-specificity/README.md
+++ b/packages/selector-specificity/README.md
@@ -32,7 +32,7 @@ To compare or otherwise manipulate lists of selectors you need to call `selector
 The package exports a utility function to compare two specificities.
 
 ```js
-import { selectorSpecificity , compare } from '@csstools/selector-specificity';
+import { selectorSpecificity, compare } from '@csstools/selector-specificity';
 
 const s1 = selectorSpecificity(ast1);
 const s2 = selectorSpecificity(ast2);

--- a/packages/selector-specificity/package.json
+++ b/packages/selector-specificity/package.json
@@ -52,7 +52,7 @@
 		"lint:package-json": "node ../../.github/bin/format-package-json.mjs",
 		"prepublishOnly": "npm run clean && npm run build && npm run test",
 		"stryker": "stryker run --logLevel error",
-		"test": "npm run test:exports && node ./test/example.mjs && node ./test/test.mjs && node ./test/tests-from-bramus-specificity.mjs && node ./test/tests-from-keeganstreet-specificity.mjs",
+		"test": "npm run test:exports && node ./test/example.mjs && node ./test/test.mjs && node ./test/tests-from-bramus-specificity.mjs && node ./test/tests-from-keeganstreet-specificity.mjs && node ./test/test-compare.mjs",
 		"test:exports": "node ./test/_import.mjs && node ./test/_require.cjs"
 	},
 	"homepage": "https://github.com/csstools/postcss-plugins/tree/main/packages/selector-specificity#readme",

--- a/packages/selector-specificity/src/index.ts
+++ b/packages/selector-specificity/src/index.ts
@@ -1,7 +1,13 @@
 import parser from 'postcss-selector-parser';
 import type { Node } from 'postcss-selector-parser';
 
-export default function selectorSpecificity(node: Node) {
+export type Specificity = {
+	a: number,
+	b: number,
+	c: number,
+};
+
+export default function selectorSpecificity(node: Node): Specificity {
 	// https://www.w3.org/TR/selectors-4/#specificity-rules
 
 	if (!node) {
@@ -156,4 +162,14 @@ function isPseudoElement(node: Node): boolean {
 	// Typescript definition of "isPseudoElement" is incorrect.
 	// This function removes the magic and is a simple boolean check.
 	return parser.isPseudoElement(node);
+}
+
+export function compare(s1: Specificity, s2: Specificity): number {
+	if (s1.a === s2.a) {
+		if (s1.b === s2.b) {
+			return s1.c - s2.c;
+		}
+		return s1.b - s2.b;
+	}
+	return s1.a - s2.a;
 }

--- a/packages/selector-specificity/test/_import.mjs
+++ b/packages/selector-specificity/test/_import.mjs
@@ -1,6 +1,8 @@
 import assert from 'assert';
-import selectorSpecificity from '@csstools/selector-specificity';
+import selectorSpecificity, { compare } from '@csstools/selector-specificity';
 
 assert.equal(selectorSpecificity().a, 0);
 assert.equal(selectorSpecificity().b, 0);
 assert.equal(selectorSpecificity().c, 0);
+
+assert.equal(compare(selectorSpecificity(), selectorSpecificity()), 0);

--- a/packages/selector-specificity/test/_require.cjs
+++ b/packages/selector-specificity/test/_require.cjs
@@ -1,6 +1,8 @@
 const assert = require('assert');
-const selectorSpecificity = require('@csstools/selector-specificity');
+const { default: selectorSpecificity, compare } = require('@csstools/selector-specificity');
 
 assert.equal(selectorSpecificity().a, 0);
 assert.equal(selectorSpecificity().b, 0);
 assert.equal(selectorSpecificity().c, 0);
+
+assert.equal(compare(selectorSpecificity(), selectorSpecificity()), 0);

--- a/packages/selector-specificity/test/test-compare.mjs
+++ b/packages/selector-specificity/test/test-compare.mjs
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import { compare } from '@csstools/selector-specificity';
+
+assert.strictEqual(compare({ a: 0, b: 0, c: 0 }, { a: 0, b: 0, c: 0 }), 0);
+
+assert.strictEqual(compare({ a: 0, b: 0, c: 0 }, { a: 0, b: 0, c: 1 }), -1);
+assert.strictEqual(compare({ a: 0, b: 0, c: 0 }, { a: 0, b: 1, c: 0 }), -1);
+assert.strictEqual(compare({ a: 0, b: 0, c: 0 }, { a: 1, b: 0, c: 0 }), -1);
+assert.strictEqual(compare({ a: 0, b: 0, c: 0 }, { a: 1, b: 1, c: 0 }), -1);
+assert.strictEqual(compare({ a: 0, b: 0, c: 0 }, { a: 1, b: 0, c: 1 }), -1);
+assert.strictEqual(compare({ a: 0, b: 0, c: 0 }, { a: 0, b: 1, c: 1 }), -1);
+assert.strictEqual(compare({ a: 0, b: 0, c: 0 }, { a: 1, b: 1, c: 1 }), -1);
+
+assert.strictEqual(compare({ a: 0, b: 0, c: 1 }, { a: 0, b: 0, c: 0 }), 1);
+assert.strictEqual(compare({ a: 0, b: 1, c: 0 }, { a: 0, b: 0, c: 0 }), 1);
+assert.strictEqual(compare({ a: 1, b: 0, c: 0 }, { a: 0, b: 0, c: 0 }), 1);
+assert.strictEqual(compare({ a: 1, b: 1, c: 0 }, { a: 0, b: 0, c: 0 }), 1);
+assert.strictEqual(compare({ a: 1, b: 0, c: 1 }, { a: 0, b: 0, c: 0 }), 1);
+assert.strictEqual(compare({ a: 0, b: 1, c: 1 }, { a: 0, b: 0, c: 0 }), 1);
+assert.strictEqual(compare({ a: 1, b: 1, c: 1 }, { a: 0, b: 0, c: 0 }), 1);


### PR DESCRIPTION
This PR adds a `compare()` utility function like the [`specificty`](https://www.npmjs.com/package/specificity) package or the [`@bramus/specificity`](https://www.npmjs.com/package/@bramus/specificity) have.

Also, Stylelint may need it. See https://github.com/stylelint/stylelint/pull/6131