### PR TITLE
[postcss-global-data] Fix type for files option

### DIFF
--- a/plugins/postcss-global-data/CHANGELOG.md
+++ b/plugins/postcss-global-data/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to PostCSS global-data
 
+### Unreleased (patch)
+
+- Fixed: TypeScript definition of the plugin options.
+
 ### 1.0.2 (February 15, 2023)
 
 - Fixed: file watching with PostCSS CLI

--- a/plugins/postcss-global-data/dist/index.d.ts
+++ b/plugins/postcss-global-data/dist/index.d.ts
@@ -2,7 +2,7 @@ import type { PluginCreator } from 'postcss';
 /** postcss-global-data plugin options */
 export type pluginOptions = {
     /** List of files to be used as context */
-    files?: [];
+    files?: Array<string>;
 };
 declare const creator: PluginCreator<pluginOptions>;
 export default creator;

--- a/plugins/postcss-global-data/src/index.ts
+++ b/plugins/postcss-global-data/src/index.ts
@@ -4,7 +4,7 @@ import { parseImport } from './parse-import';
 /** postcss-global-data plugin options */
 export type pluginOptions = {
 	/** List of files to be used as context */
-	files?: string[],
+	files?: Array<string>,
 };
 
 const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {

--- a/plugins/postcss-global-data/src/index.ts
+++ b/plugins/postcss-global-data/src/index.ts
@@ -4,7 +4,7 @@ import { parseImport } from './parse-import';
 /** postcss-global-data plugin options */
 export type pluginOptions = {
 	/** List of files to be used as context */
-	files?: [],
+	files?: string[],
 };
 
 const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {


### PR DESCRIPTION
The type for the `files` option current only accepts an empty array or undefined. It should be an array of strings or undefined.

<img width="728" alt="Screenshot 2023-02-17 at 2 32 13 PM" src="https://user-images.githubusercontent.com/411908/219770184-2a124163-5def-433e-be0c-64cf556a20f3.png">
