### PR TITLE
cascade layers fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5348,9 +5348,9 @@
 			"link": true
 		},
 		"node_modules/postcss-import": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-			"integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.0.0.tgz",
+			"integrity": "sha512-Y20shPQ07RitgBGv2zvkEAu9bqvrD77C9axhj/aA1BQj4czape2MdClCExvB27EwYEJdGgKZBpKanb0t1rK2Kg==",
 			"dev": true,
 			"dependencies": {
 				"postcss-value-parser": "^4.0.0",
@@ -5358,7 +5358,7 @@
 				"resolve": "^1.1.7"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.0"
@@ -6966,7 +6966,7 @@
 				"postcss-selector-parser": "^6.0.10"
 			},
 			"devDependencies": {
-				"postcss-import": "^14.1.0",
+				"postcss-import": "^15.0.0",
 				"puppeteer": "^16.2.0"
 			},
 			"engines": {
@@ -7095,7 +7095,7 @@
 				"postcss-value-parser": "^4.2.0"
 			},
 			"devDependencies": {
-				"postcss-import": "^14.0.2"
+				"postcss-import": "^15.0.0"
 			},
 			"engines": {
 				"node": "^12 || ^14 || >=16"
@@ -7133,7 +7133,7 @@
 				"postcss-value-parser": "^4.2.0"
 			},
 			"devDependencies": {
-				"postcss-import": "^14.1.0",
+				"postcss-import": "^15.0.0",
 				"style-dictionary-design-tokens-example": "^1.1.0"
 			},
 			"engines": {
@@ -8859,7 +8859,7 @@
 			"version": "file:plugins/postcss-cascade-layers",
 			"requires": {
 				"@csstools/selector-specificity": "^2.0.2",
-				"postcss-import": "^14.1.0",
+				"postcss-import": "^15.0.0",
 				"postcss-selector-parser": "^6.0.10",
 				"puppeteer": "^16.2.0"
 			}
@@ -8881,7 +8881,7 @@
 		"@csstools/postcss-design-tokens": {
 			"version": "file:plugins/postcss-design-tokens",
 			"requires": {
-				"postcss-import": "^14.1.0",
+				"postcss-import": "^15.0.0",
 				"postcss-value-parser": "^4.2.0",
 				"style-dictionary-design-tokens-example": "^1.1.0"
 			}
@@ -11449,7 +11449,7 @@
 		"postcss-custom-properties": {
 			"version": "file:plugins/postcss-custom-properties",
 			"requires": {
-				"postcss-import": "^14.0.2",
+				"postcss-import": "^15.0.0",
 				"postcss-value-parser": "^4.2.0"
 			}
 		},
@@ -11507,9 +11507,9 @@
 			}
 		},
 		"postcss-import": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-			"integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.0.0.tgz",
+			"integrity": "sha512-Y20shPQ07RitgBGv2zvkEAu9bqvrD77C9axhj/aA1BQj4czape2MdClCExvB27EwYEJdGgKZBpKanb0t1rK2Kg==",
 			"dev": true,
 			"requires": {
 				"postcss-value-parser": "^4.0.0",

--- a/plugins/postcss-cascade-layers/.tape.mjs
+++ b/plugins/postcss-cascade-layers/.tape.mjs
@@ -24,8 +24,11 @@ postcssTape(plugin)({
 	'anon-layer': {
 		message: "supports anonymous layer usage",
 	},
-	'examples/example': {
-		message: "minimal example",
+	'invalid-nested-css': {
+		message: "ignores nested css",
+	},
+	'extensions': {
+		message: "css custom extensions",
 	},
 	'unlayered-styles': {
 		message: 'supports unlayered styles alongside layers',
@@ -40,7 +43,7 @@ postcssTape(plugin)({
 			onConditionalRulesChangingLayerOrder: 'warn',
 			onImportLayerRule: 'warn'
 		},
-		warnings: 3,
+		warnings: 4,
 	},
 	'warnings:with-postcss-import': {
 		message: 'correctly handles warnings when postcss-import is used',
@@ -51,7 +54,11 @@ postcssTape(plugin)({
 		},
 		warnings: 2,
 		plugins: [
-			postcssImport(), /* postcss-import must run first */
+			postcssImport({
+				nameLayer: (index) => {
+					return `anon-layer-import--${index}`;
+				}
+			}), /* postcss-import must run first */
 			plugin(),
 		]
 	},
@@ -63,5 +70,8 @@ postcssTape(plugin)({
 	},
 	'specificity-buckets-b': {
 		message: "creates non overlapping specificity buckets",
+	},
+	'examples/example': {
+		message: "minimal example",
 	},
 });

--- a/plugins/postcss-cascade-layers/CHANGELOG.md
+++ b/plugins/postcss-cascade-layers/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes to PostCSS Cascade Layers
 
+### Unreleased
+
+- Fix broken `@keyframes` in `@layer`.
+- Add support for `@container` as a conditional rule.
+
 ### 1.0.5 (July 8, 2022)
 
 - Fix case insensitive `@layer` matching (`@LaYeR`).

--- a/plugins/postcss-cascade-layers/package.json
+++ b/plugins/postcss-cascade-layers/package.json
@@ -53,7 +53,7 @@
 		"postcss": "^8.2"
 	},
 	"devDependencies": {
-		"postcss-import": "^14.1.0",
+		"postcss-import": "^15.0.0",
 		"puppeteer": "^16.2.0"
 	},
 	"scripts": {

--- a/plugins/postcss-cascade-layers/src/constants.ts
+++ b/plugins/postcss-cascade-layers/src/constants.ts
@@ -9,6 +9,7 @@ export const IMPLICIT_LAYER_SUFFIX = 'b147acf6-11a6-4338-a4d0-80aef4cd1a2f';
 export const CONDITIONAL_ATRULES = [
 	'media',
 	'supports',
+	'container',
 ];
 
 export const ATRULES_WITH_NON_SELECTOR_BLOCK_LISTS = [

--- a/plugins/postcss-cascade-layers/src/desugar-and-parse-layer-names.ts
+++ b/plugins/postcss-cascade-layers/src/desugar-and-parse-layer-names.ts
@@ -1,17 +1,18 @@
 import type { Container } from 'postcss';
 import type { Model } from './model';
 import selectorParser from 'postcss-selector-parser';
-import { INVALID_LAYER_NAME } from './constants';
+import { CONDITIONAL_ATRULES, INVALID_LAYER_NAME } from './constants';
 import { someAtRuleInTree, someInTree } from './some-in-tree';
 import { getLayerAtRuleAncestor } from './get-layer-atrule-ancestor';
 import { removeEmptyAncestorBlocks, removeEmptyDescendantBlocks } from './clean-blocks';
+import { isProcessableLayerRule } from './is-processable-layer-rule';
 
 export function desugarAndParseLayerNames(root: Container, model: Model) {
 	// - parse layer names
 	// - rename anon layers
 	// - handle empty layers
 	root.walkAtRules((layerRule) => {
-		if (layerRule.name.toLowerCase() !== 'layer') {
+		if (!isProcessableLayerRule(layerRule)) {
 			return;
 		}
 
@@ -90,7 +91,7 @@ export function desugarAndParseLayerNames(root: Container, model: Model) {
 			layerRule.params = model.createAnonymousLayerName();
 		}
 
-		const hasNestedLayers = someAtRuleInTree(layerRule, (node) => node.name.toLowerCase() === 'layer');
+		const hasNestedLayers = someAtRuleInTree(layerRule, (node) => isProcessableLayerRule(node));
 		const hasUnlayeredStyles = someInTree(layerRule, (node) => {
 			if (node.type !== 'rule') {
 				return;
@@ -109,7 +110,7 @@ export function desugarAndParseLayerNames(root: Container, model: Model) {
 
 			// only keep unlayered styles for the implicit layer.
 			implicitLayer.walkAtRules((node) => {
-				if (node.name.toLowerCase() !== 'layer') {
+				if (!isProcessableLayerRule(node)) {
 					return;
 				}
 
@@ -118,7 +119,11 @@ export function desugarAndParseLayerNames(root: Container, model: Model) {
 
 			// go through the unlayered rules and delete these from top level atRule
 			layerRule.walk((node) => {
-				if (node.type !== 'rule') {
+				if (node.type === 'atrule' && isProcessableLayerRule(node)) {
+					return;
+				}
+
+				if (node.type === 'atrule' && CONDITIONAL_ATRULES.includes(node.name.toLowerCase())) {
 					return;
 				}
 

--- a/plugins/postcss-cascade-layers/src/desugar-nested-layers.ts
+++ b/plugins/postcss-cascade-layers/src/desugar-nested-layers.ts
@@ -1,18 +1,19 @@
 import type { Container, AtRule, ChildNode } from 'postcss';
 import { removeEmptyAncestorBlocks, removeEmptyDescendantBlocks } from './clean-blocks';
+import { isProcessableLayerRule } from './is-processable-layer-rule';
 import type { Model } from './model';
 import { someAtRuleInTree } from './some-in-tree';
 
 export function desugarNestedLayers(root: Container<ChildNode>, model: Model) {
 	while (someAtRuleInTree(root, (node) => {
 		return node.nodes && someAtRuleInTree(node, (nested) => {
-			return nested.name.toLowerCase() === 'layer';
+			return isProcessableLayerRule(nested);
 		});
 	})) {
 		let foundUnexpectedLayerNesting = false;
 
 		root.walkAtRules((layerRule) => {
-			if (layerRule.name.toLowerCase() !== 'layer') {
+			if (!isProcessableLayerRule(layerRule)) {
 				return;
 			}
 
@@ -20,7 +21,7 @@ export function desugarNestedLayers(root: Container<ChildNode>, model: Model) {
 				return;
 			}
 
-			if (layerRule.parent.type === 'atrule' && (layerRule.parent as AtRule).name.toLowerCase() === 'layer') {
+			if (layerRule.parent.type === 'atrule' && isProcessableLayerRule(layerRule.parent as AtRule)) {
 				const parent = layerRule.parent as AtRule;
 
 				// Concatenate the current layer params with those of the parent. Store the result in the data model.

--- a/plugins/postcss-cascade-layers/src/get-layer-atrule-ancestor.ts
+++ b/plugins/postcss-cascade-layers/src/get-layer-atrule-ancestor.ts
@@ -1,4 +1,5 @@
 import type { AtRule, Node } from 'postcss';
+import { isProcessableLayerRule } from './is-processable-layer-rule';
 
 // Returns the first ancestor of the current node that is an @layer rule.
 export function getLayerAtRuleAncestor(node: Node): AtRule | null {
@@ -9,7 +10,7 @@ export function getLayerAtRuleAncestor(node: Node): AtRule | null {
 			continue;
 		}
 
-		if ((parent as AtRule).name.toLowerCase() === 'layer') {
+		if (isProcessableLayerRule(parent as AtRule)) {
 			return parent as AtRule;
 		}
 

--- a/plugins/postcss-cascade-layers/src/index.ts
+++ b/plugins/postcss-cascade-layers/src/index.ts
@@ -12,6 +12,7 @@ import { recordLayerOrder } from './record-layer-order';
 import { ATRULES_WITH_NON_SELECTOR_BLOCK_LISTS, INVALID_LAYER_NAME } from './constants';
 import { splitImportantStyles } from './split-important-styles';
 import { pluginOptions } from './options';
+import { isProcessableLayerRule } from './is-processable-layer-rule';
 
 const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 	const options = Object.assign({
@@ -135,9 +136,9 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 
 			// Remove all @layer at-rules
 			// Contained styles are inserted before
-			while (someAtRuleInTree(root, (node) => node.name.toLowerCase() === 'layer')) {
+			while (someAtRuleInTree(root, (node) => isProcessableLayerRule(node))) {
 				root.walkAtRules((atRule) => {
-					if (atRule.name.toLowerCase() !== 'layer') {
+					if (!isProcessableLayerRule(atRule)) {
 						return;
 					}
 

--- a/plugins/postcss-cascade-layers/src/is-processable-layer-rule.ts
+++ b/plugins/postcss-cascade-layers/src/is-processable-layer-rule.ts
@@ -1,0 +1,28 @@
+import type { AtRule, ChildNode, Container, Document } from 'postcss';
+
+const allowedParentAtRules = new Set(['layer', 'supports', 'media']);
+
+export function isProcessableLayerRule(atRule: AtRule): boolean {
+	if (atRule.type !== 'atrule') {
+		return false;
+	}
+
+	if (atRule.name.toLowerCase() !== 'layer') {
+		return false;
+	}
+
+	let parent : Container<ChildNode>|Document = atRule.parent;
+	while (parent) {
+		if (parent.type === 'rule') {
+			return false;
+		}
+
+		if (parent.type === 'atrule' && !allowedParentAtRules.has((parent as AtRule).name.toLowerCase())) {
+			return false;
+		}
+
+		parent = parent.parent;
+	}
+
+	return true;
+}

--- a/plugins/postcss-cascade-layers/src/model.ts
+++ b/plugins/postcss-cascade-layers/src/model.ts
@@ -1,5 +1,6 @@
 import type { AtRule, Node } from 'postcss';
 import { ANONYMOUS_LAYER_SUFFIX, IMPLICIT_LAYER_SUFFIX } from './constants';
+import { isProcessableLayerRule } from './is-processable-layer-rule';
 
 export class Model {
 	anonymousLayerCount = 0;
@@ -79,7 +80,7 @@ export class Model {
 				continue;
 			}
 
-			if ((parent as AtRule).name.toLowerCase() === 'layer') {
+			if (isProcessableLayerRule(parent as AtRule)) {
 				params.push(...this.layerParamsParsed.get((parent as AtRule).params));
 			}
 

--- a/plugins/postcss-cascade-layers/src/record-layer-order.ts
+++ b/plugins/postcss-cascade-layers/src/record-layer-order.ts
@@ -1,13 +1,14 @@
 import type { Container, Result } from 'postcss';
 import { ANONYMOUS_LAYER_SUFFIX, IMPLICIT_LAYER_SUFFIX } from './constants';
 import { getConditionalAtRuleAncestor } from './get-conditional-atrule-ancestor';
+import { isProcessableLayerRule } from './is-processable-layer-rule';
 import type { Model } from './model';
 import { pluginOptions } from './options';
 
 export function recordLayerOrder(root: Container, model: Model, { result, options }: { result: Result, options: pluginOptions }) {
 	// record layer order
 	root.walkAtRules((layerRule) => {
-		if (layerRule.name.toLowerCase() !== 'layer') {
+		if (!isProcessableLayerRule(layerRule)) {
 			return;
 		}
 

--- a/plugins/postcss-cascade-layers/src/sort-root-nodes.ts
+++ b/plugins/postcss-cascade-layers/src/sort-root-nodes.ts
@@ -3,13 +3,14 @@ import type { Model } from './model';
 import { ATRULES_WITH_NON_SELECTOR_BLOCK_LISTS, CONDITIONAL_ATRULES, WITH_SELECTORS_LAYER_NAME } from './constants';
 import { someInTree } from './some-in-tree';
 import { removeEmptyAncestorBlocks, removeEmptyDescendantBlocks } from './clean-blocks';
+import { isProcessableLayerRule } from './is-processable-layer-rule';
 
 // Sort root nodes to apply the preferred order by layer priority for non-selector rules.
 // Selector rules are adjusted by specificity.
 export function sortRootNodes(root: Container, model: Model) {
 	// Separate selector rules from other rules
 	root.walkAtRules((layerRule) => {
-		if (layerRule.name.toLowerCase() !== 'layer') {
+		if (!isProcessableLayerRule(layerRule)) {
 			return;
 		}
 
@@ -70,22 +71,6 @@ export function sortRootNodes(root: Container, model: Model) {
 	});
 
 	root.nodes.sort((a, b) => {
-		const aIsCharset = a.type === 'atrule' && a.name.toLowerCase() === 'charset';
-		const bIsCharset = b.type === 'atrule' && b.name.toLowerCase() === 'charset';
-		if (aIsCharset && bIsCharset) {
-			return 0;
-		} else if (aIsCharset !== bIsCharset) {
-			return aIsCharset ? -1 : 1;
-		}
-
-		const aIsImport = a.type === 'atrule' && a.name.toLowerCase() === 'import';
-		const bIsImport = b.type === 'atrule' && b.name.toLowerCase() === 'import';
-		if (aIsImport && bIsImport) {
-			return 0;
-		} else if (aIsImport !== bIsImport) {
-			return aIsImport ? -1 : 1;
-		}
-
 		const aIsLayer = a.type === 'atrule' && a.name.toLowerCase() === 'layer';
 		const bIsLayer = b.type === 'atrule' && b.name.toLowerCase() === 'layer';
 		if (aIsLayer && bIsLayer) {

--- a/plugins/postcss-cascade-layers/test/extensions.css
+++ b/plugins/postcss-cascade-layers/test/extensions.css
@@ -1,0 +1,23 @@
+/* We expect unlayered extensions to appear later so that they override layered extensions */
+
+@custom-media --custom-media-query: unlayered;
+
+@custom-selector --custom-selector: #unlayered;
+
+@property --property {
+	syntax: '<color>';
+	inherits: false;
+	initial-value: unlayered;
+}
+
+@layer A {
+	@custom-media --custom-media-query: layered;
+
+	@custom-selector --custom-selector: #layered;
+
+	@property --property {
+		syntax: '<color>';
+		inherits: false;
+		initial-value: layered;
+	}
+}

--- a/plugins/postcss-cascade-layers/test/extensions.expect.css
+++ b/plugins/postcss-cascade-layers/test/extensions.expect.css
@@ -1,0 +1,20 @@
+
+	@custom-media --custom-media-query: layered;
+
+	@custom-selector --custom-selector: #layered;
+
+	@property --property {
+		syntax: '<color>';
+		inherits: false;
+		initial-value: layered;
+	}/* We expect unlayered extensions to appear later so that they override layered extensions */
+
+@custom-media --custom-media-query: unlayered;
+
+@custom-selector --custom-selector: #unlayered;
+
+@property --property {
+	syntax: '<color>';
+	inherits: false;
+	initial-value: unlayered;
+}

--- a/plugins/postcss-cascade-layers/test/imports/theme-overrides.css
+++ b/plugins/postcss-cascade-layers/test/imports/theme-overrides.css
@@ -1,9 +1,9 @@
 .theme-styles {
-	color:red;
+	color:blue;
 }
 
 @media screen and (prefers-color-scheme: dark) {
 	.theme-styles {
-			color: pink;
+			color: cyan;
 		}
 }

--- a/plugins/postcss-cascade-layers/test/invalid-nested-css.css
+++ b/plugins/postcss-cascade-layers/test/invalid-nested-css.css
@@ -1,0 +1,14 @@
+.unlayered {
+	contain: layout inline-size;
+}
+
+.partially-layered {
+	background-color: blue;
+	height: 100px;
+	width: 100px;
+
+	@layer A {
+		/* Only conditional rules are allowed to be nested */
+		background-color: red;
+	}
+}

--- a/plugins/postcss-cascade-layers/test/invalid-nested-css.expect.css
+++ b/plugins/postcss-cascade-layers/test/invalid-nested-css.expect.css
@@ -1,0 +1,14 @@
+.unlayered {
+	contain: layout inline-size;
+}
+
+.partially-layered {
+	background-color: blue;
+	height: 100px;
+	width: 100px;
+
+	@layer A {
+		/* Only conditional rules are allowed to be nested */
+		background-color: red;
+	}
+}

--- a/plugins/postcss-cascade-layers/test/nested-case-insensitive.expect.css
+++ b/plugins/postcss-cascade-layers/test/nested-case-insensitive.expect.css
@@ -9,9 +9,6 @@
 		}
 	}
 
-@KEYFRAMES slide-left {
-	}
-
 	target {
 			color: yellow;
 		}

--- a/plugins/postcss-cascade-layers/test/nested-complex.css
+++ b/plugins/postcss-cascade-layers/test/nested-complex.css
@@ -10,12 +10,25 @@
 			order: 2;
 		}
 	}
+
+	@container (min-width: 700px) {
+		target {
+			order: 2.1;
+		}
+	}
 }
 
 @media screen {
 	target {
 		layered: no;
 		order: 3;
+	}
+
+	@container (min-width: 701px) {
+		target {
+			layered: no;
+			order: 3.1;
+		}
 	}
 
 	@layer E {

--- a/plugins/postcss-cascade-layers/test/nested-complex.expect.css
+++ b/plugins/postcss-cascade-layers/test/nested-complex.expect.css
@@ -9,6 +9,12 @@
 		}
 	}
 
+	@container (min-width: 700px) {
+		target {
+			order: 2.1;
+		}
+	}
+
 @media screen {
 		target:not(#\#) {
 			order: 4;
@@ -19,6 +25,13 @@
 	target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 		layered: no;
 		order: 3;
+	}
+
+	@container (min-width: 701px) {
+		target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+			layered: no;
+			order: 3.1;
+		}
 	}
 }
 

--- a/plugins/postcss-cascade-layers/test/nested.css
+++ b/plugins/postcss-cascade-layers/test/nested.css
@@ -1,3 +1,9 @@
+@font-face {
+	font-family: "Open Sans";
+	src: url("/fonts/OpenSans-Regular-webfont.woff2#unlayered") format("woff2"),
+		url("/fonts/OpenSans-Regular-webfont.woff#unlayered") format("woff");
+}
+
 @layer A {
 	target {
 		color: red;
@@ -29,6 +35,12 @@
 		}
 	}
 
+	@font-face {
+		font-family: "Open Sans";
+		src: url("/fonts/OpenSans-Regular-webfont.woff2#layered") format("woff2"),
+			url("/fonts/OpenSans-Regular-webfont.woff#layered") format("woff");
+	}
+
 	@layer Z {
 		target {
 			color: yellow;
@@ -43,8 +55,12 @@
 		}
 	}
 
+	h1 {
+		color: pink;
+	}
+
 	@media (prefers-color-scheme: dark) {
-		h1 {
+		h2 {
 			color: red;
 			background: black;
 		}

--- a/plugins/postcss-cascade-layers/test/nested.expect.css
+++ b/plugins/postcss-cascade-layers/test/nested.expect.css
@@ -9,10 +9,17 @@
 		}
 	}
 
-@keyframes slide-left {
-	}
+	@font-face {
+		font-family: "Open Sans";
+		src: url("/fonts/OpenSans-Regular-webfont.woff2#layered") format("woff2"),
+			url("/fonts/OpenSans-Regular-webfont.woff#layered") format("woff");
+	}@font-face {
+	font-family: "Open Sans";
+	src: url("/fonts/OpenSans-Regular-webfont.woff2#unlayered") format("woff2"),
+		url("/fonts/OpenSans-Regular-webfont.woff#unlayered") format("woff");
+}
 
-	target {
+target {
 			color: yellow;
 		}
 
@@ -36,8 +43,12 @@ target:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 			color: yellow;
 		}
 
+h1:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+		color: pink;
+	}
+
 @media (prefers-color-scheme: dark) {
-		h1:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+		h2:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
 			color: red;
 			background: black;
 		}

--- a/plugins/postcss-cascade-layers/test/warnings.css
+++ b/plugins/postcss-cascade-layers/test/warnings.css
@@ -1,5 +1,6 @@
 /* [postcss-cascade-layers]: To use the @import at-rule with layer, the postcss-import plugin is also required. This plugin alone will not support importing layers. */
-@import 'imports/theme.css' layer(utilities);
+@import 'imports/theme.css' layer(theme);
+@import 'imports/theme-overrides.css' layer;
 
 /* [postcss-cascade-layers]: handling "revert-layer" is unsupported by this plugin and will cause style differences between browser versions. */
 @layer {

--- a/plugins/postcss-cascade-layers/test/warnings.expect.css
+++ b/plugins/postcss-cascade-layers/test/warnings.expect.css
@@ -1,5 +1,6 @@
-
-@import 'imports/theme.css' layer(utilities);/* [postcss-cascade-layers]: To use the @import at-rule with layer, the postcss-import plugin is also required. This plugin alone will not support importing layers. */
+/* [postcss-cascade-layers]: To use the @import at-rule with layer, the postcss-import plugin is also required. This plugin alone will not support importing layers. */
+@import 'imports/theme.css' layer(theme);
+@import 'imports/theme-overrides.css' layer;
 
 /* [postcss-cascade-layers]: handling "revert-layer" is unsupported by this plugin and will cause style differences between browser versions. */
 .foo {

--- a/plugins/postcss-cascade-layers/test/warnings.with-postcss-import.expect.css
+++ b/plugins/postcss-cascade-layers/test/warnings.with-postcss-import.expect.css
@@ -1,18 +1,31 @@
 /* [postcss-cascade-layers]: To use the @import at-rule with layer, the postcss-import plugin is also required. This plugin alone will not support importing layers. */
 .theme-styles {
 	color:red;
+}
+@media screen and (prefers-color-scheme: dark) {
+	.theme-styles {
+			color: pink;
+		}
+}
+.theme-styles:not(#\#) {
+	color:blue;
+}
+@media screen and (prefers-color-scheme: dark) {
+	.theme-styles:not(#\#) {
+			color: cyan;
+		}
 }/* [postcss-cascade-layers]: handling "revert-layer" is unsupported by this plugin and will cause style differences between browser versions. */
-.foo:not(#\#) {
+.foo:not(#\#):not(#\#) {
 		color: revert-layer;
 	}/* [postcss-cascade-layers]: handling different layer orders in conditional rules is unsupported by this plugin and will cause style differences between browser versions. */
 @media (min-width: 10px) {
-		.foo:not(#\#):not(#\#) {
+		.foo:not(#\#):not(#\#):not(#\#) {
 			color: red;
 		}
 }
-.foo:not(#\#):not(#\#):not(#\#) {
+.foo:not(#\#):not(#\#):not(#\#):not(#\#) {
 		color: pink;
 	}
-.foo:not(#\#):not(#\#) {
+.foo:not(#\#):not(#\#):not(#\#) {
 		color: red;
 	}

--- a/plugins/postcss-custom-properties/package.json
+++ b/plugins/postcss-custom-properties/package.json
@@ -38,7 +38,7 @@
 		"postcss": "^8.2"
 	},
 	"devDependencies": {
-		"postcss-import": "^14.0.2"
+		"postcss-import": "^15.0.0"
 	},
 	"scripts": {
 		"build": "rollup -c ../../rollup/default.js",

--- a/plugins/postcss-design-tokens/package.json
+++ b/plugins/postcss-design-tokens/package.json
@@ -44,7 +44,7 @@
 		"postcss": "^8.2"
 	},
 	"devDependencies": {
-		"postcss-import": "^14.1.0",
+		"postcss-import": "^15.0.0",
 		"style-dictionary-design-tokens-example": "^1.1.0"
 	},
 	"scripts": {

--- a/sites/postcss-preset-env/package-lock.json
+++ b/sites/postcss-preset-env/package-lock.json
@@ -26,7 +26,7 @@
 				"npm-run-all": "^4.1.5",
 				"postcss": "^8.4.14",
 				"postcss-cli": "^10.0.0",
-				"postcss-import": "^14.1.0",
+				"postcss-import": "^15.0.0",
 				"postcss-preset-env": "^7.7.2",
 				"rollup": "^2.75.5",
 				"rollup-plugin-filesize": "^9.1.2",
@@ -8350,16 +8350,16 @@
 			}
 		},
 		"node_modules/postcss-import": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-			"integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.0.0.tgz",
+			"integrity": "sha512-Y20shPQ07RitgBGv2zvkEAu9bqvrD77C9axhj/aA1BQj4czape2MdClCExvB27EwYEJdGgKZBpKanb0t1rK2Kg==",
 			"dependencies": {
 				"postcss-value-parser": "^4.0.0",
 				"read-cache": "^1.0.0",
 				"resolve": "^1.1.7"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.0"
@@ -17029,9 +17029,9 @@
 			}
 		},
 		"postcss-import": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-			"integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.0.0.tgz",
+			"integrity": "sha512-Y20shPQ07RitgBGv2zvkEAu9bqvrD77C9axhj/aA1BQj4czape2MdClCExvB27EwYEJdGgKZBpKanb0t1rK2Kg==",
 			"requires": {
 				"postcss-value-parser": "^4.0.0",
 				"read-cache": "^1.0.0",

--- a/sites/postcss-preset-env/package.json
+++ b/sites/postcss-preset-env/package.json
@@ -87,7 +87,7 @@
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.4.14",
 		"postcss-cli": "^10.0.0",
-		"postcss-import": "^14.1.0",
+		"postcss-import": "^15.0.0",
 		"postcss-preset-env": "^7.7.2",
 		"rollup": "^2.75.5",
 		"rollup-plugin-filesize": "^9.1.2",

--- a/sites/postcss-preset-env/postcss.config.cjs
+++ b/sites/postcss-preset-env/postcss.config.cjs
@@ -1,10 +1,15 @@
+const crypto = require('crypto');
+const cwd = process.cwd();
+
 module.exports = ctx => {
 	const isProd = ctx.env === 'production';
 
 	return {
 		map: !isProd,
 		plugins: {
-			'postcss-import': {},
+			'postcss-import': {
+				nameLayer: hashLayerName,
+			},
 			'postcss-preset-env': {
 				stage: 0,
 				preserve: true,
@@ -21,3 +26,18 @@ module.exports = ctx => {
 		},
 	};
 };
+
+function hashLayerName(index, rootFilename) {
+	if (!rootFilename) {
+		return `import-anon-layer-${index}`;
+	}
+
+	// A stable, deterministic and unique layer name:
+	// - layer index
+	// - relative rootFilename to current working directory
+	return `import-anon-layer-${crypto
+		.createHash('sha256')
+		.update(`${index}-${rootFilename.split(cwd)[1]}`)
+		.digest('hex')
+		.slice(0, 12)}`;
+}


### PR DESCRIPTION
- fixes an issue with empty duplicate `at-rules`.
- added support for `@container` queries by adding it the list of known conditional rules.
- update `postcss-import` to `15.0.0` : https://github.com/postcss/postcss-import/blob/master/CHANGELOG.md#1500--2022-08-30