### PR TITLE
correctly clean empty rules

### DIFF
--- a/plugins/postcss-cascade-layers/.tape.mjs
+++ b/plugins/postcss-cascade-layers/.tape.mjs
@@ -36,6 +36,9 @@ postcssTape(plugin)({
 	'extensions': {
 		message: "css custom extensions",
 	},
+	'pre-defined-order-for-nested-layer': {
+		message: 'supports pre-defined orders for nested layers'
+	},
 	'unlayered-styles': {
 		message: 'supports unlayered styles alongside layers',
 	},

--- a/plugins/postcss-cascade-layers/CHANGELOG.md
+++ b/plugins/postcss-cascade-layers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to PostCSS Cascade Layers
 
+### Unreleased
+
+- Fix pre-defined layer order in nested `@layer` rules.
+
 ### 1.1.0 (September 14, 2022)
 
 - Add support for `@scope` and `@container` as parent rules for `@layer`

--- a/plugins/postcss-cascade-layers/src/clean-blocks.ts
+++ b/plugins/postcss-cascade-layers/src/clean-blocks.ts
@@ -4,13 +4,13 @@ import { CONDITIONAL_ATRULES } from './constants';
 export function removeEmptyDescendantBlocks(block: Container) {
 	block.walk((node) => {
 		if (node.type === 'rule' || (node.type === 'atrule' && ['layer', ...CONDITIONAL_ATRULES].includes(node.name.toLowerCase()))) {
-			if (!node.nodes || !node.nodes.length) {
+			if (node.nodes?.length === 0) {
 				node.remove();
 			}
 		}
 	});
 
-	if (!block.nodes || !block.nodes.length) {
+	if (block.nodes?.length === 0) {
 		block.remove();
 	}
 }
@@ -19,7 +19,11 @@ export function removeEmptyAncestorBlocks(block: Container) {
 	let currentNode: Document | Container<ChildNode> = block;
 
 	while (currentNode) {
-		if (currentNode.nodes && currentNode.nodes.length > 0) {
+		if (typeof currentNode.nodes === 'undefined') {
+			return;
+		}
+
+		if (currentNode.nodes.length > 0) {
 			return;
 		}
 

--- a/plugins/postcss-cascade-layers/test/pre-defined-order-for-nested-layer.css
+++ b/plugins/postcss-cascade-layers/test/pre-defined-order-for-nested-layer.css
@@ -1,0 +1,27 @@
+@layer one {
+	@layer two, three;
+
+	@layer three {
+		.test {
+			/* Third most specific */
+			order: 1.3;
+		}
+	}
+
+	@layer two {
+		.test {
+			/* Least specific */
+			order: 1.2;
+		}
+	}
+
+	.test {
+		/* Second most specific */
+		order: 1;
+	}
+}
+
+.test {
+	/* Most specific */
+	order: 0;
+}

--- a/plugins/postcss-cascade-layers/test/pre-defined-order-for-nested-layer.expect.css
+++ b/plugins/postcss-cascade-layers/test/pre-defined-order-for-nested-layer.expect.css
@@ -1,0 +1,20 @@
+
+		.test:not(#\#) {
+			/* Third most specific */
+			order: 1.3;
+		}
+
+.test {
+			/* Least specific */
+			order: 1.2;
+		}
+
+.test:not(#\#):not(#\#) {
+		/* Second most specific */
+		order: 1;
+	}
+
+.test:not(#\#):not(#\#):not(#\#):not(#\#) {
+	/* Most specific */
+	order: 0;
+}


### PR DESCRIPTION
fixes : https://github.com/csstools/postcss-plugins/issues/624

In `postcss-cascade-layers` we have a couple of de-sugaring and normalisation steps.
One of these steps re-structures rules and removes empty left-over rules after the step.

`@layer foo;` is technically an empty rule in the PostCSS AST.
But there is a difference between `typeof rule.nodes === 'undefined'` and `rule.nodes.length  === 0`.

I've updated the code to preserve at-rules when `typeof rule.nodes === 'undefined'`.

```css
@layer one { /* has nodes */
	@layer two, three; /* nodes is undefined */
}

@layer four {} /* has 0 nodes */
```

The final result is that all `@layer` rules still exist when the layer order is recorded.