### PR TITLE
postcss-gap-properties: fix detection of `display: grid`

### DIFF
--- a/plugins/postcss-gap-properties/CHANGELOG.md
+++ b/plugins/postcss-gap-properties/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to PostCSS Gap Properties
 
+### Unreleased
+
+- Fix detection of `display: grid;`
+
 ### 3.0.4 (July 8, 2022)
 
 - Fix case insensitive matching.

--- a/plugins/postcss-gap-properties/src/index.js
+++ b/plugins/postcss-gap-properties/src/index.js
@@ -29,6 +29,10 @@ function creator(opts) {
 
 			const replacement = `grid-${decl.prop.toLowerCase()}`;
 			const hasGridPrefixedDeclaration = decl.parent.some((node) => {
+				if (node.type !== 'decl') {
+					return false;
+				}
+
 				return node.prop.toLowerCase() === replacement;
 			});
 			if (hasGridPrefixedDeclaration) {

--- a/plugins/postcss-gap-properties/src/index.js
+++ b/plugins/postcss-gap-properties/src/index.js
@@ -17,6 +17,10 @@ function creator(opts) {
 			}
 
 			const isNotDisplayGrid = !(decl.parent.some((node) => {
+				if (node.type !== 'decl') {
+					return false;
+				}
+
 				return node.prop.toLowerCase() === 'display' && node.value.toLowerCase() === 'grid';
 			}));
 			if (isNotDisplayGrid) {

--- a/plugins/postcss-gap-properties/test/basic.css
+++ b/plugins/postcss-gap-properties/test/basic.css
@@ -22,3 +22,12 @@ manual-fallback {
 	gap: var(--main-value);
 	order: 4;
 }
+
+.nested {
+	display: grid;
+	column-gap:  0.5;
+
+	& .descendant {
+		max-width: 100%;
+	}
+}

--- a/plugins/postcss-gap-properties/test/basic.expect.css
+++ b/plugins/postcss-gap-properties/test/basic.expect.css
@@ -25,3 +25,13 @@ manual-fallback {
 	gap: var(--main-value);
 	order: 4;
 }
+
+.nested {
+	display: grid;
+	grid-column-gap:  0.5;
+	column-gap:  0.5;
+
+	& .descendant {
+		max-width: 100%;
+	}
+}

--- a/plugins/postcss-gap-properties/test/basic.preserve-false.expect.css
+++ b/plugins/postcss-gap-properties/test/basic.preserve-false.expect.css
@@ -22,3 +22,12 @@ manual-fallback {
 	gap: var(--main-value);
 	order: 4;
 }
+
+.nested {
+	display: grid;
+	grid-column-gap:  0.5;
+
+	& .descendant {
+		max-width: 100%;
+	}
+}


### PR DESCRIPTION
fixes: https://github.com/csstools/postcss-plugins/issues/540