### PR TITLE
cascade-layers : container is an element specific conditional rule

### DIFF
--- a/plugins/postcss-cascade-layers/CHANGELOG.md
+++ b/plugins/postcss-cascade-layers/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Unreleased
 
 - Fix broken `@keyframes` in `@layer`.
-- Add support for `@container` as a conditional rule.
 
 ### 1.0.5 (July 8, 2022)
 

--- a/plugins/postcss-cascade-layers/src/constants.ts
+++ b/plugins/postcss-cascade-layers/src/constants.ts
@@ -6,10 +6,17 @@ export const WITH_SELECTORS_LAYER_NAME = 'csstools-layer-with-selector-rules';
 export const ANONYMOUS_LAYER_SUFFIX = '6efdb677-bb05-44e5-840f-29d2175862fd';
 export const IMPLICIT_LAYER_SUFFIX = 'b147acf6-11a6-4338-a4d0-80aef4cd1a2f';
 
+// https://drafts.csswg.org/css-cascade-5/#layer-ordering
+// Layers that are defined inside of a conditional group rule do not contribute to the layer order
+// unless the condition is true or unless the conditional group rule can evaluate differently for different elements in the document.
+//
+// Since the layer order is global to the document,
+// any layers defined inside an element-sensitive conditional group rule need to be accommodated
+// when establishing the global layer order, regardless of the rule’s condition.
+// Conditions that are global to the document, however (such as @media and @supports) can accommodate such @layer rules conditionally.
 export const CONDITIONAL_ATRULES = [
 	'media',
 	'supports',
-	'container',
 ];
 
 export const ATRULES_WITH_NON_SELECTOR_BLOCK_LISTS = [


### PR DESCRIPTION
This was not allowed, I missed this when adding it.
Luckily we haven't released this yet :)

- https://github.com/w3c/csswg-drafts/issues/6827#issuecomment-1044974179
- https://drafts.csswg.org/css-cascade-5/#layer-ordering

> Layers that are defined inside of a [conditional group rule](https://drafts.csswg.org/css-conditional-3/#conditional-group-rule) do not contribute to the layer order unless the condition is true or unless the conditional group rule can evaluate differently for different elements in the document.

> Note: Since the layer order is global to the document, any layers defined inside an element-sensitive [conditional group rule](https://drafts.csswg.org/css-conditional-3/#conditional-group-rule) need to be accommodated when establishing the global layer order, regardless of the rule’s condition. Conditions that are global to the document, however (such as [`media`](https://drafts.csswg.org/css-conditional-3/#at-ruledef-media) and [`supports`](https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports)) can accommodate such [`layer`](https://drafts.csswg.org/css-cascade-5/#at-ruledef-layer) rules conditionally.