### PR TITLE
postcss-nesting: group declarations

### DIFF
--- a/experimental/postcss-nesting/.tape.mjs
+++ b/experimental/postcss-nesting/.tape.mjs
@@ -54,7 +54,7 @@ postcssTape(plugin)({
 	},
 	'invalid-selector': {
 		message: 'warns on invalid selectors',
-		warnings: 3
+		warnings: 2
 	},
 	'media': {
 		message: 'supports nested @media',

--- a/experimental/postcss-nesting/CHANGELOG.md
+++ b/experimental/postcss-nesting/CHANGELOG.md
@@ -3,6 +3,25 @@
 ### Unreleased
 
 - Fix: Do not throw when a selector is invalid, show a warning instead.
+- Fix: Correctly handle declarations after nested rules.
+
+```diff
+/* 
+	Example 7
+	https://drafts.csswg.org/css-nesting/#mixing
+*/
+article {
+	color: green;
+
++ 	color: red;
+}
+:is(article) {
+		color: blue;
+	}
+- article {
+- 	color: red;
+- }
+```
 
 ### 1.1.0 (November 3, 2022)
 

--- a/experimental/postcss-nesting/package.json
+++ b/experimental/postcss-nesting/package.json
@@ -26,7 +26,6 @@
 		"mod.js"
 	],
 	"dependencies": {
-		"@csstools/selector-specificity": "^2.0.0",
 		"postcss-selector-parser": "^6.0.10"
 	},
 	"peerDependencies": {

--- a/experimental/postcss-nesting/src/lib/atrule-within-atrule.ts
+++ b/experimental/postcss-nesting/src/lib/atrule-within-atrule.ts
@@ -1,10 +1,14 @@
 import type { AtRule } from 'postcss';
 import cleanupParent from './cleanup-parent.js';
+import groupDeclarations from './group-declarations.js';
 import mergeParams from './merge-params.js';
 import shiftNodesBeforeParent from './shift-nodes-before-parent.js';
 import validAtrules from './valid-atrules.js';
 
 export default function transformAtruleWithinAtrule(node: AtRule, parent: AtRule) {
+	// Group all declarations after the first one.
+	groupDeclarations(parent);
+
 	// move previous siblings and the node to before the parent
 	shiftNodesBeforeParent(node, parent);
 

--- a/experimental/postcss-nesting/src/lib/atrule-within-rule.ts
+++ b/experimental/postcss-nesting/src/lib/atrule-within-rule.ts
@@ -3,8 +3,12 @@ import shiftNodesBeforeParent from './shift-nodes-before-parent.js';
 import validAtrules from './valid-atrules.js';
 import { walkFunc } from './walk-func.js';
 import type { AtRule, Result, Rule } from 'postcss';
+import groupDeclarations from './group-declarations.js';
 
 export default function atruleWithinRule(node: AtRule, parent: Rule, result: Result, walk: walkFunc) {
+	// Group all declarations after the first one.
+	groupDeclarations(parent);
+
 	// move previous siblings and the node to before the parent
 	shiftNodesBeforeParent(node, parent);
 

--- a/experimental/postcss-nesting/src/lib/group-declarations.ts
+++ b/experimental/postcss-nesting/src/lib/group-declarations.ts
@@ -1,0 +1,31 @@
+import type { ChildNode, Container } from 'postcss';
+
+export default function groupDeclarations(node: Container<ChildNode>) {
+	// https://drafts.csswg.org/css-nesting/#mixing
+	// When a style rule contains both declarations and nested style rules or nested conditional group rules,
+	// all three can be arbitrarily mixed.
+	// However, the relative order of declarations vs other rules is not preserved in any way.
+	//
+	// For the purpose of determining the Order Of Appearance,
+	// nested style rules and nested conditional group rules are considered to come after their parent rule.
+
+	let indexOfLastDeclarationInFirstDeclarationList = -1;
+
+	node.each((child, index) => {
+		if (child.type === 'decl') {
+			if (indexOfLastDeclarationInFirstDeclarationList === -1) {
+				indexOfLastDeclarationInFirstDeclarationList = index;
+				return;
+			}
+
+			if (indexOfLastDeclarationInFirstDeclarationList === index - 1) {
+				indexOfLastDeclarationInFirstDeclarationList = index;
+				return;
+			}
+
+			child.remove();
+			node.insertAfter(indexOfLastDeclarationInFirstDeclarationList, child);
+			indexOfLastDeclarationInFirstDeclarationList = node.index(child);
+		}
+	});
+}

--- a/experimental/postcss-nesting/src/lib/merge-selectors/merge-selectors.ts
+++ b/experimental/postcss-nesting/src/lib/merge-selectors/merge-selectors.ts
@@ -71,4 +71,3 @@ export default function mergeSelectors(node: Node, postcssResult: Result, fromSe
 
 	return result;
 }
-

--- a/experimental/postcss-nesting/src/lib/rule-within-rule.ts
+++ b/experimental/postcss-nesting/src/lib/rule-within-rule.ts
@@ -2,19 +2,26 @@ import shiftNodesBeforeParent from './shift-nodes-before-parent.js';
 import cleanupParent from './cleanup-parent.js';
 import mergeSelectors from './merge-selectors/merge-selectors.js';
 import type { Result, Rule } from 'postcss';
+import groupDeclarations from './group-declarations.js';
 
 export default function transformRuleWithinRule(node: Rule, parent: Rule, result: Result) {
-	// move previous siblings and the node to before the parent
-	shiftNodesBeforeParent(node, parent);
+	let selectors = [];
 
-	// update the selectors of the node to be merged with the parent
 	try {
-		const selectors = mergeSelectors(node, result, parent.selectors, node.selectors);
-		node.selectors = selectors;
+		selectors = mergeSelectors(node, result, parent.selectors, node.selectors);
 	} catch (err) {
 		node.warn(result, `Failed to transform selectors : "${parent.selector}" / "${node.selector}" with message: "${err.message}"`);
 		return;
 	}
+
+	// Group all declarations after the first one.
+	groupDeclarations(parent);
+
+	// move previous siblings and the node to before the parent
+	shiftNodesBeforeParent(node, parent);
+
+	// update the selectors of the node to be merged with the parent
+	node.selectors = selectors;
 
 	// merge similar rules back together
 	const areSameRule = (node.type === 'rule' && parent.type === 'rule' && node.selector === parent.selector);

--- a/experimental/postcss-nesting/test/basic.expect.css
+++ b/experimental/postcss-nesting/test/basic.expect.css
@@ -1,11 +1,20 @@
 a {
 	order: 1;
+
+	order: 5;
+	order: 6;
+
+	order: 10;
+
+	order: 14;
 }
 
 @media screen, print {
 
 a {
 		order: 2;
+
+		order: 4;
 }
 	}
 
@@ -16,55 +25,25 @@ a {
 }
 		}
 
-@media screen, print {
-
-a {
-
-		order: 4;
-}
-	}
-
-a {
-
-	order: 5;
-	order: 6;
-}
-
 :is(a) b {
 		order: 7;
+
+		order: 9;
 	}
 
 :is(:is(a) b) c {
 			order: 8;
 		}
 
-:is(a) b {
-
-		order: 9;
-	}
-
-a {
-
-	order: 10;
-}
-
 :is(body) :is(a) {
 		order: 11;
+
+		order: 13;
 	}
 
 :is(html) :is(:is(body) :is(a)) {
 			order: 12;
 		}
-
-:is(body) :is(a) {
-
-		order: 13;
-	}
-
-a {
-
-	order: 14;
-}
 
 @media screen {
 
@@ -133,6 +112,7 @@ a {
 .comments {
 	/* leading : 1 */
 	order: 61;
+	order: 64;
 	/* trailing: 2 */
 }
 :is(.comments) .comment {
@@ -142,12 +122,8 @@ a {
 :is(.comments) .comment {
 		order: 63;
 	}
-.comments {
-
-	/* leading : 4 */
-	order: 64;
-	/* trailing: 5 */
-}
+/* leading : 4 */
+/* trailing: 5 */
 /* nested deeper */
 :is(:is(.comments) .comment) .comment {
 			order: 65;

--- a/experimental/postcss-nesting/test/direct.expect.css
+++ b/experimental/postcss-nesting/test/direct.expect.css
@@ -1,42 +1,38 @@
 a, b {
 	order: 1;
+	order: 5;
 }
 :is(a,b) c, :is(a,b) d {
 		order: 2;
+		order: 4;
 	}
 :is(:is(a,b) c,:is(a,b) d) e, :is(:is(a,b) c,:is(a,b) d) f {
 			order: 3;
 		}
-:is(a,b) c, :is(a,b) d {
-		order: 4;
-	}
-a, b {
-	order: 5;
-}
 a, b {
 	order: 1;
+	order: 5;
 }
 :is(a,b) c, :is(a,b) d {
 		order: 2;
+		order: 4;
 	}
 :is(:is(a,b) c,:is(a,b) d) e, :is(:is(a,b) c,:is(a,b) d) f {
 			order: 3;
 		}
-:is(a,b) c, :is(a,b) d {
-		order: 4;
-	}
-a, b {
-	order: 5;
-}
 
 a,
 b {
 	order: 1;
+
+	order: 5;
 }
 
 :is(a,b) c,
 	:is(a,b) d {
 		order: 2;
+
+		order: 4;
 	}
 
 :is(:is(a,b) c,:is(a,b) d) e,
@@ -44,41 +40,21 @@ b {
 			order: 3;
 		}
 
-:is(a,b) c,
-	:is(a,b) d {
-
-		order: 4;
-	}
-
-a,
-b {
-
-	order: 5;
-}
-
 .a,
 .b {
 	order: 6;
+
+	order: 10;
 }
 
 :is(.a,.b) .c,
 	:is(.a,.b) .d {
 		order: 7;
+
+		order: 9;
 	}
 
 :is(:is(.a,.b) .c,:is(.a,.b) .d) .e,
 		:is(:is(.a,.b) .c,:is(.a,.b) .d) .f {
 			order: 8;
 		}
-
-:is(.a,.b) .c,
-	:is(.a,.b) .d {
-
-		order: 9;
-	}
-
-.a,
-.b {
-
-	order: 10;
-}

--- a/experimental/postcss-nesting/test/invalid-selector.expect.css
+++ b/experimental/postcss-nesting/test/invalid-selector.expect.css
@@ -1,14 +1,11 @@
-
-	:scope.child {
+.foo : bar {
+	&.child {
 		order: 1;
 	}
-
-.foo : bar {
 }
 
-&.child : bar {
+.foo {
+	&.child : bar {
 		order: 3;
 	}
-
-.foo {
 }

--- a/experimental/postcss-nesting/test/mixin-declaration.expect.css
+++ b/experimental/postcss-nesting/test/mixin-declaration.expect.css
@@ -3,13 +3,11 @@ body {color: blue;
 
 	background: red;
 	font-size: 1rem;
+
+	margin: 0;
 }
 @media (min-width: 64em) {
 body {
 		background: green;
 }
 	}
-body {
-
-	margin: 0;
-}

--- a/experimental/postcss-nesting/test/spec-examples.expect.css
+++ b/experimental/postcss-nesting/test/spec-examples.expect.css
@@ -366,14 +366,12 @@ figure {
 /* Example 7 */
 article {
 	color: green;
+
+	color: red;
 }
 :is(article) {
 		color: blue;
 	}
-article {
-
-	color: red;
-}
 
 /* Example 8 */
 .foo, .foo::before, .foo::after {

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,6 @@
 			"version": "1.1.0",
 			"license": "CC0-1.0",
 			"dependencies": {
-				"@csstools/selector-specificity": "^2.0.0",
 				"postcss-selector-parser": "^6.0.10"
 			},
 			"engines": {
@@ -9064,7 +9063,6 @@
 		"@csstools/postcss-nesting-experimental": {
 			"version": "file:experimental/postcss-nesting",
 			"requires": {
-				"@csstools/selector-specificity": "^2.0.0",
 				"postcss-selector-parser": "^6.0.10"
 			}
 		},


### PR DESCRIPTION
I missed that [section 2.3 was rewritten](https://drafts.csswg.org/css-nesting/#mixing)

This is a really nice change for us because it means that we can closely follow the spec without breaking things like mixins.

```css
article {
  color: green;
  & { color: blue; }
  color: red;
}

/* equivalent to */
article {
  color: green;
  color: red;
  & { color: blue; }
}
```