### PR TITLE
feat(design-tokens): Add a unit on a token value on demand

### DIFF
--- a/plugins/postcss-design-tokens/src/data-formats/base/token.ts
+++ b/plugins/postcss-design-tokens/src/data-formats/base/token.ts
@@ -3,6 +3,7 @@ export interface TokenTransformOptions {
 		rootFontSize: number;
 	};
 	toUnit?: string;
+	asUnit?: string;
 }
 
 export interface Token {

--- a/plugins/postcss-design-tokens/src/data-formats/style-dictionary/v3/value.ts
+++ b/plugins/postcss-design-tokens/src/data-formats/style-dictionary/v3/value.ts
@@ -83,6 +83,11 @@ export function applyTransformsToValue(value: string|undefined|null, transformOp
 		}
 	}
 
+	// add unit to unit-less value
+	if (transformOptions.asUnit) {
+		return `${value}${transformOptions.asUnit}`;
+	}
+
 	return value;
 }
 

--- a/plugins/postcss-design-tokens/src/values.ts
+++ b/plugins/postcss-design-tokens/src/values.ts
@@ -50,6 +50,16 @@ export function onCSSValue(tokens: Map<string, Token>, result: Result, decl: Dec
 				transformOptions.toUnit = remainingNodes[i + 1].value;
 				i++;
 			}
+
+			if (
+				remainingNodes[i].type === 'word' &&
+				remainingNodes[i].value.toLowerCase() === 'as' &&
+				remainingNodes[i + 1] &&
+				remainingNodes[i + 1].type === 'word'
+			) {
+				transformOptions.asUnit = remainingNodes[i + 1].value;
+				i++;
+			}
 		}
 
 		node.value = replacement.cssValue(transformOptions);


### PR DESCRIPTION
- Add the "as" keyword for adding a unit to unit-less token
 
## Example: 

### JSON
```json
{
    "typography": {
        "size": {
            "small": { "value": 0.8 }
        }
    }
}
```

### CSS
```css
.scope-headings-small {
    font-size: design-token('typography.size.small' as rem);
}
```

### Ouput
```css
.scope-headings-small {
    font-size: 0.8rem;
}
```