### PR TITLE
mention restriction about nested rules starting with an identifier

### DIFF
--- a/plugins/postcss-nesting/README.md
+++ b/plugins/postcss-nesting/README.md
@@ -81,7 +81,7 @@ Future versions of this plugin will first warn and then error if you use `@nest`
 
 We advice everyone to migrate their codebase **now** to nested CSS without `@nest`.
 
-## ⚠️ Nested selectors cannot start with a identifier (tag name)
+## ⚠️ Nested selectors cannot start with a letter
 
 The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with an identifier (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
 

--- a/plugins/postcss-nesting/README.md
+++ b/plugins/postcss-nesting/README.md
@@ -83,26 +83,7 @@ We advice everyone to migrate their codebase **now** to nested CSS without `@nes
 
 ## ⚠️ Nested selectors cannot start with a letter
 
-The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with an identifier (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
-
-```pcss
-.foo {
-	/* ❌ invalid */
-	span {
-		color: hotpink;
-	}
-
-	/* ✅ valid */
-	& span {
-		color: hotpink;
-	}
-
-	/* ✅ valid */
-	:is(span) {
-		color: hotpink;
-	}
-}	
-```
+The current version of the [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with an identifier (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
 
 ## Options
 

--- a/plugins/postcss-nesting/README.md
+++ b/plugins/postcss-nesting/README.md
@@ -83,7 +83,26 @@ We advice everyone to migrate their codebase **now** to nested CSS without `@nes
 
 ## ⚠️ Nested selectors cannot start with a letter
 
-The current version of the [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with an identifier (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
+The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with an identifier (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
+
+```pcss
+.foo {
+	/* ❌ invalid */
+	span {
+		color: hotpink;
+	}
+
+	/* ✅ valid */
+	& span {
+		color: hotpink;
+	}
+
+	/* ✅ valid */
+	:is(span) {
+		color: hotpink;
+	}
+}	
+```
 
 ## Options
 

--- a/plugins/postcss-nesting/README.md
+++ b/plugins/postcss-nesting/README.md
@@ -81,6 +81,28 @@ Future versions of this plugin will first warn and then error if you use `@nest`
 
 We advice everyone to migrate their codebase **now** to nested CSS without `@nest`.
 
+## ⚠️ Nested selectors cannot start with a identifier (tag name)
+
+The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with an identifier (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
+
+```pcss
+.foo {
+	/* ❌ invalid */
+	span {
+		color: hotpink;
+	}
+
+	/* ✅ valid */
+	& span {
+		color: hotpink;
+	}
+
+	/* ✅ valid */
+	:is(span) {
+		color: hotpink;
+	}
+}	
+```
 
 ## Options
 

--- a/plugins/postcss-nesting/README.md
+++ b/plugins/postcss-nesting/README.md
@@ -83,7 +83,7 @@ We advice everyone to migrate their codebase **now** to nested CSS without `@nes
 
 ## ⚠️ Nested selectors must start with a symbol
 
-The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with a letter (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
+The current version of the [CSS Nesting specification](https://www.w3.org/TR/2023/WD-css-nesting-1-20230214/#example-34e8e94f) disallows nested selectors to start with a letter (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
 
 You will get a warning when selectors start with a letter:
 > Nested selectors must start with a symbol and "span" begins with a letter.

--- a/plugins/postcss-nesting/README.md
+++ b/plugins/postcss-nesting/README.md
@@ -81,7 +81,7 @@ Future versions of this plugin will first warn and then error if you use `@nest`
 
 We advice everyone to migrate their codebase **now** to nested CSS without `@nest`.
 
-## ⚠️ Nested selectors cannot start with a letter
+## ⚠️ Nested selectors must start with a symbol
 
 The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with a letter (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
 

--- a/plugins/postcss-nesting/README.md
+++ b/plugins/postcss-nesting/README.md
@@ -83,7 +83,10 @@ We advice everyone to migrate their codebase **now** to nested CSS without `@nes
 
 ## ⚠️ Nested selectors cannot start with a letter
 
-The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with an identifier (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
+The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with a letter (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
+
+You will get a warning when selectors start with a letter:
+> Nested selectors must start with a symbol and "span" begins with a letter.
 
 ```pcss
 .foo {
@@ -97,8 +100,13 @@ The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e
 		color: hotpink;
 	}
 
+	/* ❌ invalid */
+	span & {
+		color: hotpink;
+	}
+
 	/* ✅ valid */
-	:is(span) {
+	:is(span) & {
 		color: hotpink;
 	}
 }	

--- a/plugins/postcss-nesting/docs/README.md
+++ b/plugins/postcss-nesting/docs/README.md
@@ -42,6 +42,36 @@ Future versions of this plugin will first warn and then error if you use `@nest`
 
 We advice everyone to migrate their codebase **now** to nested CSS without `@nest`.
 
+## ⚠️ Nested selectors cannot start with a letter
+
+The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with a letter (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
+
+You will get a warning when selectors start with a letter:
+> Nested selectors must start with a symbol and "span" begins with a letter.
+
+```pcss
+.foo {
+	/* ❌ invalid */
+	span {
+		color: hotpink;
+	}
+
+	/* ✅ valid */
+	& span {
+		color: hotpink;
+	}
+
+	/* ❌ invalid */
+	span & {
+		color: hotpink;
+	}
+
+	/* ✅ valid */
+	:is(span) & {
+		color: hotpink;
+	}
+}	
+```
 
 ## Options
 

--- a/plugins/postcss-nesting/docs/README.md
+++ b/plugins/postcss-nesting/docs/README.md
@@ -42,7 +42,7 @@ Future versions of this plugin will first warn and then error if you use `@nest`
 
 We advice everyone to migrate their codebase **now** to nested CSS without `@nest`.
 
-## ⚠️ Nested selectors cannot start with a letter
+## ⚠️ Nested selectors must start with a symbol
 
 The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with a letter (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
 

--- a/plugins/postcss-nesting/docs/README.md
+++ b/plugins/postcss-nesting/docs/README.md
@@ -44,7 +44,7 @@ We advice everyone to migrate their codebase **now** to nested CSS without `@nes
 
 ## ⚠️ Nested selectors must start with a symbol
 
-The [CSS Nesting specification](https://www.w3.org/TR/css-nesting-1/#example-34e8e94f) disallows nested selectors to start with a letter (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
+The current version of the [CSS Nesting specification](https://www.w3.org/TR/2023/WD-css-nesting-1-20230214/#example-34e8e94f) disallows nested selectors to start with a letter (i.e. a tag name or element selector). To write such selectors, they need to be prefixed with `& ` or wrapped with `:is()`.
 
 You will get a warning when selectors start with a letter:
 > Nested selectors must start with a symbol and "span" begins with a letter.


### PR DESCRIPTION
the latest css nesting spec disallows this for technical reasons:
```pcss
.foo {
  span {
    color: hotpink;
  }
}
```

when i first upgraded to postcss-nesting 11.0, i was under the impression that such syntax would be supported, because those technical limitations do not exist outside browsers. so i was very surprised when https://github.com/csstools/postcss-plugins/pull/861 was released in 11.2.1 and my styles broke.

this note will help avoid such unexpected surprises for users of `postcss-nesting`.