### PR TITLE
Improve performance of control comments in `postcss-custom-properties`

### DIFF
--- a/plugins/postcss-custom-properties/CHANGELOG.md
+++ b/plugins/postcss-custom-properties/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to PostCSS Custom Properties
 
+### Unreleased
+
+- Improve plugin performance
+
 ### 12.1.10 (October 20, 2022)
 
 - Fix how `preserve: false` interacts with logic around duplicate code (see `12.1.9`).

--- a/plugins/postcss-custom-properties/src/lib/is-ignored.ts
+++ b/plugins/postcss-custom-properties/src/lib/is-ignored.ts
@@ -1,20 +1,35 @@
-function isBlockIgnored(ruleOrDeclaration) {
-	const rule = ruleOrDeclaration.selector ?
-		ruleOrDeclaration : ruleOrDeclaration.parent;
+import type { Comment, Container, Declaration, Node } from 'postcss';
 
-	return /(!\s*)?postcss-custom-properties:\s*off\b/i.test(rule.toString());
+const blockRegExp = /(!\s*)?postcss-custom-properties:\s*off\b/i;
+
+const blockIgnoredCache = new WeakMap();
+
+function isBlockIgnored(container: Container) {
+	if (blockIgnoredCache.has(container)) {
+		return blockIgnoredCache.get(container);
+	}
+
+	const result = container.some((child) => isIgnoreComment(child, blockRegExp));
+	blockIgnoredCache.set(container, result);
+
+	return result;
 }
 
-function isRuleIgnored(rule) {
-	const previous = rule.prev();
+const declarationRegExp = /(!\s*)?postcss-custom-properties:\s*ignore\s+next\b/i;
 
-	return Boolean(isBlockIgnored(rule) ||
-		previous &&
-		previous.type === 'comment' &&
-		/(!\s*)?postcss-custom-properties:\s*ignore\s+next\b/i.test(previous.text));
+function isDeclarationIgnored(decl: Declaration) {
+	if (decl.parent && isBlockIgnored(decl.parent)) {
+		return true;
+	}
+
+	return isIgnoreComment(decl.prev(), declarationRegExp);
+}
+
+function isIgnoreComment(node: Node, regexp: RegExp) {
+	return node && node.type === 'comment' && regexp.test((node as Comment).text);
 }
 
 export {
 	isBlockIgnored,
-	isRuleIgnored,
+	isDeclarationIgnored,
 };

--- a/plugins/postcss-custom-properties/src/lib/is-ignored.ts
+++ b/plugins/postcss-custom-properties/src/lib/is-ignored.ts
@@ -5,6 +5,10 @@ const blockRegExp = /(!\s*)?postcss-custom-properties:\s*off\b/i;
 const blockIgnoredCache = new WeakMap();
 
 function isBlockIgnored(container: Container) {
+	if (!container || !container.nodes) {
+		return false;
+	}
+
 	if (blockIgnoredCache.has(container)) {
 		return blockIgnoredCache.get(container);
 	}
@@ -18,7 +22,11 @@ function isBlockIgnored(container: Container) {
 const declarationRegExp = /(!\s*)?postcss-custom-properties:\s*ignore\s+next\b/i;
 
 function isDeclarationIgnored(decl: Declaration) {
-	if (decl.parent && isBlockIgnored(decl.parent)) {
+	if (!decl) {
+		return false;
+	}
+
+	if (isBlockIgnored(decl.parent)) {
 		return true;
 	}
 

--- a/plugins/postcss-custom-properties/src/lib/transform-properties.ts
+++ b/plugins/postcss-custom-properties/src/lib/transform-properties.ts
@@ -1,11 +1,11 @@
 import valuesParser from 'postcss-value-parser';
 import transformValueAST from './transform-value-ast';
-import { isRuleIgnored } from './is-ignored';
 import { Declaration } from 'postcss';
+import { isDeclarationIgnored } from './is-ignored';
 
 // transform custom pseudo selectors with custom selectors
 export default (decl, customProperties, opts) => {
-	if (isTransformableDecl(decl) && !isRuleIgnored(decl)) {
+	if (isTransformableDecl(decl) && !isDeclarationIgnored(decl)) {
 		const originalValue = decl.value;
 		const valueAST = valuesParser(originalValue);
 		let value = transformValueAST(valueAST, customProperties);


### PR DESCRIPTION
closes : https://github.com/csstools/postcss-plugins/pull/730

@marvinhagemeister After discussing this with @Antonio-Laguna we decided to keep the functionality but to improve performance sufficiently.

We found that the performance issue only happens in fairly large code bases with large numbers of custom properties.

This change has three parts :
- more efficient way to gather and parse custom properties from `html`/`:root` elements
- more efficient way to check if a control comment exists
- caching the existence of control comments in a `WeakMap`.

With these changes the overhead of the feature becomes negligible.
`O(n^2)` -> `O(n)`