### PR TITLE
css-tokenizer : documentation

### DIFF
--- a/packages/css-tokenizer/CHANGELOG.md
+++ b/packages/css-tokenizer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to CSS Tokenizer
 
+### Unreleased (patch)
+
+- Document `tokenize` helper function
+
 ### 2.1.0 (February 21, 2023)
 
 - Add `tokenize` helper function

--- a/packages/css-tokenizer/README.md
+++ b/packages/css-tokenizer/README.md
@@ -38,6 +38,25 @@ while (true) {
 }
 ```
 
+Or use the `tokenize` helper function:
+
+```js
+import { tokenize } from '@csstools/css-tokenizer';
+
+const myCSS =  `@media only screen and (min-width: 768rem) {
+	.foo {
+		content: 'Some content!' !important;
+	}
+}
+`;
+
+const tokens = tokenize({
+	css: myCSS,
+});
+
+console.log(tokens);
+```
+
 ### Options
 
 ```ts


### PR DESCRIPTION
fixes : https://github.com/csstools/postcss-plugins/issues/930

------

_This is a bit of a dummy change after https://github.com/csstools/postcss-plugins/pull/938_

_My expectation is that this one change will cascade to all other packages that use the tokenizer and from there to all postcss plugins that use those packages._