### PR TITLE
Allow custom media queries to be used in @container rules

### DIFF
--- a/plugins/postcss-custom-media/src/index.js
+++ b/plugins/postcss-custom-media/src/index.js
@@ -32,7 +32,7 @@ const creator = opts => {
 			await writeCustomMediaToExports(helpers[customMediaHelperKey], exportTo);
 		},
 		AtRule: (atrule, helpers) => {
-			if (atrule.name !== 'media') {
+			if (!(atrule.name === 'media' || atrule.name === 'container')) {
 				return;
 			}
 

--- a/plugins/postcss-custom-media/test/basic.css
+++ b/plugins/postcss-custom-media/test/basic.css
@@ -8,6 +8,12 @@
 	}
 }
 
+@container (--mq-a) {
+	body {
+		order: 1;
+	}
+}
+
 @media (--mq-b) {
 	body {
 		order: 1;

--- a/plugins/postcss-custom-media/test/basic.expect.css
+++ b/plugins/postcss-custom-media/test/basic.expect.css
@@ -4,6 +4,12 @@
 	}
 }
 
+@container (max-width: 30em),(max-height: 30em) {
+	body {
+		order: 1;
+	}
+}
+
 @media screen and (max-width: 30em) {
 	body {
 		order: 1;

--- a/plugins/postcss-custom-media/test/basic.preserve.expect.css
+++ b/plugins/postcss-custom-media/test/basic.preserve.expect.css
@@ -14,6 +14,18 @@
 	}
 }
 
+@container (max-width: 30em),(max-height: 30em) {
+	body {
+		order: 1;
+	}
+}
+
+@container (--mq-a) {
+	body {
+		order: 1;
+	}
+}
+
 @media screen and (max-width: 30em) {
 	body {
 		order: 1;


### PR DESCRIPTION
Container queries have a syntax nearly identical to media queries, and can replace them in many cases, while adding extra functionality. But as of right now, the custom-media plugin doesn't allow using the defined media queries in `@container` rules.  

This PR adds causes the plugin to process `@container` at-rules in the same way `@media` at-rules are handled

FWIW, container queries are now [natively supported in Blink and WebKit](https://caniuse.com/css-container-queries), and supported via [polyfill](https://github.com/GoogleChromeLabs/container-query-polyfill) in Gecko/Firefox