### PR TITLE
cascade-layers : test with :where

### DIFF
--- a/plugins/postcss-cascade-layers/.tape.mjs
+++ b/plugins/postcss-cascade-layers/.tape.mjs
@@ -52,6 +52,9 @@ postcssTape(plugin)({
 			plugin(),
 		]
 	},
+	'where': {
+		message: "works with zero specificity selectors",
+	},
 	'specificity-buckets-a': {
 		message: "creates non overlapping specificity buckets",
 	},

--- a/plugins/postcss-cascade-layers/test/where.css
+++ b/plugins/postcss-cascade-layers/test/where.css
@@ -1,0 +1,17 @@
+@layer default, override;
+
+:where(.foo) {
+	color: green;
+}
+
+@layer override {
+	:where(.foo) {
+		color: orange;
+	}
+}
+
+@layer default {
+	:where(.foo) {
+		color: red;
+	}
+}

--- a/plugins/postcss-cascade-layers/test/where.expect.css
+++ b/plugins/postcss-cascade-layers/test/where.expect.css
@@ -1,0 +1,11 @@
+:where(.foo):not(#\#):not(#\#) {
+	color: green;
+}
+
+:where(.foo):not(#\#) {
+		color: orange;
+	}
+
+:where(.foo) {
+		color: red;
+	}


### PR DESCRIPTION
I suddenly worried that this might not work if all selectors have zero specificity.
Considering how the buckets of specificity are created this could have been a bug.

-> It all works as expected