### PR TITLE
css has pseudo : pseudo element support and .js-has-pseudo class

### DIFF
--- a/plugin-packs/postcss-preset-env/test/basic.autoprefixer.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.autoprefixer.expect.css
@@ -269,7 +269,7 @@
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.autoprefixer.false.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.autoprefixer.false.expect.css
@@ -269,7 +269,7 @@
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ch38.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch38.expect.css
@@ -189,7 +189,7 @@
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ch88-ff78-saf10.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch88-ff78-saf10.expect.css
@@ -188,7 +188,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.expect.css
@@ -181,7 +181,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.no-is-pseudo.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ch88-ff78.no-is-pseudo.expect.css
@@ -181,7 +181,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.expect.css
@@ -292,7 +292,7 @@
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ff49.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ff49.expect.css
@@ -185,7 +185,7 @@
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ff66.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ff66.expect.css
@@ -173,7 +173,7 @@
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.ie10.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.ie10.expect.css
@@ -301,7 +301,7 @@
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.nesting.false.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.nesting.false.expect.css
@@ -290,7 +290,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.op_mini.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.op_mini.expect.css
@@ -276,7 +276,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.preserve.true.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.preserve.true.expect.css
@@ -524,7 +524,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.safari15.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.safari15.expect.css
@@ -157,7 +157,7 @@
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.stage0-ff49.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0-ff49.expect.css
@@ -190,7 +190,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.stage0-ff66.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0-ff66.expect.css
@@ -178,7 +178,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/basic.stage0.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.stage0.expect.css
@@ -297,7 +297,7 @@ h1.test-custom-selectors,h2.test-custom-selectors,h3.test-custom-selectors,h4.te
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/client-side-polyfills.stage-1.expect.css
+++ b/plugin-packs/postcss-preset-env/test/client-side-polyfills.stage-1.expect.css
@@ -10,7 +10,7 @@
 	order: 3;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2p-15] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2p-15] {
 	order: 4;
 }
 

--- a/plugin-packs/postcss-preset-env/test/client-side-polyfills.stage-2.expect.css
+++ b/plugin-packs/postcss-preset-env/test/client-side-polyfills.stage-2.expect.css
@@ -10,7 +10,7 @@
 	order: 3;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2p-15] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2p-15] {
 	order: 4;
 }
 

--- a/plugin-packs/postcss-preset-env/test/disable-client-side-polyfills.disabled.expect.css
+++ b/plugin-packs/postcss-preset-env/test/disable-client-side-polyfills.disabled.expect.css
@@ -6,7 +6,7 @@ input:blank {
 	order: 1;
 }
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(does-not-exist):not(does-not-exist) {
 	order: 2;
 }
 

--- a/plugin-packs/postcss-preset-env/test/layers-basic.expect.css
+++ b/plugin-packs/postcss-preset-env/test/layers-basic.expect.css
@@ -474,7 +474,7 @@ h1.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):n
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+.js-has-pseudo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugin-packs/postcss-preset-env/test/layers-basic.preserve.true.expect.css
+++ b/plugin-packs/postcss-preset-env/test/layers-basic.preserve.true.expect.css
@@ -535,7 +535,7 @@ h1.test-custom-selectors:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):n
 	background-color: yellow;
 }
 
-[csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+.js-has-pseudo:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) [csstools-has-1a-38-2t-37-38-19-2w-2p-37-19-34-37-2t-39-2s-33-19-2r-30-2p-37-37-1m-2w-2p-37-14-1a-2x-32-32-2t-36-19-2r-30-2p-37-37-15]:not(.does-not-exist) {
 	background-color: yellow;
 }
 

--- a/plugins/css-has-pseudo/.tape.mjs
+++ b/plugins/css-has-pseudo/.tape.mjs
@@ -38,9 +38,6 @@ postcssTape(plugin)({
 	},
 	'browser': {
 		message: 'prepare CSS for chrome test',
-		options: {
-			preserve: false
-		}
 	},
 	'plugin-order-logical:before': {
 		message: 'works with other plugins that modify selectors',

--- a/plugins/css-has-pseudo/test/_browser.html
+++ b/plugins/css-has-pseudo/test/_browser.html
@@ -10,7 +10,7 @@
 	<!-- This is the real test stylesheet and has correct CORS attributes and http headers -->
 	<link rel="stylesheet" href="http://localhost:8081/test/browser.expect.css" crossorigin="anonymous">
 	<script src="http://localhost:8082/dist/browser-global.js"></script>
-	<script>cssHasPseudo(document, { observedAttributes: ['attrname', 'a_test_attr', 'c_test_attr'], debug: false, hover: true, forcePolyfill: true });</script>
+	<script>cssHasPseudo(document, { observedAttributes: ['attrname', 'a_test_attr', 'c_test_attr'], debug: false, hover: true, forcePolyfill: window.location.hash === '#force-polyfill' });</script>
 </head>
 <body>
 	<the-fixture id="fixture"></the-fixture>
@@ -28,22 +28,24 @@
 		}
 
 		self.runTest = async function runTest() {
-			const nestedResult = await testNestedHas();
 			const adjacentPositionResult = await testAdjacentPosition();
 			const hasWithPseudoClassesResult = await testHasWithPseudoClasses();
 			const invalidationResult = await testInvalidation();
+			const nestedResult = await testNestedHas();
 			const parentPositionResult = await testParentPosition();
+			const pseudoResult = await testPseudos();
 			const specificityResult = await testSpecificity();
-			const visitednessResult = await testVisitedness()
+			const visitednessResult = await testVisitedness();
 
 			return (
 				adjacentPositionResult &&
 				hasWithPseudoClassesResult &&
 				invalidationResult &&
+				nestedResult &&
 				parentPositionResult &&
+				pseudoResult &&
 				specificityResult &&
-				visitednessResult &&
-				nestedResult
+				visitednessResult
 			);
 		}
 
@@ -1180,6 +1182,34 @@
 
 			await rafP(() => {
 				testColor(document.getElementById('a'), red);
+			});
+
+			return true;
+		}
+
+		async function testPseudos() {
+			// https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-pseudo-class.html
+
+			fixture.innerHTML = `
+				<main id="pseudo_main">
+					<div id="a">
+						<div id="b"></div>
+					</div>
+				</main>
+			`;
+
+			const red = 'rgb(255, 0, 0)';
+			var green = 'rgb(0, 128, 0)';
+
+			function testColor(el, pseudo, color) {
+				var actual = getComputedStyle(el, pseudo).color;
+				if (actual !== color) {
+					throw new Error('pseudo elements after :has should work : div#' + el.id + '.color; expected ' + color + ' but got ' + actual);
+				}
+			}
+
+			await rafP(() => {
+				testColor(document.getElementById('a'), '::before', green);
 			});
 
 			return true;

--- a/plugins/css-has-pseudo/test/_browser.mjs
+++ b/plugins/css-has-pseudo/test/_browser.mjs
@@ -63,13 +63,27 @@ import { promises as fsp } from 'fs';
 		page.on('pageerror', (msg) => {
 			throw msg;
 		});
-		await page.goto('http://localhost:8080');
-		const result = await page.evaluate(async() => {
-			// eslint-disable-next-line no-undef
-			return await window.runTest();
-		});
-		if (!result) {
-			throw new Error('Test failed, expected "window.runTest()" to return true');
+
+		{
+			await page.goto('http://localhost:8080');
+			const result = await page.evaluate(async() => {
+				// eslint-disable-next-line no-undef
+				return await window.runTest();
+			});
+			if (!result) {
+				throw new Error('Test failed, expected "window.runTest()" to return true');
+			}
+		}
+
+		{
+			await page.goto('http://localhost:8080#force-polyfill');
+			const result = await page.evaluate(async() => {
+				// eslint-disable-next-line no-undef
+				return await window.runTest();
+			});
+			if (!result) {
+				throw new Error('Test failed, expected "window.runTest()" to return true');
+			}
 		}
 
 		await browser.close();

--- a/plugins/css-has-pseudo/test/basic.css
+++ b/plugins/css-has-pseudo/test/basic.css
@@ -128,7 +128,7 @@ body:not(:has(:focus)) {
 }
 
 .x:has(> :any-link) {
-	order: 31;
+	order: 31.1;
 }
 
 @supports selector(:has(:focus)) {
@@ -147,4 +147,8 @@ body:not(:has(:focus)) {
 	:has(:focus) {
 		order: 34;
 	}
+}
+
+#pseudo_main :has(> #b)::before:hover::marker {
+	content: 'must preserve entire pseudo element part outside of the encoding';
 }

--- a/plugins/css-has-pseudo/test/basic.expect.css
+++ b/plugins/css-has-pseudo/test/basic.expect.css
@@ -1,4 +1,4 @@
-[csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
 	order: 1;
 }
 
@@ -6,7 +6,7 @@
 	order: 1;
 }
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(does-not-exist):not(does-not-exist) {
 	order: 2;
 }
 
@@ -14,7 +14,7 @@ a:has(> img) {
 	order: 2;
 }
 
-[csstools-has-2w-1d-1m-2w-2p-37-14-17-w-34-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2w-1d-1m-2w-2p-37-14-17-w-34-15]:not(does-not-exist):not(does-not-exist) {
 	order: 3;
 }
 
@@ -22,7 +22,7 @@ h1:has(+ p) {
 	order: 3;
 }
 
-[csstools-has-2w-1d-1m-2w-2p-37-14-3i-w-34-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2w-1d-1m-2w-2p-37-14-3i-w-34-15]:not(does-not-exist):not(does-not-exist) {
 	order: 4;
 }
 
@@ -30,7 +30,7 @@ h1:has(~ p) {
 	order: 4;
 }
 
-[csstools-has-37-2t-2r-38-2x-33-32-1m-32-33-38-14-1m-2w-2p-37-14-2w-1d-18-w-2w-1e-18-w-2w-1f-18-w-2w-1g-18-w-2w-1h-18-w-2w-1i-15-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo section:not([csstools-has-1m-2w-2p-37-14-2w-1d-18-w-2w-1e-18-w-2w-1f-18-w-2w-1g-18-w-2w-1h-18-w-2w-1i-15]:not(does-not-exist)) {
 	order: 5;
 }
 
@@ -38,7 +38,7 @@ section:not(:has(h1, h2, h3, h4, h5, h6)) {
 	order: 5;
 }
 
-[csstools-has-2q-33-2s-3d-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-33-2s-3d-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]:not(does-not-exist) {
 	order: 6;
 }
 
@@ -46,7 +46,7 @@ body:has(:focus) {
 	order: 6;
 }
 
-[csstools-has-2q-33-2s-3d-1m-32-33-38-14-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15-15]:not(does-not-exist) {
+.js-has-pseudo body:not([csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]) {
 	order: 7;
 }
 
@@ -59,7 +59,7 @@ body:not(:has(:focus)) {
 	order: 8;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2t-37-2r-2k-2k-2k-1m-2p-34-2t-2s-15] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2t-37-2r-2k-2k-2k-1m-2p-34-2t-2s-15] {
 	order: 9;
 }
 
@@ -67,7 +67,7 @@ body:not(:has(:focus)) {
 	order: 9;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 10;
 }
 
@@ -75,7 +75,7 @@ body:not(:has(:focus)) {
 	order: 10;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-z-2p-1m-2w-33-3a-2t-36-15]:not(#does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-z-2p-1m-2w-33-3a-2t-36-15]:not(#does-not-exist):not(.does-not-exist) {
 	order: 11;
 }
 
@@ -83,7 +83,7 @@ body:not(:has(:focus)) {
 	order: 11;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 12;
 }
 
@@ -91,7 +91,7 @@ body:not(:has(:focus)) {
 	order: 12;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-2q-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-2q-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 13;
 }
 
@@ -99,7 +99,7 @@ body:not(:has(:focus)) {
 	order: 13;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-1m-2w-2p-37-14-1a-3c-15-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-1m-2w-2p-37-14-1a-3c-15-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 14;
 }
 
@@ -107,7 +107,7 @@ body:not(:has(:focus)) {
 	order: 14;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2k-1m-2w-2p-37-2k-14-2k-11-1f-1x-2k-11-1e-1c-2k-1a-2p-2k-1m-2w-33-3a-2t-36-2k-15-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2k-1m-2w-2p-37-2k-14-2k-11-1f-1x-2k-11-1e-1c-2k-1a-2p-2k-1m-2w-33-3a-2t-36-2k-15-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 15;
 }
 
@@ -115,7 +115,7 @@ body:not(:has(:focus)) {
 	order: 15;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-1m-2q-2t-2u-33-36-2t-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-1m-2q-2t-2u-33-36-2t-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(does-not-exist) {
 	order: 16; /* not allowed by spec but encoding should work */
 }
 
@@ -123,7 +123,7 @@ body:not(:has(:focus)) {
 	order: 16; /* not allowed by spec but encoding should work */
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-2p-37-14-w-17-w-1a-2q-15-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-2p-37-14-w-17-w-1a-2q-15-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 17;
 }
 
@@ -131,7 +131,7 @@ body:not(:has(:focus)) {
 	order: 17;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2n-2n-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2n-2n-2u-33-33-15]:not(does-not-exist) {
 	order: 18;
 }
 
@@ -139,7 +139,7 @@ body:not(:has(:focus)) {
 	order: 18;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-19-19-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-19-19-2u-33-33-15]:not(.does-not-exist) {
 	order: 19;
 }
 
@@ -147,7 +147,7 @@ body:not(:has(:focus)) {
 	order: 19;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-16-15] {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-16-15] {
 	order: 20;
 }
 
@@ -155,7 +155,7 @@ body:not(:has(:focus)) {
 	order: 20;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-3d-w-16-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-3d-w-16-15]:not(.does-not-exist) {
 	order: 21;
 }
 
@@ -163,7 +163,7 @@ body:not(:has(:focus)) {
 	order: 21;
 }
 
-[csstools-has-1a-2p-1m-32-33-38-14-1m-2w-2p-37-14-1q-w-1a-2q-15-15]:not(.does-not-exist) {
+.js-has-pseudo .a:not([csstools-has-1m-2w-2p-37-14-1q-w-1a-2q-15]) {
 	order: 22;
 }
 
@@ -171,7 +171,7 @@ body:not(:has(:focus)) {
 	order: 22;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-3i-w-1a-3d-1m-2w-2p-37-14-1a-2v-w-1a-2w-15-w-1a-2x-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-3i-w-1a-3d-1m-2w-2p-37-14-1a-2v-w-1a-2w-15-w-1a-2x-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 23;
 }
 
@@ -179,7 +179,7 @@ body:not(:has(:focus)) {
 	order: 23;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 24;
 }
 
@@ -187,7 +187,7 @@ body:not(:has(:focus)) {
 	order: 24;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-1a-2q]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-1a-2q]:not(.does-not-exist):not(.does-not-exist) {
 	order: 24;
 }
 
@@ -195,7 +195,7 @@ body:not(:has(:focus)) {
 	order: 24;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c-15]:not(.does-not-exist) {
 	order: 25;
 }
 
@@ -203,7 +203,7 @@ body:not(:has(:focus)) {
 	order: 25;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), .js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
 	order: 26;
 }
 
@@ -211,7 +211,7 @@ body:not(:has(:focus)) {
 	order: 26;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 27;
 }
 
@@ -219,7 +219,7 @@ body:not(:has(:focus)) {
 	order: 27;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), .b {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), .b {
 	order: 28;
 }
 
@@ -227,7 +227,7 @@ body:not(:has(:focus)) {
 	order: 28;
 }
 
-.a, [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
+.a, .js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
 	order: 29;
 }
 
@@ -235,7 +235,7 @@ body:not(:has(:focus)) {
 	order: 29;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-w-16-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-w-16-15]:not(.does-not-exist) {
 	order: 30;
 }
 
@@ -243,7 +243,7 @@ body:not(:has(:focus)) {
 	order: 30;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(.does-not-exist) {
 	order: 31;
 }
 
@@ -251,12 +251,12 @@ body:not(:has(:focus)) {
 	order: 31;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-30-2x-32-2z-15]:not(.does-not-exist) {
-	order: 31;
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-30-2x-32-2z-15]:not(.does-not-exist) {
+	order: 31.1;
 }
 
 .x:has(> :any-link) {
-	order: 31;
+	order: 31.1;
 }
 
 @supports selector(:has(:focus)) {
@@ -266,7 +266,7 @@ body:not(:has(:focus)) {
 }
 
 @supports (display: grid) {
-	[csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
+	.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
 		order: 33;
 	}
 	:has(:focus) {
@@ -278,4 +278,12 @@ body:not(:has(:focus)) {
 	:has(:focus) {
 		order: 34;
 	}
+}
+
+.js-has-pseudo [csstools-has-z-34-37-2t-39-2s-33-2n-31-2p-2x-32-w-1m-2w-2p-37-14-1q-w-z-2q-15]:not(#does-not-exist):not(#does-not-exist)::before:hover::marker {
+	content: 'must preserve entire pseudo element part outside of the encoding';
+}
+
+#pseudo_main :has(> #b)::before:hover::marker {
+	content: 'must preserve entire pseudo element part outside of the encoding';
 }

--- a/plugins/css-has-pseudo/test/basic.preserve.expect.css
+++ b/plugins/css-has-pseudo/test/basic.preserve.expect.css
@@ -1,28 +1,28 @@
-[csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
 	order: 1;
 }
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(does-not-exist):not(does-not-exist) {
 	order: 2;
 }
 
-[csstools-has-2w-1d-1m-2w-2p-37-14-17-w-34-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2w-1d-1m-2w-2p-37-14-17-w-34-15]:not(does-not-exist):not(does-not-exist) {
 	order: 3;
 }
 
-[csstools-has-2w-1d-1m-2w-2p-37-14-3i-w-34-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2w-1d-1m-2w-2p-37-14-3i-w-34-15]:not(does-not-exist):not(does-not-exist) {
 	order: 4;
 }
 
-[csstools-has-37-2t-2r-38-2x-33-32-1m-32-33-38-14-1m-2w-2p-37-14-2w-1d-18-w-2w-1e-18-w-2w-1f-18-w-2w-1g-18-w-2w-1h-18-w-2w-1i-15-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo section:not([csstools-has-1m-2w-2p-37-14-2w-1d-18-w-2w-1e-18-w-2w-1f-18-w-2w-1g-18-w-2w-1h-18-w-2w-1i-15]:not(does-not-exist)) {
 	order: 5;
 }
 
-[csstools-has-2q-33-2s-3d-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-33-2s-3d-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]:not(does-not-exist) {
 	order: 6;
 }
 
-[csstools-has-2q-33-2s-3d-1m-32-33-38-14-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15-15]:not(does-not-exist) {
+.js-has-pseudo body:not([csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]) {
 	order: 7;
 }
 
@@ -31,104 +31,104 @@
 	order: 8;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2t-37-2r-2k-2k-2k-1m-2p-34-2t-2s-15] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2t-37-2r-2k-2k-2k-1m-2p-34-2t-2s-15] {
 	order: 9;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 10;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-z-2p-1m-2w-33-3a-2t-36-15]:not(#does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-z-2p-1m-2w-33-3a-2t-36-15]:not(#does-not-exist):not(.does-not-exist) {
 	order: 11;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 12;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-2q-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-2q-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 13;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-1m-2w-2p-37-14-1a-3c-15-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-1m-2w-2p-37-14-1a-3c-15-y-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 14;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2k-1m-2w-2p-37-2k-14-2k-11-1f-1x-2k-11-1e-1c-2k-1a-2p-2k-1m-2w-33-3a-2t-36-2k-15-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2k-1m-2w-2p-37-2k-14-2k-11-1f-1x-2k-11-1e-1c-2k-1a-2p-2k-1m-2w-33-3a-2t-36-2k-15-2l-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 15;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-1m-2q-2t-2u-33-36-2t-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-1m-2q-2t-2u-33-36-2t-1m-2w-33-3a-2t-36-15]:not(.does-not-exist):not(does-not-exist) {
 	order: 16; /* not allowed by spec but encoding should work */
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-2p-37-14-w-17-w-1a-2q-15-15]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-2p-37-14-w-17-w-1a-2q-15-15]:not(.does-not-exist):not(.does-not-exist) {
 	order: 17;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2n-2n-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2n-2n-2u-33-33-15]:not(does-not-exist) {
 	order: 18;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-19-19-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-19-19-2u-33-33-15]:not(.does-not-exist) {
 	order: 19;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-16-15] {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-16-15] {
 	order: 20;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-3d-w-16-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-3d-w-16-15]:not(.does-not-exist) {
 	order: 21;
 }
 
-[csstools-has-1a-2p-1m-32-33-38-14-1m-2w-2p-37-14-1q-w-1a-2q-15-15]:not(.does-not-exist) {
+.js-has-pseudo .a:not([csstools-has-1m-2w-2p-37-14-1q-w-1a-2q-15]) {
 	order: 22;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-3i-w-1a-3d-1m-2w-2p-37-14-1a-2v-w-1a-2w-15-w-1a-2x-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-3i-w-1a-3d-1m-2w-2p-37-14-1a-2v-w-1a-2w-15-w-1a-2x-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 23;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 24;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-1a-2q]:not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-1a-2q]:not(.does-not-exist):not(.does-not-exist) {
 	order: 24;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c-15]:not(.does-not-exist) {
 	order: 25;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), .js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
 	order: 26;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist):not(.does-not-exist):not(.does-not-exist) {
 	order: 27;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), .b {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.does-not-exist), .b {
 	order: 28;
 }
 
-.a, [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
+.a, .js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.does-not-exist) {
 	order: 29;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-w-16-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-w-16-15]:not(.does-not-exist) {
 	order: 30;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(.does-not-exist) {
 	order: 31;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-30-2x-32-2z-15]:not(.does-not-exist) {
-	order: 31;
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-30-2x-32-2z-15]:not(.does-not-exist) {
+	order: 31.1;
 }
 
 @supports selector(:has(:focus)) {
@@ -138,7 +138,7 @@
 }
 
 @supports (display: grid) {
-	[csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
+	.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
 		order: 33;
 	}
 }
@@ -147,4 +147,8 @@
 	:has(:focus) {
 		order: 34;
 	}
+}
+
+.js-has-pseudo [csstools-has-z-34-37-2t-39-2s-33-2n-31-2p-2x-32-w-1m-2w-2p-37-14-1q-w-z-2q-15]:not(#does-not-exist):not(#does-not-exist)::before:hover::marker {
+	content: 'must preserve entire pseudo element part outside of the encoding';
 }

--- a/plugins/css-has-pseudo/test/basic.specificity-matching-name.expect.css
+++ b/plugins/css-has-pseudo/test/basic.specificity-matching-name.expect.css
@@ -1,4 +1,4 @@
-[csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
 	order: 1;
 }
 
@@ -6,7 +6,7 @@
 	order: 1;
 }
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
 	order: 2;
 }
 
@@ -14,7 +14,7 @@ a:has(> img) {
 	order: 2;
 }
 
-[csstools-has-2w-1d-1m-2w-2p-37-14-17-w-34-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-2w-1d-1m-2w-2p-37-14-17-w-34-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
 	order: 3;
 }
 
@@ -22,7 +22,7 @@ h1:has(+ p) {
 	order: 3;
 }
 
-[csstools-has-2w-1d-1m-2w-2p-37-14-3i-w-34-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-2w-1d-1m-2w-2p-37-14-3i-w-34-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
 	order: 4;
 }
 
@@ -30,7 +30,7 @@ h1:has(~ p) {
 	order: 4;
 }
 
-[csstools-has-37-2t-2r-38-2x-33-32-1m-32-33-38-14-1m-2w-2p-37-14-2w-1d-18-w-2w-1e-18-w-2w-1f-18-w-2w-1g-18-w-2w-1h-18-w-2w-1i-15-15]:not(other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
+.js-has-pseudo section:not([csstools-has-1m-2w-2p-37-14-2w-1d-18-w-2w-1e-18-w-2w-1f-18-w-2w-1g-18-w-2w-1h-18-w-2w-1i-15]:not(other-thing-that-does-not-exist)) {
 	order: 5;
 }
 
@@ -38,7 +38,7 @@ section:not(:has(h1, h2, h3, h4, h5, h6)) {
 	order: 5;
 }
 
-[csstools-has-2q-33-2s-3d-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]:not(other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-2q-33-2s-3d-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]:not(other-thing-that-does-not-exist) {
 	order: 6;
 }
 
@@ -46,7 +46,7 @@ body:has(:focus) {
 	order: 6;
 }
 
-[csstools-has-2q-33-2s-3d-1m-32-33-38-14-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15-15]:not(other-thing-that-does-not-exist) {
+.js-has-pseudo body:not([csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15]) {
 	order: 7;
 }
 
@@ -59,7 +59,7 @@ body:not(:has(:focus)) {
 	order: 8;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2t-37-2r-2k-2k-2k-1m-2p-34-2t-2s-15] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2t-37-2r-2k-2k-2k-1m-2p-34-2t-2s-15] {
 	order: 9;
 }
 
@@ -67,7 +67,7 @@ body:not(:has(:focus)) {
 	order: 9;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 10;
 }
 
@@ -75,7 +75,7 @@ body:not(:has(:focus)) {
 	order: 10;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-z-2p-1m-2w-33-3a-2t-36-15]:not(#other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-z-2p-1m-2w-33-3a-2t-36-15]:not(#other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 11;
 }
 
@@ -83,7 +83,7 @@ body:not(:has(:focus)) {
 	order: 11;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 12;
 }
 
@@ -91,7 +91,7 @@ body:not(:has(:focus)) {
 	order: 12;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-2q-y-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-2q-y-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 13;
 }
 
@@ -99,7 +99,7 @@ body:not(:has(:focus)) {
 	order: 13;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-1m-2w-2p-37-14-1a-3c-15-y-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2p-1p-y-1m-2w-2p-37-14-1a-3c-15-y-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 14;
 }
 
@@ -107,7 +107,7 @@ body:not(:has(:focus)) {
 	order: 14;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2k-1m-2w-2p-37-2k-14-2k-11-1f-1x-2k-11-1e-1c-2k-1a-2p-2k-1m-2w-33-3a-2t-36-2k-15-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2j-2k-1m-2w-2p-37-2k-14-2k-11-1f-1x-2k-11-1e-1c-2k-1a-2p-2k-1m-2w-33-3a-2t-36-2k-15-2l-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 15;
 }
 
@@ -115,7 +115,7 @@ body:not(:has(:focus)) {
 	order: 15;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-1m-2q-2t-2u-33-36-2t-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-1m-2q-2t-2u-33-36-2t-1m-2w-33-3a-2t-36-15]:not(.other-thing-that-does-not-exist):not(other-thing-that-does-not-exist) {
 	order: 16; /* not allowed by spec but encoding should work */
 }
 
@@ -123,7 +123,7 @@ body:not(:has(:focus)) {
 	order: 16; /* not allowed by spec but encoding should work */
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-2p-37-14-w-17-w-1a-2q-15-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-1m-2w-2p-37-14-w-17-w-1a-2q-15-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 17;
 }
 
@@ -131,7 +131,7 @@ body:not(:has(:focus)) {
 	order: 17;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2n-2n-2u-33-33-15]:not(other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-2n-2n-2u-33-33-15]:not(other-thing-that-does-not-exist) {
 	order: 18;
 }
 
@@ -139,7 +139,7 @@ body:not(:has(:focus)) {
 	order: 18;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-19-19-2u-33-33-15]:not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-19-19-2u-33-33-15]:not(.other-thing-that-does-not-exist) {
 	order: 19;
 }
 
@@ -147,7 +147,7 @@ body:not(:has(:focus)) {
 	order: 19;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-16-15] {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-16-15] {
 	order: 20;
 }
 
@@ -155,7 +155,7 @@ body:not(:has(:focus)) {
 	order: 20;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-3d-w-16-15]:not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-3d-w-16-15]:not(.other-thing-that-does-not-exist) {
 	order: 21;
 }
 
@@ -163,7 +163,7 @@ body:not(:has(:focus)) {
 	order: 21;
 }
 
-[csstools-has-1a-2p-1m-32-33-38-14-1m-2w-2p-37-14-1q-w-1a-2q-15-15]:not(.other-thing-that-does-not-exist) {
+.js-has-pseudo .a:not([csstools-has-1m-2w-2p-37-14-1q-w-1a-2q-15]) {
 	order: 22;
 }
 
@@ -171,7 +171,7 @@ body:not(:has(:focus)) {
 	order: 22;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-3i-w-1a-3d-1m-2w-2p-37-14-1a-2v-w-1a-2w-15-w-1a-2x-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-3i-w-1a-3d-1m-2w-2p-37-14-1a-2v-w-1a-2w-15-w-1a-2x-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 23;
 }
 
@@ -179,7 +179,7 @@ body:not(:has(:focus)) {
 	order: 23;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 24;
 }
 
@@ -187,7 +187,7 @@ body:not(:has(:focus)) {
 	order: 24;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-1a-2q]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-1a-2q]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 24;
 }
 
@@ -195,7 +195,7 @@ body:not(:has(:focus)) {
 	order: 24;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c-15]:not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c-15]:not(.other-thing-that-does-not-exist) {
 	order: 25;
 }
 
@@ -203,7 +203,7 @@ body:not(:has(:focus)) {
 	order: 25;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.other-thing-that-does-not-exist), [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.other-thing-that-does-not-exist), .js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist) {
 	order: 26;
 }
 
@@ -211,7 +211,7 @@ body:not(:has(:focus)) {
 	order: 26;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15-w-3i-w-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist):not(.other-thing-that-does-not-exist) {
 	order: 27;
 }
 
@@ -219,7 +219,7 @@ body:not(:has(:focus)) {
 	order: 27;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.other-thing-that-does-not-exist), .b {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2p-15]:not(.other-thing-that-does-not-exist), .b {
 	order: 28;
 }
 
@@ -227,7 +227,7 @@ body:not(:has(:focus)) {
 	order: 28;
 }
 
-.a, [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist) {
+.a, .js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-15]:not(.other-thing-that-does-not-exist) {
 	order: 29;
 }
 
@@ -235,7 +235,7 @@ body:not(:has(:focus)) {
 	order: 29;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-w-16-15]:not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-2q-w-16-15]:not(.other-thing-that-does-not-exist) {
 	order: 30;
 }
 
@@ -243,7 +243,7 @@ body:not(:has(:focus)) {
 	order: 30;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-33-38-2w-2t-36-19-38-2w-2x-32-2v-19-38-2w-2p-38-19-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(.other-thing-that-does-not-exist) {
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1a-33-38-2w-2t-36-19-38-2w-2x-32-2v-19-38-2w-2p-38-19-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(.other-thing-that-does-not-exist) {
 	order: 31;
 }
 
@@ -251,12 +251,12 @@ body:not(:has(:focus)) {
 	order: 31;
 }
 
-[csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-30-2x-32-2z-15]:not(.other-thing-that-does-not-exist) {
-	order: 31;
+.js-has-pseudo [csstools-has-1a-3c-1m-2w-2p-37-14-1q-w-1m-30-2x-32-2z-15]:not(.other-thing-that-does-not-exist) {
+	order: 31.1;
 }
 
 .x:has(> :any-link) {
-	order: 31;
+	order: 31.1;
 }
 
 @supports selector(:has(:focus)) {
@@ -266,7 +266,7 @@ body:not(:has(:focus)) {
 }
 
 @supports (display: grid) {
-	[csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
+	.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1m-2u-33-2r-39-37-15] {
 		order: 33;
 	}
 	:has(:focus) {
@@ -278,4 +278,12 @@ body:not(:has(:focus)) {
 	:has(:focus) {
 		order: 34;
 	}
+}
+
+.js-has-pseudo [csstools-has-z-34-37-2t-39-2s-33-2n-31-2p-2x-32-w-1m-2w-2p-37-14-1q-w-z-2q-15]:not(#other-thing-that-does-not-exist):not(#other-thing-that-does-not-exist)::before:hover::marker {
+	content: 'must preserve entire pseudo element part outside of the encoding';
+}
+
+#pseudo_main :has(> #b)::before:hover::marker {
+	content: 'must preserve entire pseudo element part outside of the encoding';
 }

--- a/plugins/css-has-pseudo/test/browser.css
+++ b/plugins/css-has-pseudo/test/browser.css
@@ -182,3 +182,7 @@ main {
 #nested_main :has(> :has(#c)) {
 	color: red;
 }
+
+#pseudo_main :has(> #b)::before {
+	color: green;
+}

--- a/plugins/css-has-pseudo/test/browser.expect.css
+++ b/plugins/css-has-pseudo/test/browser.expect.css
@@ -1,87 +1,168 @@
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-pseudo-class.html */
-[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-2x-32-34-39-38-15-w-2s-2x-3a]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-2x-32-34-39-38-15-w-2s-2x-3a]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+	color: grey
+}
+#d_main:has(input) div {
 	color: grey
 }
 
-[csstools-has-z-2s-2n-31-2p-2x-32-1m-20-1t-2b-14-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2r-2w-2t-2r-2z-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2s-2n-31-2p-2x-32-1m-20-1t-2b-14-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2r-2w-2t-2r-2z-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: red
 }
 
-[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-33-34-38-2x-33-32-1m-2r-2w-2t-2r-2z-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+#d_main:HAS(#d_checkbox:checked)>#d_subject {
 	color: red
 }
 
-[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-1t-37-14-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2s-2x-37-2p-2q-30-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-33-34-38-2x-33-32-1m-2r-2w-2t-2r-2z-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+	color: red
+}
+
+#d_main:has(#d_option:checked)>#d_subject {
+	color: red
+}
+
+.js-has-pseudo [csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-1t-37-14-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2s-2x-37-2p-2q-30-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: green
 }
 
-[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-33-34-38-2x-33-32-1m-2s-2x-37-2p-2q-30-2t-2s-15-1q-w-1m-2x-37-14-z-2s-2n-37-39-2q-2y-2t-2r-38-18-w-z-2s-2n-37-39-2q-2y-2t-2r-38-1e-15]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+#d_main:hAs(#d_checkbox:disabled)>#d_subject {
 	color: green
 }
 
-[csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-33-34-38-2v-36-33-39-34-1m-2s-2x-37-2p-2q-30-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-33-34-38-2x-33-32-1m-2s-2x-37-2p-2q-30-2t-2s-15-1q-w-1m-2x-37-14-z-2s-2n-37-39-2q-2y-2t-2r-38-18-w-z-2s-2n-37-39-2q-2y-2t-2r-38-1e-15]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+	color: green
+}
+
+#d_main:has(#d_option:disabled)> :is(#d_subject, #d_subject2) {
+	color: green
+}
+
+.js-has-pseudo [csstools-has-z-2s-2n-31-2p-2x-32-1m-2w-2p-37-14-z-2s-2n-33-34-38-2v-36-33-39-34-1m-2s-2x-37-2p-2q-30-2t-2s-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
 	color: blue
 }
 
-[csstools-has-z-2s-2n-31-2p-2x-32-1m-32-33-38-14-1m-2w-2p-37-14-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2t-32-2p-2q-30-2t-2s-15-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38-1f]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+#d_main:has(#d_optgroup:disabled)>#d_subject {
+	color: blue
+}
+
+.js-has-pseudo #d_main:not([csstools-has-1m-2w-2p-37-14-z-2s-2n-2r-2w-2t-2r-2z-2q-33-3c-1m-2t-32-2p-2q-30-2t-2s-15]:not(#does-not-exist))>#d_subject3 {
 	color: green
 }
 
-[csstools-has-z-2s-2n-31-2p-2x-32-1m-32-33-38-14-1m-2w-2p-37-14-z-2s-2n-33-34-38-2x-33-32-1m-2t-32-2p-2q-30-2t-2s-15-15-w-1m-2x-37-14-z-2s-2n-37-39-2q-2y-2t-2r-38-1f-18-w-z-2s-2n-37-39-2q-2y-2t-2r-38-1g-15]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+#d_main:not(:has(#d_checkbox:enabled))>#d_subject3 {
 	color: green
 }
 
-[csstools-has-z-2s-2n-31-2p-2x-32-1m-32-33-38-14-1m-2w-2p-37-14-z-2s-2n-33-34-38-2v-36-33-39-34-1m-2t-32-2p-2q-30-2t-2s-15-15-1q-z-2s-2n-37-39-2q-2y-2t-2r-38-1f]:not(#does-not-exist):not(#does-not-exist):not(#does-not-exist) {
+.js-has-pseudo #d_main:not([csstools-has-1m-2w-2p-37-14-z-2s-2n-33-34-38-2x-33-32-1m-2t-32-2p-2q-30-2t-2s-15]:not(#does-not-exist)) :is(#d_subject3, #d_subject4) {
+	color: green
+}
+
+#d_main:not(:has(#d_option:enabled)) :is(#d_subject3, #d_subject4) {
+	color: green
+}
+
+.js-has-pseudo #d_main:not([csstools-has-1m-2w-2p-37-14-z-2s-2n-33-34-38-2v-36-33-39-34-1m-2t-32-2p-2q-30-2t-2s-15]:not(#does-not-exist))>#d_subject3 {
+	color: blue
+}
+
+#d_main:not(:has(#d_optgroup:enabled))>#d_subject3 {
 	color: blue
 }
 
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-in-ancestor-position.html */
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1a-2r-2n-38-2t-37-38-18-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-1a-2r-2n-38-2t-37-38-18-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+	background-color: red
+}
+div:has(.c_test, [c_test_attr]) #c_subject {
 	background-color: red
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1q-w-1a-2r-2n-38-2t-37-38-18-w-1q-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-1q-w-1a-2r-2n-38-2t-37-38-18-w-1q-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: green
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-1a-2r-2n-38-2t-37-38-18-w-3i-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+div:has(> .c_test, > [c_test_attr]) #c_subject {
+	background-color: green
+}
+
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-1a-2r-2n-38-2t-37-38-18-w-3i-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: yellow
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-1a-2r-2n-38-2t-37-38-18-w-17-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+div:has(~ .c_test, ~ [c_test_attr]) #c_subject {
+	background-color: yellow
+}
+
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-1a-2r-2n-38-2t-37-38-18-w-17-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: blue
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-2s-2x-3a-w-1a-2r-2n-38-2t-37-38-18-w-3i-w-2s-2x-3a-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+div:has(+ .c_test, + [c_test_attr]) #c_subject {
+	background-color: blue
+}
+
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-2s-2x-3a-w-1a-2r-2n-38-2t-37-38-18-w-3i-w-2s-2x-3a-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	background-color: purple
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-2s-2x-3a-w-1a-2r-2n-38-2t-37-38-18-w-17-w-2s-2x-3a-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+div:has(~ div .c_test, ~ div [c_test_attr]) #c_subject {
+	background-color: purple
+}
+
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-2s-2x-3a-w-1a-2r-2n-38-2t-37-38-18-w-17-w-2s-2x-3a-w-2j-2r-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-w-z-2r-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+	background-color: pink
+}
+
+div:has(+ div .c_test, + div [c_test_attr]) #c_subject {
 	background-color: pink
 }
 
 /* https://github.com/web-platform-tests/wpt/blob/master/css/selectors/invalidation/has-in-adjacent-position.html */
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1a-2p-2n-2c-2t-37-38-18-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-1a-2p-2n-2c-2t-37-38-18-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+	background-color: red;
+}
+div:has(.a_Test, [a_test_attr])+#a_subject {
 	background-color: red;
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-1q-w-1a-2p-2n-2c-2t-37-38-18-w-1q-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-1q-w-1a-2p-2n-2c-2t-37-38-18-w-1q-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: green;
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-1a-2p-2n-2c-2t-37-38-18-w-3i-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+div:has(> .a_Test, > [a_test_attr])+#a_subject {
+	background-color: green;
+}
+
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-1a-2p-2n-2c-2t-37-38-18-w-3i-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: yellow;
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-1a-2p-2n-2c-2t-37-38-18-w-17-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
+div:has(~ .a_Test, ~ [a_test_attr])+#a_subject {
+	background-color: yellow;
+}
+
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-1a-2p-2n-2c-2t-37-38-18-w-17-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist) {
 	background-color: blue;
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-2s-2x-3a-w-1a-2p-2n-2c-2t-37-38-18-w-3i-w-2s-2x-3a-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+div:has(+ .a_Test, + [a_test_attr])+#a_subject {
+	background-color: blue;
+}
+
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-3i-w-2s-2x-3a-w-1a-2p-2n-2c-2t-37-38-18-w-3i-w-2s-2x-3a-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	background-color: purple;
 }
 
-[csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-2s-2x-3a-w-1a-2p-2n-2c-2t-37-38-18-w-17-w-2s-2x-3a-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+div:has(~ div .a_Test, ~ div [a_test_attr])+#a_subject {
+	background-color: purple;
+}
+
+.js-has-pseudo [csstools-has-2s-2x-3a-1m-2w-2p-37-14-17-w-2s-2x-3a-w-1a-2p-2n-2c-2t-37-38-18-w-17-w-2s-2x-3a-w-2j-2p-2n-38-2t-37-38-2n-2p-38-38-36-2l-15-17-z-2p-2n-37-39-2q-2y-2t-2r-38]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+	background-color: pink;
+}
+
+div:has(+ div .a_Test, + div [a_test_attr])+#a_subject {
 	background-color: pink;
 }
 
@@ -95,90 +176,186 @@ main {
 	padding: 5px;
 }
 
-[csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-1q-w-1a-2q-2n-2r-2w-2x-30-2s-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-1q-w-1a-2q-2n-2r-2w-2x-30-2s-15]:not(.does-not-exist) {
 	background-color: red;
 }
 
-[csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-1a-2q-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-15]:not(.does-not-exist) {
+.b_subject:has(> .b_child) {
+	background-color: red;
+}
+
+.js-has-pseudo [csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-1a-2q-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-15]:not(.does-not-exist) {
 	background-color: green;
 }
 
-[csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-2j-2p-38-38-36-32-2p-31-2t-1p-y-2q-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-y-2l-15]:not(.does-not-exist) {
+.b_subject:has(.b_descendant) {
+	background-color: green;
+}
+
+.js-has-pseudo [csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-2j-2p-38-38-36-32-2p-31-2t-1p-y-2q-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-y-2l-15]:not(.does-not-exist) {
 	background-color: blue;
 }
 
-[csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-z-2q-2n-2s-2x-3a-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-15]:not(#does-not-exist) {
+.b_subject:has([attrname="b_descendant"]) {
+	background-color: blue;
+}
+
+.js-has-pseudo [csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-z-2q-2n-2s-2x-3a-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-15]:not(#does-not-exist) {
 	background-color: yellow;
 }
 
-[csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-2q-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-15]:not(does-not-exist) {
+.b_subject:has(#b_div_descendant) {
+	background-color: yellow;
+}
+
+.js-has-pseudo [csstools-has-1a-2q-2n-37-39-2q-2y-2t-2r-38-1m-2w-2p-37-14-2q-2n-2s-2t-37-2r-2t-32-2s-2p-32-38-15]:not(does-not-exist) {
 	background-color: yellowgreen;
 }
 
-[csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1d-1m-2w-2p-37-14-1m-30-2x-32-2z-15]:not(#does-not-exist) {
+.b_subject:has(b_descendant) {
+	background-color: yellowgreen;
+}
+
+.js-has-pseudo [csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1d-1m-2w-2p-37-14-1m-30-2x-32-2z-15]:not(#does-not-exist) {
 	color: green;
 }
 
-[csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1e-1m-2w-2p-37-14-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(#does-not-exist) {
+#visited-1:has(:link) {
+	color: green;
+}
+
+.js-has-pseudo [csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1e-1m-2w-2p-37-14-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(#does-not-exist) {
 	color: yellow;
 }
 
-[csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1f-1m-2w-2p-37-14-1m-30-2x-32-2z-15]:not(#does-not-exist) {
+#visited-2:has(:visited) {
+	color: yellow;
+}
+
+.js-has-pseudo [csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1f-1m-2w-2p-37-14-1m-30-2x-32-2z-15]:not(#does-not-exist) {
 	color: yellowgreen;
 }
 
-[csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1g-1m-2w-2p-37-14-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(#does-not-exist) {
+#visited-3:has(:any-link) {
+	color: yellowgreen;
+}
+
+.js-has-pseudo [csstools-has-z-3a-2x-37-2x-38-2t-2s-19-1g-1m-2w-2p-37-14-1a-2s-33-2t-37-19-32-33-38-19-2t-3c-2x-37-38-15]:not(#does-not-exist) {
 	color: red;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
+#visited-4:has(:visited) {
+	color: red;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t0:PASS;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
+#main_specificity :has(#foo) {
+	--t0:PASS;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	--t0:FAIL;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist):not(does-not-exist) {
+#main_specificity :has(.foo) {
+	--t0:FAIL;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist):not(does-not-exist) {
 	--t1:PASS;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
+#main_specificity :has(span#foo) {
+	--t1:PASS;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t1:FAIL;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2q-2p-36-18-w-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
+#main_specificity :has(#foo) {
+	--t1:FAIL;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2q-2p-36-18-w-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t2:FAIL;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-z-2u-33-33-18-w-1a-2q-2p-36-15]:not(#does-not-exist):not(#does-not-exist) {
+#main_specificity :has(.bar, #foo) {
+	--t2:FAIL;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-z-2u-33-33-18-w-1a-2q-2p-36-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t2:PASS;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2q-2p-36-18-w-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
+#main_specificity :has(#foo, .bar) {
+	--t2:PASS;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2q-2p-36-18-w-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t3:PASS;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2u-33-33-18-w-1a-2q-2p-36-15]:not(#does-not-exist) {
+#main_specificity :has(.bar, #foo) {
+	--t3:PASS;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-1a-2u-33-33-18-w-1a-2q-2p-36-15]:not(#does-not-exist) {
 	--t3:FAIL;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-w-17-w-37-34-2p-32-15]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
+#main_specificity :has(.foo, .bar) {
+	--t3:FAIL;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-w-17-w-37-34-2p-32-15]:not(#does-not-exist):not(does-not-exist):not(does-not-exist) {
 	--t4:PASS;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-15]:not(#does-not-exist):not(does-not-exist) {
+#main_specificity :has(span + span) {
+	--t4:PASS;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-15]:not(#does-not-exist):not(does-not-exist) {
 	--t4:FAIL;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-18-w-30-2x-18-w-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
+#main_specificity :has(span) {
+	--t4:FAIL;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-18-w-30-2x-18-w-z-2u-33-33-15]:not(#does-not-exist):not(#does-not-exist) {
 	--t5:PASS;
 }
 
-[csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-18-w-30-2x-18-w-34-15]:not(#does-not-exist):not(does-not-exist) {
+#main_specificity :has(span, li, #foo) {
+	--t5:PASS;
+}
+
+.js-has-pseudo [csstools-has-z-31-2p-2x-32-2n-37-34-2t-2r-2x-2u-2x-2r-2x-38-3d-w-1m-2w-2p-37-14-37-34-2p-32-18-w-30-2x-18-w-34-15]:not(#does-not-exist):not(does-not-exist) {
 	--t5:FAIL;
 }
 
-[csstools-has-z-32-2t-37-38-2t-2s-2n-31-2p-2x-32-w-1m-2w-2p-37-14-1q-w-1m-2w-2p-37-14-z-2r-15-15]:not(#does-not-exist):not(#does-not-exist) {
+#main_specificity :has(span, li, p) {
+	--t5:FAIL;
+}
+
+.js-has-pseudo [csstools-has-z-32-2t-37-38-2t-2s-2n-31-2p-2x-32-w-1m-2w-2p-37-14-1q-w-1m-2w-2p-37-14-z-2r-15-15]:not(#does-not-exist):not(#does-not-exist) {
 	color: red;
+}
+
+#nested_main :has(> :has(#c)) {
+	color: red;
+}
+
+.js-has-pseudo [csstools-has-z-34-37-2t-39-2s-33-2n-31-2p-2x-32-w-1m-2w-2p-37-14-1q-w-z-2q-15]:not(#does-not-exist):not(#does-not-exist)::before {
+	color: green;
+}
+
+#pseudo_main :has(> #b)::before {
+	color: green;
 }

--- a/plugins/css-has-pseudo/test/examples/example.expect.css
+++ b/plugins/css-has-pseudo/test/examples/example.expect.css
@@ -1,4 +1,4 @@
-[csstools-has-1a-38-2x-38-30-2t-1m-2w-2p-37-14-17-w-34-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2x-38-30-2t-1m-2w-2p-37-14-17-w-34-15]:not(does-not-exist) {
 	margin-bottom: 1.5rem;
 }
 .title:has(+ p) {

--- a/plugins/css-has-pseudo/test/examples/example.preserve-false.expect.css
+++ b/plugins/css-has-pseudo/test/examples/example.preserve-false.expect.css
@@ -1,3 +1,3 @@
-[csstools-has-1a-38-2x-38-30-2t-1m-2w-2p-37-14-17-w-34-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1a-38-2x-38-30-2t-1m-2w-2p-37-14-17-w-34-15]:not(does-not-exist) {
 	margin-bottom: 1.5rem;
 }

--- a/plugins/css-has-pseudo/test/generated-selector-cases.expect.css
+++ b/plugins/css-has-pseudo/test/generated-selector-cases.expect.css
@@ -1,880 +1,880 @@
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 0;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 1;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 2;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 3;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 4;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 5;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 6;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 7;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 8;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 9;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 10;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 11;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 12;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 13;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 14;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 15;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 16;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 17;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 18;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 19;
 }
 
-[csstools-has-2q-39-38-38-33-32-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-39-38-38-33-32-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 20;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-2q-39-38-38-33-32]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 21;
 }
 
-[csstools-has-2q-39-38-38-33-32-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-39-38-38-33-32-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 22;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-2q-39-38-38-33-32]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 23;
 }
 
-[csstools-has-2q-39-38-38-33-32-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-39-38-38-33-32-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 24;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-2q-39-38-38-33-32]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 25;
 }
 
-[csstools-has-2q-39-38-38-33-32-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-39-38-38-33-32-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 26;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-2q-39-38-38-33-32]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 27;
 }
 
-[csstools-has-2q-39-38-38-33-32-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-39-38-38-33-32-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 28;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-2q-39-38-38-33-32]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 29;
 }
 
-[csstools-has-2q-39-38-38-33-32-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-39-38-38-33-32-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 30;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-2q-39-38-38-33-32]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 31;
 }
 
-[csstools-has-2q-39-38-38-33-32-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-39-38-38-33-32-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 32;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-2q-39-38-38-33-32]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 33;
 }
 
-[csstools-has-2q-39-38-38-33-32-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-39-38-38-33-32-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 34;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-2q-39-38-38-33-32]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 35;
 }
 
-[csstools-has-2q-39-38-38-33-32-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2q-39-38-38-33-32-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 36;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-2q-39-38-38-33-32]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-2q-39-38-38-33-32]:not(does-not-exist) {
 	order: 37;
 }
 
-button, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+button, .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 38;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], button {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], button {
 	order: 39;
 }
 
-[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 40;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 41;
 }
 
-[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 42;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 43;
 }
 
-[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 44;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 45;
 }
 
-[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 46;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 47;
 }
 
-[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 48;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 49;
 }
 
-[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 50;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 51;
 }
 
-[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 52;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 53;
 }
 
-[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 54;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 55;
 }
 
-[csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-16pq-17td-16po-188u-6bx-16po-186c-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 56;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1a-16pq-17td-16po-188u-6bx-16po-186c]:not(.does-not-exist) {
 	order: 57;
 }
 
-.🧑🏾‍🎤, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.🧑🏾‍🎤, .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 58;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], .🧑🏾‍🎤 {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], .🧑🏾‍🎤 {
 	order: 59;
 }
 
-[csstools-has-1a-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 60;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1a-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1a-2u-33-33]:not(.does-not-exist) {
 	order: 61;
 }
 
-[csstools-has-1a-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 62;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1a-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1a-2u-33-33]:not(.does-not-exist) {
 	order: 63;
 }
 
-[csstools-has-1a-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 64;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1a-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1a-2u-33-33]:not(.does-not-exist) {
 	order: 65;
 }
 
-[csstools-has-1a-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 66;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1a-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1a-2u-33-33]:not(.does-not-exist) {
 	order: 67;
 }
 
-[csstools-has-1a-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 68;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1a-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1a-2u-33-33]:not(.does-not-exist) {
 	order: 69;
 }
 
-[csstools-has-1a-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 70;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1a-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1a-2u-33-33]:not(.does-not-exist) {
 	order: 71;
 }
 
-[csstools-has-1a-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 72;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1a-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1a-2u-33-33]:not(.does-not-exist) {
 	order: 73;
 }
 
-[csstools-has-1a-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 74;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1a-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1a-2u-33-33]:not(.does-not-exist) {
 	order: 75;
 }
 
-[csstools-has-1a-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1a-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 76;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1a-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1a-2u-33-33]:not(.does-not-exist) {
 	order: 77;
 }
 
-.foo, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.foo, .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 78;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], .foo {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], .foo {
 	order: 79;
 }
 
-[csstools-has-z-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 80;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-z-2u-33-33]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-z-2u-33-33]:not(#does-not-exist) {
 	order: 81;
 }
 
-[csstools-has-z-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 82;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-z-2u-33-33]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-z-2u-33-33]:not(#does-not-exist) {
 	order: 83;
 }
 
-[csstools-has-z-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 84;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-z-2u-33-33]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-z-2u-33-33]:not(#does-not-exist) {
 	order: 85;
 }
 
-[csstools-has-z-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 86;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-z-2u-33-33]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-z-2u-33-33]:not(#does-not-exist) {
 	order: 87;
 }
 
-[csstools-has-z-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 88;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-z-2u-33-33]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-z-2u-33-33]:not(#does-not-exist) {
 	order: 89;
 }
 
-[csstools-has-z-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 90;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-z-2u-33-33]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-z-2u-33-33]:not(#does-not-exist) {
 	order: 91;
 }
 
-[csstools-has-z-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 92;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-z-2u-33-33]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-z-2u-33-33]:not(#does-not-exist) {
 	order: 93;
 }
 
-[csstools-has-z-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 94;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-z-2u-33-33]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-z-2u-33-33]:not(#does-not-exist) {
 	order: 95;
 }
 
-[csstools-has-z-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-z-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(#does-not-exist) {
 	order: 96;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-z-2u-33-33]:not(#does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-z-2u-33-33]:not(#does-not-exist) {
 	order: 97;
 }
 
-#foo, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+#foo, .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 98;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], #foo {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], #foo {
 	order: 99;
 }
 
-[csstools-has-2n-2n-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2n-2n-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 100;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-2n-2n-2u-33-33]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 101;
 }
 
-[csstools-has-2n-2n-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2n-2n-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 102;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-2n-2n-2u-33-33]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 103;
 }
 
-[csstools-has-2n-2n-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2n-2n-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 104;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-2n-2n-2u-33-33]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 105;
 }
 
-[csstools-has-2n-2n-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2n-2n-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 106;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-2n-2n-2u-33-33]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 107;
 }
 
-[csstools-has-2n-2n-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2n-2n-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 108;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-2n-2n-2u-33-33]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 109;
 }
 
-[csstools-has-2n-2n-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2n-2n-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 110;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-2n-2n-2u-33-33]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 111;
 }
 
-[csstools-has-2n-2n-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2n-2n-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 112;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-2n-2n-2u-33-33]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 113;
 }
 
-[csstools-has-2n-2n-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2n-2n-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 114;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-2n-2n-2u-33-33]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 115;
 }
 
-[csstools-has-2n-2n-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2n-2n-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 116;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-2n-2n-2u-33-33]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-2n-2n-2u-33-33]:not(does-not-exist) {
 	order: 117;
 }
 
-__foo, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+__foo, .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 118;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], __foo {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], __foo {
 	order: 119;
 }
 
-[csstools-has-1m-19-19-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-19-19-2u-33-33-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 120;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-19-19-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 121;
 }
 
-[csstools-has-1m-19-19-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-19-19-2u-33-33-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 122;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 123;
 }
 
-[csstools-has-1m-19-19-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-19-19-2u-33-33-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 124;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 125;
 }
 
-[csstools-has-1m-19-19-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-19-19-2u-33-33-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 126;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-19-19-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 127;
 }
 
-[csstools-has-1m-19-19-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-19-19-2u-33-33-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 128;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 129;
 }
 
-[csstools-has-1m-19-19-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-19-19-2u-33-33-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 130;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-19-19-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 131;
 }
 
-[csstools-has-1m-19-19-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-19-19-2u-33-33-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 132;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 133;
 }
 
-[csstools-has-1m-19-19-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-19-19-2u-33-33-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 134;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-19-19-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 135;
 }
 
-[csstools-has-1m-19-19-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-19-19-2u-33-33-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 136;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-19-19-2u-33-33]:not(.does-not-exist) {
 	order: 137;
 }
 
-:--foo, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+:--foo, .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 138;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], :--foo {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], :--foo {
 	order: 139;
 }
 
-[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 140;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 141;
 }
 
-[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 142;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 143;
 }
 
-[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 144;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 145;
 }
 
-[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 146;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 147;
 }
 
-[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 148;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 149;
 }
 
-[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 150;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 151;
 }
 
-[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 152;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 153;
 }
 
-[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 154;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 155;
 }
 
-[csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2u-33-33-1p-y-2q-2p-3e-y-2l-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 156;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-2j-2u-33-33-1p-y-2q-2p-3e-y-2l]:not(.does-not-exist) {
 	order: 157;
 }
 
-[foo="baz"], [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+[foo="baz"], .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 158;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], [foo="baz"] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], [foo="baz"] {
 	order: 159;
 }
 
-[csstools-has-16-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-16-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 160;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-16] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-16] {
 	order: 161;
 }
 
-[csstools-has-16-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-16-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 162;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-16] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-16] {
 	order: 163;
 }
 
-[csstools-has-16-w-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-16-w-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 164;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-16] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-16] {
 	order: 165;
 }
 
-[csstools-has-16-17-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-16-17-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 166;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-16] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-16] {
 	order: 167;
 }
 
-[csstools-has-16-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-16-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 168;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-16] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-16] {
 	order: 169;
 }
 
-[csstools-has-16-3i-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-16-3i-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 170;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-16] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-16] {
 	order: 171;
 }
 
-[csstools-has-16-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-16-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 172;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-16] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-16] {
 	order: 173;
 }
 
-[csstools-has-16-1q-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-16-1q-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 174;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-16] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-16] {
 	order: 175;
 }
 
-[csstools-has-16-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
+.js-has-pseudo [csstools-has-16-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 176;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-16] {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-16] {
 	order: 177;
 }
 
-*, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+*, .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 178;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], * {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], * {
 	order: 179;
 }
 
-[csstools-has-1m-2w-33-3a-2t-36-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-33-3a-2t-36-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 180;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 181;
 }
 
-[csstools-has-1m-2w-33-3a-2t-36-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-33-3a-2t-36-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 182;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 183;
 }
 
-[csstools-has-1m-2w-33-3a-2t-36-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-33-3a-2t-36-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 184;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 185;
 }
 
-[csstools-has-1m-2w-33-3a-2t-36-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-33-3a-2t-36-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 186;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 187;
 }
 
-[csstools-has-1m-2w-33-3a-2t-36-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-33-3a-2t-36-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 188;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 189;
 }
 
-[csstools-has-1m-2w-33-3a-2t-36-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-33-3a-2t-36-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 190;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 191;
 }
 
-[csstools-has-1m-2w-33-3a-2t-36-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-33-3a-2t-36-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 192;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 193;
 }
 
-[csstools-has-1m-2w-33-3a-2t-36-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-33-3a-2t-36-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 194;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 195;
 }
 
-[csstools-has-1m-2w-33-3a-2t-36-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-33-3a-2t-36-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 196;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-2w-33-3a-2t-36]:not(.does-not-exist) {
 	order: 197;
 }
 
-:hover, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+:hover, .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 198;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], :hover {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], :hover {
 	order: 199;
 }
 
-[csstools-has-1m-1m-2q-2t-2u-33-36-2t-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-1m-2q-2t-2u-33-36-2t-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 200;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15]::before {
 	order: 201;
 }
 
-[csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 202;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w]::before {
 	order: 203;
 }
 
-[csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 204;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-w]::before {
 	order: 205;
 }
 
-[csstools-has-1m-1m-2q-2t-2u-33-36-2t-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-1m-2q-2t-2u-33-36-2t-17-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 206;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-17]::before {
 	order: 207;
 }
 
-[csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-17-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 208;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-17-w]::before {
 	order: 209;
 }
 
-[csstools-has-1m-1m-2q-2t-2u-33-36-2t-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-1m-2q-2t-2u-33-36-2t-3i-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 210;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-3i]::before {
 	order: 211;
 }
 
-[csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-3i-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 212;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-3i-w]::before {
 	order: 213;
 }
 
-[csstools-has-1m-1m-2q-2t-2u-33-36-2t-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-1m-2q-2t-2u-33-36-2t-1q-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 214;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-1q]::before {
 	order: 215;
 }
 
-[csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-1m-2q-2t-2u-33-36-2t-w-1q-w-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 216;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w-1m-1m-2q-2t-2u-33-36-2t]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15-w-1q-w]::before {
 	order: 217;
 }
 
-::before, [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
+::before, .js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15] {
 	order: 218;
 }
 
-[csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], ::before {
+.js-has-pseudo [csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15], ::before {
 	order: 219;
 }
 
@@ -886,7 +886,7 @@ foo[baz=":has(.foo)"] {
 	order: 221;
 }
 
-[csstools-has-1m-32-33-38-14-1m-2w-2p-37-14-1a-2u-33-33-15-15] {
+.js-has-pseudo :not([csstools-has-1m-2w-2p-37-14-1a-2u-33-33-15]) {
 	order: 222;
 }
 
@@ -894,11 +894,11 @@ foo[baz=":has(.foo)"] {
 	order: 223;
 }
 
-[csstools-has-1m-19-19-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
+.js-has-pseudo [csstools-has-1m-19-19-1m-2w-2p-37-14-1a-2u-33-33-15]:not(.does-not-exist) {
 	order: 224;
 }
 
-[csstools-has-2n-2n-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2n-2n-1m-2w-2p-37-14-1a-2u-33-33-15]:not(does-not-exist) {
 	order: 225;
 }
 

--- a/plugins/css-has-pseudo/test/plugin-order-logical.after.expect.css
+++ b/plugins/css-has-pseudo/test/plugin-order-logical.after.expect.css
@@ -1,6 +1,6 @@
-[csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px
 }
-[csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px
 }

--- a/plugins/css-has-pseudo/test/plugin-order-logical.after.preserve.expect.css
+++ b/plugins/css-has-pseudo/test/plugin-order-logical.after.preserve.expect.css
@@ -1,55 +1,55 @@
-[csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px;
 }
 [dir="ltr"] a:has(.b) {
 	margin-left: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-30-38-36-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-30-38-36-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px;
 }
 a:has(.b):dir(ltr) {
 	margin-left: 2px;
 }
-[csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px;
 }
 [dir="rtl"] a:has(.b) {
 	margin-right: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-36-38-30-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-36-38-30-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px;
 }
 a:has(.b):dir(rtl) {
 	margin-right: 2px;
 }
-[dir="ltr"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+[dir="ltr"] .js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-left: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
 	margin-left: 2px;
 }
-[dir="rtl"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+[dir="rtl"] .js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-right: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
 	margin-right: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-inline-start: 2px;
 }
-[dir="ltr"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+[dir="ltr"] .js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-left: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
 	margin-left: 2px;
 }
-[dir="rtl"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+[dir="rtl"] .js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-right: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
 	margin-right: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-inline-start: 2px;
 }
 a:has(.b) {

--- a/plugins/css-has-pseudo/test/plugin-order-logical.before.expect.css
+++ b/plugins/css-has-pseudo/test/plugin-order-logical.before.expect.css
@@ -1,6 +1,6 @@
-[csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px
 }
-[csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px
 }

--- a/plugins/css-has-pseudo/test/plugin-order-logical.before.preserve.expect.css
+++ b/plugins/css-has-pseudo/test/plugin-order-logical.before.preserve.expect.css
@@ -1,55 +1,55 @@
-[csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2s-2x-36-1p-y-30-38-36-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px;
 }
 [dir="ltr"] a:has(.b) {
 	margin-left: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-30-38-36-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-30-38-36-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-left: 2px;
 }
 a:has(.b):dir(ltr) {
 	margin-left: 2px;
 }
-[csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2j-2s-2x-36-1p-y-36-38-30-y-2l-w-2p-1m-2w-2p-37-14-1a-2q-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px;
 }
 [dir="rtl"] a:has(.b) {
 	margin-right: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-36-38-30-15]:not(.does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15-1m-2s-2x-36-14-36-38-30-15]:not(.does-not-exist):not(does-not-exist) {
 	margin-right: 2px;
 }
 a:has(.b):dir(rtl) {
 	margin-right: 2px;
 }
-[dir="ltr"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+[dir="ltr"] .js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-left: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
 	margin-left: 2px;
 }
-[dir="rtl"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+[dir="rtl"] .js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-right: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
 	margin-right: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-inline-start: 2px;
 }
-[dir="ltr"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+[dir="ltr"] .js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-left: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(ltr) {
 	margin-left: 2px;
 }
-[dir="rtl"] [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+[dir="rtl"] .js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-right: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist):dir(rtl) {
 	margin-right: 2px;
 }
-[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 	margin-inline-start: 2px;
 }
 a:has(.b) {

--- a/plugins/css-has-pseudo/test/plugin-order-nesting.after.expect.css
+++ b/plugins/css-has-pseudo/test/plugin-order-nesting.after.expect.css
@@ -1,12 +1,12 @@
 
-	[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+	.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 		order: 1;
 	}
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
 		order: 2;
 	}
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
 		order: 3;
 	}

--- a/plugins/css-has-pseudo/test/plugin-order-nesting.after.preserve.expect.css
+++ b/plugins/css-has-pseudo/test/plugin-order-nesting.after.preserve.expect.css
@@ -1,5 +1,5 @@
 
-	[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+	.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 		order: 1;
 	}
 
@@ -7,7 +7,7 @@ a:has(.b) {
 		order: 1;
 	}
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
 		order: 2;
 	}
 
@@ -15,7 +15,7 @@ a:has(> img):focus {
 		order: 2;
 	}
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
 		order: 3;
 	}
 

--- a/plugins/css-has-pseudo/test/plugin-order-nesting.before.expect.css
+++ b/plugins/css-has-pseudo/test/plugin-order-nesting.before.expect.css
@@ -1,12 +1,12 @@
 
-	[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+	.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 		order: 1;
 	}
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
 		order: 2;
 	}
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
 		order: 3;
 	}

--- a/plugins/css-has-pseudo/test/plugin-order-nesting.before.preserve.expect.css
+++ b/plugins/css-has-pseudo/test/plugin-order-nesting.before.preserve.expect.css
@@ -1,5 +1,5 @@
 
-	[csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
+	.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1a-2q-15]:not(does-not-exist) {
 		order: 1;
 	}
 
@@ -7,7 +7,7 @@ a:has(.b) {
 		order: 1;
 	}
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-1m-2u-33-2r-39-37]:not(does-not-exist):not(does-not-exist) {
 		order: 2;
 	}
 
@@ -15,7 +15,7 @@ a:has(> img):focus {
 		order: 2;
 	}
 
-[csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
+.js-has-pseudo [csstools-has-2p-1m-2w-2p-37-14-1q-w-2x-31-2v-15-w-1m-2w-2p-37-14-1q-w-1a-37-33-31-2t-15]:not(does-not-exist):not(does-not-exist) {
 		order: 3;
 	}
 


### PR DESCRIPTION
## Pseudo elements

Previous iteration encoded pseudo elements as part of the `[csstools-has-...]`
This pretty much broke them.

`:has(> .foo)::after` is now split before the pseudo element.
This ensures pseudo elements still work.


## `.js-has-pseudo`

Works a bit different from the other polyfills.
We already require access to CSSOM to analyse the stylesheet.
I am using this to rewrite the rules.

If the polyfill is loaded and applied we remove `.js-has-pseudo` from the selectors in CSSOM.

If the polyfill is loaded but there is native support we remove these rules entirely.

Overall this has the least side effects in terms of specificity and interaction with `:not()`.