### PR TITLE
Compatible with ts NodeNext module resolution

### DIFF
--- a/plugin-packs/postcss-preset-env/package.json
+++ b/plugin-packs/postcss-preset-env/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/css-blank-pseudo/package.json
+++ b/plugins/css-blank-pseudo/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		},
 		"./browser": {

--- a/plugins/css-has-pseudo/package.json
+++ b/plugins/css-has-pseudo/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		},
 		"./browser": {

--- a/plugins/css-prefers-color-scheme/package.json
+++ b/plugins/css-prefers-color-scheme/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		},
 		"./browser": {

--- a/plugins/postcss-attribute-case-insensitive/package.json
+++ b/plugins/postcss-attribute-case-insensitive/package.json
@@ -31,6 +31,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-base-plugin/package.json
+++ b/plugins/postcss-base-plugin/package.json
@@ -29,6 +29,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-cascade-layers/package.json
+++ b/plugins/postcss-cascade-layers/package.json
@@ -36,6 +36,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-color-function/package.json
+++ b/plugins/postcss-color-function/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-color-functional-notation/package.json
+++ b/plugins/postcss-color-functional-notation/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-color-hex-alpha/package.json
+++ b/plugins/postcss-color-hex-alpha/package.json
@@ -35,6 +35,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-color-rebeccapurple/package.json
+++ b/plugins/postcss-color-rebeccapurple/package.json
@@ -35,6 +35,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-conditional-values/package.json
+++ b/plugins/postcss-conditional-values/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-custom-media/package.json
+++ b/plugins/postcss-custom-media/package.json
@@ -35,6 +35,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-custom-properties/package.json
+++ b/plugins/postcss-custom-properties/package.json
@@ -21,6 +21,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-custom-selectors/package.json
+++ b/plugins/postcss-custom-selectors/package.json
@@ -38,6 +38,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-design-tokens/package.json
+++ b/plugins/postcss-design-tokens/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-dir-pseudo-class/package.json
+++ b/plugins/postcss-dir-pseudo-class/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-double-position-gradients/package.json
+++ b/plugins/postcss-double-position-gradients/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-env-function/package.json
+++ b/plugins/postcss-env-function/package.json
@@ -17,6 +17,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-extract/package.json
+++ b/plugins/postcss-extract/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-focus-visible/package.json
+++ b/plugins/postcss-focus-visible/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-focus-within/package.json
+++ b/plugins/postcss-focus-within/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		},
 		"./browser": {

--- a/plugins/postcss-font-format-keywords/package.json
+++ b/plugins/postcss-font-format-keywords/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-gap-properties/package.json
+++ b/plugins/postcss-gap-properties/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-gradients-interpolation-method/package.json
+++ b/plugins/postcss-gradients-interpolation-method/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-hwb-function/package.json
+++ b/plugins/postcss-hwb-function/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-ic-unit/package.json
+++ b/plugins/postcss-ic-unit/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-image-set-function/package.json
+++ b/plugins/postcss-image-set-function/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-is-pseudo-class/package.json
+++ b/plugins/postcss-is-pseudo-class/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-lab-function/package.json
+++ b/plugins/postcss-lab-function/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-logical-float-and-clear/package.json
+++ b/plugins/postcss-logical-float-and-clear/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-logical-resize/package.json
+++ b/plugins/postcss-logical-resize/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-logical-viewport-units/package.json
+++ b/plugins/postcss-logical-viewport-units/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-logical/package.json
+++ b/plugins/postcss-logical/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-media-queries-aspect-ratio-number-values/package.json
+++ b/plugins/postcss-media-queries-aspect-ratio-number-values/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-nested-calc/package.json
+++ b/plugins/postcss-nested-calc/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-nesting/package.json
+++ b/plugins/postcss-nesting/package.json
@@ -20,6 +20,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-normalize-display-values/package.json
+++ b/plugins/postcss-normalize-display-values/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-oklab-function/package.json
+++ b/plugins/postcss-oklab-function/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-overflow-shorthand/package.json
+++ b/plugins/postcss-overflow-shorthand/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-place/package.json
+++ b/plugins/postcss-place/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-progressive-custom-properties/package.json
+++ b/plugins/postcss-progressive-custom-properties/package.json
@@ -18,6 +18,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-pseudo-class-any-link/package.json
+++ b/plugins/postcss-pseudo-class-any-link/package.json
@@ -32,6 +32,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-scope-pseudo-class/package.json
+++ b/plugins/postcss-scope-pseudo-class/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-selector-not/package.json
+++ b/plugins/postcss-selector-not/package.json
@@ -31,6 +31,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-stepped-value-functions/package.json
+++ b/plugins/postcss-stepped-value-functions/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-text-decoration-shorthand/package.json
+++ b/plugins/postcss-text-decoration-shorthand/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-trigonometric-functions/package.json
+++ b/plugins/postcss-trigonometric-functions/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/plugins/postcss-unset-value/package.json
+++ b/plugins/postcss-unset-value/package.json
@@ -28,6 +28,7 @@
 		".": {
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts",
 			"default": "./dist/index.mjs"
 		}
 	},


### PR DESCRIPTION
In `"moduleResolution": "NodeNext"` it requires a `types` property in `exports` field, otherwise we need `./dist/index.d.mts` instead of `.d.ts`