### PR TITLE
selector-specificity : fix exceptions on `:nth-child`

### DIFF
--- a/packages/selector-specificity/CHANGELOG.md
+++ b/packages/selector-specificity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to Selector Specificity
 
+### Unreleased (patch)
+
+- Fixed: Exception on `:nth-child` without arguments. [#439](https://github.com/csstools/postcss-plugins/issues/439)
+
 ### 2.0.0 (June 4, 2022)
 
 - Breaking: use only named exports instead of `default`

--- a/packages/selector-specificity/src/index.ts
+++ b/packages/selector-specificity/src/index.ts
@@ -57,6 +57,7 @@ export function selectorSpecificity(node: Node): Specificity {
 					b += mostSpecificListItem.b;
 					c += mostSpecificListItem.c;
 				}
+
 				break;
 			}
 
@@ -71,40 +72,46 @@ export function selectorSpecificity(node: Node): Specificity {
 				{
 					b += 1;
 
-					const ofSeparatorIndex = node.nodes[0].nodes.findIndex((x) => {
-						return x.type === 'tag' && x.value === 'of';
-					});
+					if (node.nodes && node.nodes.length > 0) {
+						const ofSeparatorIndex = node.nodes[0].nodes.findIndex((x) => {
+							return x.type === 'tag' && x.value === 'of';
+						});
 
-					if (ofSeparatorIndex > -1) {
-						const subSelector = [
-							parser.selector({
-								nodes: node.nodes[0].nodes.slice(ofSeparatorIndex + 1),
-								value: '',
-							}),
-						];
+						if (ofSeparatorIndex > -1) {
+							const subSelector = [
+								parser.selector({
+									nodes: node.nodes[0].nodes.slice(ofSeparatorIndex + 1),
+									value: '',
+								}),
+							];
 
-						if (node.nodes.length > 1) {
-							subSelector.push(...node.nodes.slice(1));
+							if (node.nodes.length > 1) {
+								subSelector.push(...node.nodes.slice(1));
+							}
+
+							const mostSpecificListItem = specificityOfMostSpecificListItem(subSelector);
+
+							a += mostSpecificListItem.a;
+							b += mostSpecificListItem.b;
+							c += mostSpecificListItem.c;
 						}
-
-						const mostSpecificListItem = specificityOfMostSpecificListItem(subSelector);
-
-						a += mostSpecificListItem.a;
-						b += mostSpecificListItem.b;
-						c += mostSpecificListItem.c;
 					}
 				}
+
 				break;
 
 			case ':local':
 			case ':global':
 				// see : https://github.com/css-modules/css-modules
-				node.nodes.forEach((child) => {
-					const specificity = selectorSpecificity(child);
-					a += specificity.a;
-					b += specificity.b;
-					c += specificity.c;
-				});
+				if (node.nodes && node.nodes.length > 0) {
+					node.nodes.forEach((child) => {
+						const specificity = selectorSpecificity(child);
+						a += specificity.a;
+						b += specificity.b;
+						c += specificity.c;
+					});
+				}
+
 				break;
 
 			default:

--- a/packages/selector-specificity/test/test.mjs
+++ b/packages/selector-specificity/test/test.mjs
@@ -7,6 +7,62 @@ function calculate(selector) {
 	return selectorSpecificity(selectorAST);
 }
 
+assert.deepEqual(calculate('*'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':where(*)'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':is(*)'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':not(*)'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':where(*)'), { a: 0, b: 0, c: 0 });
+
+assert.deepEqual(calculate(':-moz-any'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':-moz-any()'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':-moz-any(.a)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':-webkit-any'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':-webkit-any()'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':-webkit-any(.a)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':any'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':any()'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':any(.a)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':has'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':has()'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':has(.a)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':is'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':is()'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':is(.a)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':matches'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':matches()'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':matches(.a)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':not'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':not()'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':not(.a)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':where'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':where()'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':where(.a)'), { a: 0, b: 0, c: 0 });
+
+assert.deepEqual(calculate(':nth-child'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-child()'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-child(1n)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-child(.a)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-last-child'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-last-child()'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-last-child(1n)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-last-child(.a)'), { a: 0, b: 1, c: 0 });
+
+assert.deepEqual(calculate(':nth-of-type'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-of-type()'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-of-type(1n)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-of-type(.a)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-last-of-type'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-last-of-type()'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-last-of-type(1n)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':nth-last-of-type(.a)'), { a: 0, b: 1, c: 0 });
+
+assert.deepEqual(calculate(':local'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':local()'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':local(.a)'), { a: 0, b: 1, c: 0 });
+assert.deepEqual(calculate(':global'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':global()'), { a: 0, b: 0, c: 0 });
+assert.deepEqual(calculate(':global(.a)'), { a: 0, b: 1, c: 0 });
+
 assert.deepEqual(calculate(':before'), { a: 0, b: 0, c: 1 });
 assert.deepEqual(calculate('::before'), { a: 0, b: 0, c: 1 });
 


### PR DESCRIPTION
fixes : https://github.com/csstools/postcss-plugins/issues/439

_I've also added a few more tests for other pseudo classes which might take arguments._