### PR TITLE
Skip ignore comment checks for files with no ignore comments

### DIFF
--- a/plugins/postcss-custom-properties/src/lib/is-ignored.ts
+++ b/plugins/postcss-custom-properties/src/lib/is-ignored.ts
@@ -1,3 +1,7 @@
+function hasIgnoreComment(input: string) {
+	return /(!\s*)?postcss-custom-properties:\s*(?:off|ignore\s+next)\b/.test(input);
+}
+
 function isBlockIgnored(ruleOrDeclaration) {
 	const rule = ruleOrDeclaration.selector ?
 		ruleOrDeclaration : ruleOrDeclaration.parent;
@@ -15,6 +19,7 @@ function isRuleIgnored(rule) {
 }
 
 export {
+	hasIgnoreComment,
 	isBlockIgnored,
 	isRuleIgnored,
 };


### PR DESCRIPTION
Previously we'd cast every rule to a string and then check if an ignore comment is present. That constant casting and repeatedly calling the regex costs a lot of time. We can avoid that work if we know that the input source doesn't contain any ignore comments at all.

This speeds up postcss compilation time in one of my projects by about 4.6s. In that project there are no css files with postcss comments anywhere.

Before: 

<img width="520" alt="postcss" src="https://user-images.githubusercontent.com/1062408/204104521-221adae0-c941-43d1-970f-996bca855b25.png">



