### PR TITLE
Adding Logical Options to the Playground

### DIFF
--- a/sites/postcss-preset-env/playground.njk
+++ b/sites/postcss-preset-env/playground.njk
@@ -38,8 +38,7 @@ description: Play with PostCSS Preset Env in your browser
 			<fieldset>
 				<label for="inlineDirection">inline direction</label>
 				<select id="inlineDirection">
-					<option value="">not set</option>
-					<option value="left-to-right">left to right</option>
+					<option selected value="left-to-right">left to right</option>
 					<option value="right-to-left">right to left</option>
 					<option value="top-to-bottom">top to bottom</option>
 					<option value="bottom-to-top">bottom to top</option>
@@ -48,10 +47,9 @@ description: Play with PostCSS Preset Env in your browser
 			<fieldset>
 				<label for="blockDirection">block direction</label>
 				<select id="blockDirection">
-					<option value="">not set</option>
 					<option value="left-to-right">left to right</option>
 					<option value="right-to-left">right to left</option>
-					<option value="top-to-bottom">top to bottom</option>
+					<option selected value="top-to-bottom">top to bottom</option>
 					<option value="bottom-to-top">bottom to top</option>
 				</select>
 			</fieldset>

--- a/sites/postcss-preset-env/playground.njk
+++ b/sites/postcss-preset-env/playground.njk
@@ -34,6 +34,27 @@ description: Play with PostCSS Preset Env in your browser
 					<option value="false">false</option>
 				</select>
 			</fieldset>
+
+			<fieldset>
+				<label for="inlineDirection">inline direction</label>
+				<select id="inlineDirection">
+					<option value="">not set</option>
+					<option value="left-to-right">left to right</option>
+					<option value="right-to-left">right to left</option>
+					<option value="top-to-bottom">top to bottom</option>
+					<option value="bottom-to-top">bottom to top</option>
+				</select>
+			</fieldset>
+			<fieldset>
+				<label for="blockDirection">block direction</label>
+				<select id="blockDirection">
+					<option value="">not set</option>
+					<option value="left-to-right">left to right</option>
+					<option value="right-to-left">right to left</option>
+					<option value="top-to-bottom">top to bottom</option>
+					<option value="bottom-to-top">bottom to top</option>
+				</select>
+			</fieldset>
 		</div>
 
 		<div id="input-editor" class="editor"></div>

--- a/sites/postcss-preset-env/src/static/css/pages/_playground.css
+++ b/sites/postcss-preset-env/src/static/css/pages/_playground.css
@@ -36,8 +36,8 @@
 		padding-inline: var(--space-10);
 
 		@media (--from-medium) {
-				padding-inline: var(--space-20);
-			}
+			padding-inline: var(--space-20);
+		}
 
 		@media (--from-wide) {
 			padding-inline: var(--space-25);

--- a/sites/postcss-preset-env/src/static/css/pages/_playground.css
+++ b/sites/postcss-preset-env/src/static/css/pages/_playground.css
@@ -23,7 +23,7 @@
 				"controls controls"
 				"input output"
 				"config output";
-			grid-template-rows: 40px calc(65% - 40px) calc(35% - 40px);
+			grid-template-rows: auto calc(65% - 40px) calc(35% - 40px);
 			grid-template-columns: calc(50% - var(--space-10)) calc(50% - var(--space-10));
 			height: calc(100vh - var(--heading-size-from-medium));
 		}

--- a/sites/postcss-preset-env/src/static/js/playground.js
+++ b/sites/postcss-preset-env/src/static/js/playground.js
@@ -15,6 +15,10 @@ const currentConfig = {
 	minimumVendorImplementations: 0,
 	stage: 2,
 	preserve: null,
+	logical: {
+		inlineDirection: 'left-to-right',
+		blockDirection: 'top-to-bottom',
+	},
 };
 
 function processCss(source, config) {
@@ -49,6 +53,18 @@ function renderConfig(config) {
 		delete copy.browsers;
 	}
 
+	if (copy.logical.inlineDirection === 'left-to-right') {
+		delete copy.logical.inlineDirection;
+	}
+
+	if (copy.logical.blockDirection === 'top-to-bottom') {
+		delete copy.logical.blockDirection;
+	}
+
+	if (Object.keys(copy.logical).length === 0) {
+		delete copy.logical;
+	}
+
 	return `const postcssPresetEnv = require('postcss-preset-env');
 
 module.exports = {
@@ -78,6 +94,15 @@ a {
 	& span {
 		font-weight: bold;
 	}
+}
+
+aside {
+	margin-block-start: 1rem;
+	margin-block-end: 2rem;
+	margin-inline-start: 3rem;
+	margin-inline-end: 4rem;
+	width: 10vi;
+	height: 20vb;
 }
 
 @custom-media --tablet (min-width: 48rem);
@@ -159,6 +184,8 @@ let controls = {
 	minimumVendorImplementations: document.getElementById('minimumVendorImplementations'),
 	stage: document.getElementById('stage'),
 	preserve: document.getElementById('preserve'),
+	inlineDirection: document.getElementById('inlineDirection'),
+	blockDirection: document.getElementById('blockDirection'),
 };
 
 controls.browsers.value = currentConfig.browsers.join(', ');
@@ -169,6 +196,8 @@ if (currentConfig.preserve === true) {
 } else if (currentConfig.preserve === false) {
 	controls.preserve.value = 'false';
 }
+controls.inlineDirection.value = currentConfig.logical.inlineDirection;
+controls.blockDirection.value = currentConfig.logical.blockDirection;
 
 for (const control of Object.values(controls)) {
 	control.addEventListener('change', () => {
@@ -183,6 +212,10 @@ for (const control of Object.values(controls)) {
 		currentConfig.minimumVendorImplementations = parseInt(controls.minimumVendorImplementations.value || '0', 10);
 		currentConfig.stage = parseInt(controls.stage.value || '0', 10);
 		currentConfig.preserve = preserve;
+		currentConfig.logical = {
+			inlineDirection: controls.inlineDirection.value || 'left-to-right',
+			blockDirection: controls.blockDirection.value || 'top-to-bottom',
+		};
 
 		processCss(inputState.doc, currentConfig).then((output) => {
 			configView.update([


### PR DESCRIPTION
This adds the inlineDirection and blockDirection options to the controls. 

Note that when changing block to right-to-left for example nothing seems to happen. The error, despite the `.catch` goes uncaught. I think this is mostly OK but wanted to point it out.