### PR TITLE
postcss-nesting : partially revert 10.1.9 and fix #510

### DIFF
--- a/plugins/postcss-nesting/CHANGELOG.md
+++ b/plugins/postcss-nesting/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changes to PostCSS Nesting
 
+### Unreleased
+
+- Partially revert the changes to pseudo element selectors from 10.1.9.
+
+```diff
+.anything::before {
+	@nest .something_else > & {
+		order: 1;
+	}
+}
+
+/* becomes */
+
+- .something_else > :is(.anything:::before) { /* 10.1.9 */
++ .something_else > .anything::before { /* previous and restored behavior */
+		order: 1;
+}
+```
+
+The exact behavior of this pattern is unspecified and might change in the future.
+We are reverting to the previous behavior until the specification is clarified.
+
 ### 10.1.9 (June 23, 2022)
 
 - Fix selector order with any pseudo element.

--- a/plugins/postcss-nesting/src/lib/merge-selectors/merge-selectors.js
+++ b/plugins/postcss-nesting/src/lib/merge-selectors/merge-selectors.js
@@ -157,7 +157,7 @@ export default function mergeSelectors(fromSelectors, toSelectors, opts) {
 }
 
 function isSimpleSelector(selector) {
-	if (selector.type === 'combinator' || parser.isPseudoElement(selector)) {
+	if (selector.type === 'combinator') {
 		return false;
 	}
 
@@ -178,7 +178,7 @@ function isCompoundSelector(selector, toSelector = null) {
 	}
 
 	const hasCombinators = !!(selector.parent.nodes.find((x) => {
-		return x.type === 'combinator' || parser.isPseudoElement(x);
+		return x.type === 'combinator';
 	}));
 
 	if (hasCombinators) {
@@ -208,10 +208,6 @@ function nestingIsFirstAndOnlyInSelectorWithEitherSpaceOrChildCombinator(selecto
 
 	for (let i = 1; i < selector.parent.nodes.length; i++) {
 		if (selector.parent.nodes[i].type === 'combinator' && (selector.parent.nodes[i].value !== ' ' && selector.parent.nodes[i].value !== '>')) {
-			return false;
-		}
-
-		if (parser.isPseudoElement(selector.parent.nodes[i])) {
 			return false;
 		}
 	}

--- a/plugins/postcss-nesting/test/pseudo-element.css
+++ b/plugins/postcss-nesting/test/pseudo-element.css
@@ -37,3 +37,9 @@
 		}
 	}
 }
+
+.anything::before {
+	@nest .something_else > & {
+		order: 9;
+	}
+}

--- a/plugins/postcss-nesting/test/pseudo-element.expect.css
+++ b/plugins/postcss-nesting/test/pseudo-element.expect.css
@@ -1,6 +1,6 @@
 
 
-.foo:is(::before), ::before:focus {
+.foo::before, ::before:focus {
 		order: 1;
 }
 
@@ -31,3 +31,7 @@
 .a::after:hover {
 			order: 8;
 		}
+
+.something_else > .anything::before {
+		order: 9;
+}


### PR DESCRIPTION
This reverts most changes from 10.1.9 in postcss-nesting and only keeps the updated logic for compound selector sorting.

We need to ask for clarification on the spec before finalising how pseudo elements in enclosing rules are handled.

```pcss
.anything::before {
	@nest .something_else > & {
		order: 1;
	}
}
```