### PR TITLE
has pseudo : chores

### DIFF
--- a/experimental/css-has-pseudo/package.json
+++ b/experimental/css-has-pseudo/package.json
@@ -36,14 +36,14 @@
 		"dist"
 	],
 	"dependencies": {
-		"@csstools/selector-specificity": "^2.0.0",
+		"@csstools/selector-specificity": "^2.0.1",
 		"postcss-selector-parser": "^6.0.10"
 	},
 	"peerDependencies": {
 		"postcss": "^8.3"
 	},
 	"devDependencies": {
-		"@mrhenry/core-web": "^0.7.1",
+		"@mrhenry/core-web": "^0.7.2",
 		"puppeteer": "^13.6.0"
 	},
 	"scripts": {

--- a/experimental/css-has-pseudo/src/browser.js
+++ b/experimental/css-has-pseudo/src/browser.js
@@ -21,7 +21,7 @@ export default function cssHasPseudo(document, options) {
 		if (!options.forcePolyfill) {
 			try {
 				// Chrome does not support forgiving selector lists in :has()
-				global.document.querySelector(':has(*, :does-not-exist, > *)');
+				document.querySelector(':has(*, :does-not-exist, > *)');
 
 				// Safari incorrectly returns the html element with this query
 				if (!document.querySelector(':has(:scope *)')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,11 +95,11 @@
 			"version": "0.5.2",
 			"license": "CC0-1.0",
 			"dependencies": {
-				"@csstools/selector-specificity": "^2.0.0",
+				"@csstools/selector-specificity": "^2.0.1",
 				"postcss-selector-parser": "^6.0.10"
 			},
 			"devDependencies": {
-				"@mrhenry/core-web": "^0.7.1",
+				"@mrhenry/core-web": "^0.7.2",
 				"puppeteer": "^13.6.0"
 			},
 			"engines": {
@@ -2039,9 +2039,9 @@
 			}
 		},
 		"node_modules/@mrhenry/core-web": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@mrhenry/core-web/-/core-web-0.7.1.tgz",
-			"integrity": "sha512-R9oKe34+qJX4BrO1hmk0TR0nZyDFofCm4NzfsoarpXa8kQ+IfZmXEwhUCO6FNvhP128xOR8ZEv1m/2GC7L7poQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@mrhenry/core-web/-/core-web-0.7.2.tgz",
+			"integrity": "sha512-Z6OgesBOrVVsnx8gE5pSjVloLx4OtI60K8d3G/Mgq0ImBPSJ8sejwvcBIoj3eXVKJ06qV7ripHGZFhT2bOXhGw==",
 			"dev": true,
 			"dependencies": {
 				"semver": "^7.3.5"
@@ -8623,8 +8623,8 @@
 		"@csstools/css-has-pseudo-experimental": {
 			"version": "file:experimental/css-has-pseudo",
 			"requires": {
-				"@csstools/selector-specificity": "^2.0.0",
-				"@mrhenry/core-web": "^0.7.1",
+				"@csstools/selector-specificity": "^2.0.1",
+				"@mrhenry/core-web": "^0.7.2",
 				"postcss-selector-parser": "^6.0.10",
 				"puppeteer": "^13.6.0"
 			}
@@ -8927,9 +8927,9 @@
 			}
 		},
 		"@mrhenry/core-web": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@mrhenry/core-web/-/core-web-0.7.1.tgz",
-			"integrity": "sha512-R9oKe34+qJX4BrO1hmk0TR0nZyDFofCm4NzfsoarpXa8kQ+IfZmXEwhUCO6FNvhP128xOR8ZEv1m/2GC7L7poQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@mrhenry/core-web/-/core-web-0.7.2.tgz",
+			"integrity": "sha512-Z6OgesBOrVVsnx8gE5pSjVloLx4OtI60K8d3G/Mgq0ImBPSJ8sejwvcBIoj3eXVKJ06qV7ripHGZFhT2bOXhGw==",
 			"dev": true,
 			"requires": {
 				"semver": "^7.3.5"


### PR DESCRIPTION
- update [`@mrhenry/core-web`](https://github.com/mrhenry/core-web/releases/tag/v0.7.2). This change has no effect as the client side polyfill has a `try catch` around the code that could throw before.
- update `@csstools/selector-specificity`
- remove `global` from `global.document` for consistency

_these changes do not require a new release._