### PR TITLE
declare postcss-value-parser as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6948,7 +6948,7 @@
 		"plugins/postcss-custom-media": {
 			"version": "8.0.1",
 			"license": "MIT",
-			"devDependencies": {
+			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {

--- a/plugins/postcss-custom-media/CHANGELOG.md
+++ b/plugins/postcss-custom-media/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to PostCSS Custom Media
 
+### Unreleased
+
+- Fixed: dependency declarations in package.json
+
 ### 8.0.1 (June 3, 2022)
 
 - Updated: use specific AtRule visitor

--- a/plugins/postcss-custom-media/package.json
+++ b/plugins/postcss-custom-media/package.json
@@ -47,7 +47,7 @@
 	"peerDependencies": {
 		"postcss": "^8.3"
 	},
-	"devDependencies": {
+	"dependencies": {
 		"postcss-value-parser": "^4.2.0"
 	},
 	"scripts": {

--- a/plugins/postcss-custom-media/package.json
+++ b/plugins/postcss-custom-media/package.json
@@ -44,11 +44,11 @@
 		"README.md",
 		"dist"
 	],
-	"peerDependencies": {
-		"postcss": "^8.3"
-	},
 	"dependencies": {
 		"postcss-value-parser": "^4.2.0"
+	},
+	"peerDependencies": {
+		"postcss": "^8.3"
 	},
 	"scripts": {
 		"build": "rollup -c ../../rollup/default.js",


### PR DESCRIPTION
Declaring it as `devDependency` was an unfortunate typo