### PR TITLE
Adding global class to CSS Blank

### DIFF
--- a/plugin-packs/postcss-preset-env/test/basic.autoprefixer.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.autoprefixer.expect.css
@@ -261,7 +261,7 @@
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.autoprefixer.false.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.autoprefixer.false.expect.css
@@ -261,7 +261,7 @@
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ch38.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch38.expect.css
@@ -181,7 +181,7 @@
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ch88-ff78-saf10.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch88-ff78-saf10.expect.css
@@ -180,7 +180,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.expect.css
@@ -173,7 +173,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.no-is-pseudo.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.no-is-pseudo.expect.css
@@ -173,7 +173,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.expect.css
@@ -284,7 +284,7 @@
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ff49.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ff49.expect.css
@@ -177,7 +177,7 @@
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ff66.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ff66.expect.css
@@ -165,7 +165,7 @@
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ie10.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ie10.expect.css
@@ -293,7 +293,7 @@
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.nesting.false.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.nesting.false.expect.css
@@ -282,7 +282,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.op_mini.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.op_mini.expect.css
@@ -268,7 +268,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.preserve.true.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.preserve.true.expect.css
@@ -516,7 +516,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.safari15.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.safari15.expect.css
@@ -149,7 +149,7 @@
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.stage0-ff49.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0-ff49.expect.css
@@ -182,7 +182,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.stage0-ff66.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0-ff66.expect.css
@@ -170,7 +170,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.stage0.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0.expect.css
@@ -289,7 +289,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank] {
+.test-blank-pseudo-class[blank].js-blank-pseudo, .js-blank-pseudo .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/client-side-polyfills.stage-1.expect.css
+++ b/plugin-packs/postcss-preset-env/test/client-side-polyfills.stage-1.expect.css
@@ -1,4 +1,4 @@
-[blank] {
+[blank].js-blank-pseudo, .js-blank-pseudo [blank] {
 	order: 1;
 }
 

--- a/plugin-packs/postcss-preset-env/test/disable-client-side-polyfills.disabled.expect.css
+++ b/plugin-packs/postcss-preset-env/test/disable-client-side-polyfills.disabled.expect.css
@@ -1,4 +1,4 @@
-input[blank] {
+input[blank].js-blank-pseudo, .js-blank-pseudo input[blank] {
 	order: 1;
 }
 

--- a/plugin-packs/postcss-preset-env/test/layers-basic.expect.css
+++ b/plugin-packs/postcss-preset-env/test/layers-basic.expect.css
@@ -466,7 +466,7 @@ h1.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):n
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+.test-blank-pseudo-class[blank].js-blank-pseudo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#), .js-blank-pseudo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/layers-basic.preserve.true.expect.css
+++ b/plugin-packs/postcss-preset-env/test/layers-basic.preserve.true.expect.css
@@ -527,7 +527,7 @@ h1.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):n
 	background-image: conic-gradient(yellowgreen 40%, gold 0deg 75%, #f06 0deg);
 }
 
-.test-blank-pseudo-class[blank]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+.test-blank-pseudo-class[blank].js-blank-pseudo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#), .js-blank-pseudo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) .test-blank-pseudo-class[blank] {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/unknown-feature.expect.css
+++ b/plugin-packs/postcss-preset-env/test/unknown-feature.expect.css
@@ -1,0 +1,3 @@
+.foo {
+	content: 'file contents are not important here';
+}

--- a/plugin-packs/postcss-preset-env/test/unknown-feature.expect.css
+++ b/plugin-packs/postcss-preset-env/test/unknown-feature.expect.css
@@ -1,3 +1,0 @@
-.foo {
-	content: 'file contents are not important here';
-}

--- a/plugins/css-blank-pseudo/README.md
+++ b/plugins/css-blank-pseudo/README.md
@@ -12,7 +12,7 @@ input:blank {
 
 /* becomes */
 
-input[blank] {
+input[blank].js-blank-pseudo, .js-blank-pseudo input[blank] {
 	background-color: yellow;
 }
 input:blank {
@@ -63,7 +63,7 @@ input:blank {
 
 /* becomes */
 
-input[blank] {
+input[blank].js-blank-pseudo, .js-blank-pseudo input[blank] {
 	background-color: yellow;
 }
 ```

--- a/plugins/css-blank-pseudo/README.md
+++ b/plugins/css-blank-pseudo/README.md
@@ -149,6 +149,9 @@ cssBlankPseudoInit({ replaceWith: '.css-blank' });
 ```
 
 This option should be used if it was changed at PostCSS configuration level.
+Please note that using a class, leverages `classList` under the hood which 
+might  not be supported on some old browsers such as IE9, so you may need 
+to polyfill `classList` in those cases.
 
 [cli-url]: https://github.com/csstools/postcss-plugins/actions/workflows/test.yml?query=workflow/test
 [css-url]: https://cssdb.org/#blank-pseudo-class

--- a/plugins/css-blank-pseudo/docs/README.md
+++ b/plugins/css-blank-pseudo/docs/README.md
@@ -122,6 +122,9 @@ cssBlankPseudoInit({ replaceWith: '.css-blank' });
 ```
 
 This option should be used if it was changed at PostCSS configuration level.
+Please note that using a class, leverages `classList` under the hood which 
+might  not be supported on some old browsers such as IE9, so you may need 
+to polyfill `classList` in those cases.
 
 <linkList>
 [Selectors Level 4]: <specUrl>

--- a/plugins/css-blank-pseudo/src/browser.js
+++ b/plugins/css-blank-pseudo/src/browser.js
@@ -137,6 +137,10 @@ export default function cssBlankPseudoInit(opts) {
 		window.addEventListener('load', bindEvents);
 	}
 
+	if (document.documentElement.className.indexOf(CSS_CLASS_LOADED) === -1) {
+		document.documentElement.className += ` ${CSS_CLASS_LOADED}`;
+	}
+
 	observeValueOfHTMLElement(self.HTMLInputElement, handler);
 	observeValueOfHTMLElement(self.HTMLSelectElement, handler);
 	observeValueOfHTMLElement(self.HTMLTextAreaElement, handler);
@@ -160,12 +164,7 @@ export default function cssBlankPseudoInit(opts) {
 			});
 		}).observe(document, { childList: true, subtree: true });
 	} else {
-		const handleOnLoad = () => {
-			if (document.documentElement.className.indexOf(CSS_CLASS_LOADED) === -1) {
-				document.documentElement.className += ` ${CSS_CLASS_LOADED}`;
-				updateAllCandidates();
-			}
-		};
+		const handleOnLoad = () => updateAllCandidates();
 
 		window.addEventListener('load', handleOnLoad);
 		window.addEventListener('DOMContentLoaded', handleOnLoad);

--- a/plugins/css-blank-pseudo/src/browser.js
+++ b/plugins/css-blank-pseudo/src/browser.js
@@ -1,6 +1,8 @@
 /* global document,window,self,MutationObserver */
 import isValidReplacement from './is-valid-replacement.mjs';
 
+const supportsClassList = ('classList' in document.documentElement);
+
 // form control elements selector
 function isFormControlElement(element) {
 	if (element.nodeName === 'INPUT' || element.nodeName === 'SELECT' || element.nodeName === 'TEXTAREA') {
@@ -30,8 +32,27 @@ function generateHandler(replaceWith) {
 
 	if (replaceWith[0] === '.') {
 		selector = replaceWith.slice(1);
-		remove = (el) => el.classList.remove(selector);
-		add = (el) => el.classList.add(selector);
+		remove = (el) => {
+			if (supportsClassList) {
+				el.classList.remove(selector);
+			} else {
+				const classes = el.className.split(/\s+/);
+				const index = classes.indexOf(selector);
+
+				if (index > -1) {
+					classes.splice(index, 1);
+				}
+
+				el.className = classes.join(' ');
+			}
+		};
+		add = (el) => {
+			if (supportsClassList) {
+				el.classList.add(selector);
+			} else {
+				el.className += ` ${selector}`;
+			}
+		};
 	} else {
 		// A bit naive
 		selector = replaceWith.slice(1, -1);

--- a/plugins/css-blank-pseudo/src/browser.js
+++ b/plugins/css-blank-pseudo/src/browser.js
@@ -2,6 +2,7 @@
 import isValidReplacement from './is-valid-replacement.mjs';
 
 const supportsClassList = ('classList' in document.documentElement);
+const CSS_CLASS_LOADED = 'js-blank-pseudo';
 
 // form control elements selector
 function isFormControlElement(element) {
@@ -180,8 +181,10 @@ export default function cssBlankPseudoInit(opts) {
 		}).observe(document, { childList: true, subtree: true });
 	} else {
 		const handleOnLoad = () => {
-			document.documentElement.className = document.documentElement.className + ' js-blank-pseudo';
-			updateAllCandidates();
+			if (document.documentElement.className.indexOf(CSS_CLASS_LOADED) === -1) {
+				document.documentElement.className += ` ${CSS_CLASS_LOADED}`;
+				updateAllCandidates();
+			}
 		};
 
 		window.addEventListener('load', handleOnLoad);

--- a/plugins/css-blank-pseudo/src/browser.js
+++ b/plugins/css-blank-pseudo/src/browser.js
@@ -180,6 +180,7 @@ export default function cssBlankPseudoInit(opts) {
 		}).observe(document, { childList: true, subtree: true });
 	} else {
 		const handleOnLoad = () => {
+			document.documentElement.className = document.documentElement.className + ' js-blank-pseudo';
 			updateAllCandidates();
 		};
 

--- a/plugins/css-blank-pseudo/src/browser.js
+++ b/plugins/css-blank-pseudo/src/browser.js
@@ -1,7 +1,6 @@
 /* global document,window,self,MutationObserver */
 import isValidReplacement from './is-valid-replacement.mjs';
 
-const supportsClassList = ('classList' in document.documentElement);
 const CSS_CLASS_LOADED = 'js-blank-pseudo';
 
 // form control elements selector
@@ -33,27 +32,8 @@ function generateHandler(replaceWith) {
 
 	if (replaceWith[0] === '.') {
 		selector = replaceWith.slice(1);
-		remove = (el) => {
-			if (supportsClassList) {
-				el.classList.remove(selector);
-			} else {
-				const classes = el.className.split(/\s+/);
-				const index = classes.indexOf(selector);
-
-				if (index > -1) {
-					classes.splice(index, 1);
-				}
-
-				el.className = classes.join(' ');
-			}
-		};
-		add = (el) => {
-			if (supportsClassList) {
-				el.classList.add(selector);
-			} else {
-				el.className += ` ${selector}`;
-			}
-		};
+		remove = (el) => el.classList.remove(selector);
+		add = (el) => el.classList.add(selector);
 	} else {
 		// A bit naive
 		selector = replaceWith.slice(1, -1);

--- a/plugins/css-blank-pseudo/src/index.ts
+++ b/plugins/css-blank-pseudo/src/index.ts
@@ -4,6 +4,9 @@ import isValidReplacement from './is-valid-replacement.mjs';
 
 type pluginOptions = { preserve?: boolean, replaceWith?: string };
 
+const POLYFILL_READY_CLASSNAME = 'js-blank-pseudo';
+const PSEUDO = ':blank';
+
 const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 	const options = Object.assign(
 		// Default options
@@ -30,43 +33,86 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 
 	return {
 		postcssPlugin: 'css-blank-pseudo',
-		Rule: (rule, { result }) => {
-			if (rule.selector.toLowerCase().indexOf(':blank') === -1) {
+		Rule(rule, { result }) {
+			if (!rule.selector.toLowerCase().includes(PSEUDO)) {
 				return;
 			}
 
-			let modifiedSelector;
-			try {
-				const modifiedSelectorAST = parser((selectors) => {
-					selectors.walkPseudos((selector) => {
-						if (selector.value.toLowerCase() !== ':blank') {
-							return;
+			const selectors = rule.selectors.flatMap((selector) => {
+				if (!selector.toLowerCase().includes(PSEUDO)) {
+					return [selector];
+				}
+
+				let selectorAST;
+
+				try {
+					selectorAST = parser().astSync(selector);
+				} catch (_) {
+					rule.warn(result, `Failed to parse selector : ${selector}`);
+					return selector;
+				}
+
+				if (typeof selectorAST === 'undefined') {
+					return [selector];
+				}
+
+				let containsPseudo = false;
+				selectorAST.walkPseudos((pseudo) => {
+					if (pseudo.value.toLowerCase() !== PSEUDO) {
+						return;
+					}
+
+					if (pseudo.nodes && pseudo.nodes.length) {
+						return;
+					}
+
+					containsPseudo = true;
+					pseudo.replaceWith(replacementAST.clone({}));
+				});
+
+				if (!containsPseudo) {
+					return [selector];
+				}
+
+				const selectorASTClone = selectorAST.clone();
+
+				// html > .foo:focus-within
+				// becomes:
+				// html.js-blank-pseudo > .foo:focus-within,
+				// .js-blank-pseudo html > .foo:focus-within
+				{
+					if (selectorAST.nodes?.[0]?.nodes?.length) {
+						for (let i = 0; i < selectorAST.nodes[0].nodes.length; i++) {
+							const node = selectorAST.nodes[0].nodes[i];
+							if (node.type === 'combinator' || parser.isPseudoElement(node)) {
+								// Insert the class before the first combinator or pseudo element.
+								selectorAST.nodes[0].insertBefore(node, parser.className({ value: POLYFILL_READY_CLASSNAME }));
+								break;
+							}
+
+							if (i === selectorAST.nodes[0].nodes.length - 1) {
+								// Append the class to the end of the selector if not combinator or pseudo element was found.
+								selectorAST.nodes[0].append(parser.className({ value: POLYFILL_READY_CLASSNAME }));
+								break;
+							}
 						}
+					}
 
-						if (selector.nodes && selector.nodes.length) {
-							// `:blank` is not a function
-							return;
-						}
+					if (selectorAST.nodes?.[0]?.nodes) {
+						// Prepend a space combinator and the class to the beginning of the selector.
+						selectorASTClone.nodes[0].prepend(parser.combinator({ value: ' ' }));
+						selectorASTClone.nodes[0].prepend(parser.className({ value: POLYFILL_READY_CLASSNAME }));
+					}
+				}
 
-						selector.replaceWith(replacementAST.clone({}));
-					});
-				}).processSync(rule.selector);
+				return [selectorAST.toString(), selectorASTClone.toString()];
+			});
 
-				modifiedSelector = String(modifiedSelectorAST);
-			} catch (_) {
-				rule.warn(result, `Failed to parse selector : ${rule.selector}`);
+			if (selectors.join(',') === rule.selectors.join(',')) {
 				return;
 			}
 
-			if (typeof modifiedSelector === 'undefined') {
-				return;
-			}
-
-			if (modifiedSelector === rule.selector) {
-				return;
-			}
-
-			rule.cloneBefore({ selector: modifiedSelector });
+			rule.cloneBefore({ selectors: selectors });
 
 			if (!options.preserve) {
 				rule.remove();

--- a/plugins/css-blank-pseudo/test/basic.expect.css
+++ b/plugins/css-blank-pseudo/test/basic.expect.css
@@ -1,4 +1,4 @@
-[blank] {
+[blank].js-blank-pseudo, .js-blank-pseudo [blank] {
 	order: 1;
 }
 
@@ -6,19 +6,34 @@
 	order: 1;
 }
 
-[blank],[blank] test,
-test [blank],
-test test[blank],
-test [blank] test,
-test test[blank] test,
-test [blank] [blank] test,
-test :matches([blank]) test,
-test :matches([blank] test) test,
-test :matches(test [blank]) test,
-test :matches(test test[blank]) test,
-test :matches(test [blank] test) test,
-test :matches(test test[blank] test) test,
-test :matches(test [blank] [blank] test) test {
+[blank].js-blank-pseudo,
+.js-blank-pseudo [blank],
+[blank].js-blank-pseudo test,
+.js-blank-pseudo [blank] test,
+test.js-blank-pseudo [blank],
+.js-blank-pseudo test [blank],
+test.js-blank-pseudo test[blank],
+.js-blank-pseudo test test[blank],
+test.js-blank-pseudo [blank] test,
+.js-blank-pseudo test [blank] test,
+test.js-blank-pseudo test[blank] test,
+.js-blank-pseudo test test[blank] test,
+test.js-blank-pseudo [blank] [blank] test,
+.js-blank-pseudo test [blank] [blank] test,
+test.js-blank-pseudo :matches([blank]) test,
+.js-blank-pseudo test :matches([blank]) test,
+test.js-blank-pseudo :matches([blank] test) test,
+.js-blank-pseudo test :matches([blank] test) test,
+test.js-blank-pseudo :matches(test [blank]) test,
+.js-blank-pseudo test :matches(test [blank]) test,
+test.js-blank-pseudo :matches(test test[blank]) test,
+.js-blank-pseudo test :matches(test test[blank]) test,
+test.js-blank-pseudo :matches(test [blank] test) test,
+.js-blank-pseudo test :matches(test [blank] test) test,
+test.js-blank-pseudo :matches(test test[blank] test) test,
+.js-blank-pseudo test :matches(test test[blank] test) test,
+test.js-blank-pseudo :matches(test [blank] [blank] test) test,
+.js-blank-pseudo test :matches(test [blank] [blank] test) test {
 	order: 2;
 }
 
@@ -50,7 +65,7 @@ test :matches(test :blank :blank test) test {
 	order: 4;
 }
 
-test:not([blank]) {
+test:not([blank]).js-blank-pseudo, .js-blank-pseudo test:not([blank]) {
 	order: 5;
 }
 
@@ -58,7 +73,7 @@ test:not(:blank) {
 	order: 5;
 }
 
-uppercase [blank] {
+uppercase.js-blank-pseudo [blank], .js-blank-pseudo uppercase [blank] {
 	order: 6;
 }
 

--- a/plugins/css-blank-pseudo/test/basic.preserve.expect.css
+++ b/plugins/css-blank-pseudo/test/basic.preserve.expect.css
@@ -1,20 +1,35 @@
-[blank] {
+[blank].js-blank-pseudo, .js-blank-pseudo [blank] {
 	order: 1;
 }
 
-[blank],[blank] test,
-test [blank],
-test test[blank],
-test [blank] test,
-test test[blank] test,
-test [blank] [blank] test,
-test :matches([blank]) test,
-test :matches([blank] test) test,
-test :matches(test [blank]) test,
-test :matches(test test[blank]) test,
-test :matches(test [blank] test) test,
-test :matches(test test[blank] test) test,
-test :matches(test [blank] [blank] test) test {
+[blank].js-blank-pseudo,
+.js-blank-pseudo [blank],
+[blank].js-blank-pseudo test,
+.js-blank-pseudo [blank] test,
+test.js-blank-pseudo [blank],
+.js-blank-pseudo test [blank],
+test.js-blank-pseudo test[blank],
+.js-blank-pseudo test test[blank],
+test.js-blank-pseudo [blank] test,
+.js-blank-pseudo test [blank] test,
+test.js-blank-pseudo test[blank] test,
+.js-blank-pseudo test test[blank] test,
+test.js-blank-pseudo [blank] [blank] test,
+.js-blank-pseudo test [blank] [blank] test,
+test.js-blank-pseudo :matches([blank]) test,
+.js-blank-pseudo test :matches([blank]) test,
+test.js-blank-pseudo :matches([blank] test) test,
+.js-blank-pseudo test :matches([blank] test) test,
+test.js-blank-pseudo :matches(test [blank]) test,
+.js-blank-pseudo test :matches(test [blank]) test,
+test.js-blank-pseudo :matches(test test[blank]) test,
+.js-blank-pseudo test :matches(test test[blank]) test,
+test.js-blank-pseudo :matches(test [blank] test) test,
+.js-blank-pseudo test :matches(test [blank] test) test,
+test.js-blank-pseudo :matches(test test[blank] test) test,
+.js-blank-pseudo test :matches(test test[blank] test) test,
+test.js-blank-pseudo :matches(test [blank] [blank] test) test,
+.js-blank-pseudo test :matches(test [blank] [blank] test) test {
 	order: 2;
 }
 
@@ -29,10 +44,10 @@ test :matches(test [blank] [blank] test) test {
 	order: 4;
 }
 
-test:not([blank]) {
+test:not([blank]).js-blank-pseudo, .js-blank-pseudo test:not([blank]) {
 	order: 5;
 }
 
-uppercase [blank] {
+uppercase.js-blank-pseudo [blank], .js-blank-pseudo uppercase [blank] {
 	order: 6;
 }

--- a/plugins/css-blank-pseudo/test/basic.replacewith.expect.css
+++ b/plugins/css-blank-pseudo/test/basic.replacewith.expect.css
@@ -1,4 +1,4 @@
-.css-blank {
+.css-blank.js-blank-pseudo, .js-blank-pseudo .css-blank {
 	order: 1;
 }
 
@@ -6,19 +6,34 @@
 	order: 1;
 }
 
-.css-blank,.css-blank test,
-test .css-blank,
-test test.css-blank,
-test .css-blank test,
-test test.css-blank test,
-test .css-blank .css-blank test,
-test :matches(.css-blank) test,
-test :matches(.css-blank test) test,
-test :matches(test .css-blank) test,
-test :matches(test test.css-blank) test,
-test :matches(test .css-blank test) test,
-test :matches(test test.css-blank test) test,
-test :matches(test .css-blank .css-blank test) test {
+.css-blank.js-blank-pseudo,
+.js-blank-pseudo .css-blank,
+.css-blank.js-blank-pseudo test,
+.js-blank-pseudo .css-blank test,
+test.js-blank-pseudo .css-blank,
+.js-blank-pseudo test .css-blank,
+test.js-blank-pseudo test.css-blank,
+.js-blank-pseudo test test.css-blank,
+test.js-blank-pseudo .css-blank test,
+.js-blank-pseudo test .css-blank test,
+test.js-blank-pseudo test.css-blank test,
+.js-blank-pseudo test test.css-blank test,
+test.js-blank-pseudo .css-blank .css-blank test,
+.js-blank-pseudo test .css-blank .css-blank test,
+test.js-blank-pseudo :matches(.css-blank) test,
+.js-blank-pseudo test :matches(.css-blank) test,
+test.js-blank-pseudo :matches(.css-blank test) test,
+.js-blank-pseudo test :matches(.css-blank test) test,
+test.js-blank-pseudo :matches(test .css-blank) test,
+.js-blank-pseudo test :matches(test .css-blank) test,
+test.js-blank-pseudo :matches(test test.css-blank) test,
+.js-blank-pseudo test :matches(test test.css-blank) test,
+test.js-blank-pseudo :matches(test .css-blank test) test,
+.js-blank-pseudo test :matches(test .css-blank test) test,
+test.js-blank-pseudo :matches(test test.css-blank test) test,
+.js-blank-pseudo test :matches(test test.css-blank test) test,
+test.js-blank-pseudo :matches(test .css-blank .css-blank test) test,
+.js-blank-pseudo test :matches(test .css-blank .css-blank test) test {
 	order: 2;
 }
 
@@ -50,7 +65,7 @@ test :matches(test :blank :blank test) test {
 	order: 4;
 }
 
-test:not(.css-blank) {
+test:not(.css-blank).js-blank-pseudo, .js-blank-pseudo test:not(.css-blank) {
 	order: 5;
 }
 
@@ -58,7 +73,7 @@ test:not(:blank) {
 	order: 5;
 }
 
-uppercase .css-blank {
+uppercase.js-blank-pseudo .css-blank, .js-blank-pseudo uppercase .css-blank {
 	order: 6;
 }
 

--- a/plugins/css-blank-pseudo/test/browser.expect.css
+++ b/plugins/css-blank-pseudo/test/browser.expect.css
@@ -4,7 +4,7 @@ textarea {
 	background-color: rgb(255, 192, 203);
 }
 
-[blank] {
+[blank].js-blank-pseudo, .js-blank-pseudo [blank] {
 	background-color: rgb(128, 0, 128);
 }
 

--- a/plugins/css-blank-pseudo/test/browser.replacewith.expect.css
+++ b/plugins/css-blank-pseudo/test/browser.replacewith.expect.css
@@ -4,7 +4,7 @@ textarea {
 	background-color: rgb(255, 192, 203);
 }
 
-.css-blank {
+.css-blank.js-blank-pseudo, .js-blank-pseudo .css-blank {
 	background-color: rgb(128, 0, 128);
 }
 

--- a/plugins/css-blank-pseudo/test/examples/example.expect.css
+++ b/plugins/css-blank-pseudo/test/examples/example.expect.css
@@ -1,4 +1,4 @@
-input[blank] {
+input[blank].js-blank-pseudo, .js-blank-pseudo input[blank] {
 	background-color: yellow;
 }
 input:blank {

--- a/plugins/css-blank-pseudo/test/examples/example.preserve-false.expect.css
+++ b/plugins/css-blank-pseudo/test/examples/example.preserve-false.expect.css
@@ -1,3 +1,3 @@
-input[blank] {
+input[blank].js-blank-pseudo, .js-blank-pseudo input[blank] {
 	background-color: yellow;
 }

--- a/plugins/css-blank-pseudo/test/examples/example.replacewith.expect.css
+++ b/plugins/css-blank-pseudo/test/examples/example.replacewith.expect.css
@@ -1,4 +1,4 @@
-input.css-blank {
+input.css-blank.js-blank-pseudo, .js-blank-pseudo input.css-blank {
 	background-color: yellow;
 }
 input:blank {

--- a/plugins/postcss-focus-within/README.md
+++ b/plugins/postcss-focus-within/README.md
@@ -78,6 +78,9 @@ postcssFocusWithin({ preserve: false })
 
 The `replaceWith` option defines the selector to replace `:focus-within`. By
 default, the replacement selector is `[focus-within]`.
+Please note that using a class, leverages `classList` under the hood which
+might  not be supported on some old browsers such as IE9, so you may need
+to polyfill `classList` in those cases.
 
 ```js
 postcssFocusWithin({ replaceWith: '.focus-within' });

--- a/plugins/postcss-focus-within/docs/README.md
+++ b/plugins/postcss-focus-within/docs/README.md
@@ -60,6 +60,9 @@ is preserved. By default, it is preserved.
 
 The `replaceWith` option defines the selector to replace `:focus-within`. By
 default, the replacement selector is `[focus-within]`.
+Please note that using a class, leverages `classList` under the hood which
+might  not be supported on some old browsers such as IE9, so you may need
+to polyfill `classList` in those cases.
 
 ```js
 <exportName>({ replaceWith: '.focus-within' });


### PR DESCRIPTION
This PR adds the `js-blank-pseudo` to the `documentElement` as well as handled via the plugin. This is now consistent across `focus-within` and `focus-visible` which are all doing the same with different pseudos.

As discussed I've also added a warning around `replaceWith` to warn about `classList` usage for old browsers.