### PR TITLE
logical properties : automatic test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,16 @@
 		"cli/csstools-cli": {
 			"name": "@csstools/csstools-cli",
 			"version": "2.1.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/postcss-cascade-layers": "^3.0.1",
@@ -102,25 +112,27 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			}
 		},
 		"experimental/css-has-pseudo": {
 			"name": "@csstools/css-has-pseudo-experimental",
 			"version": "0.6.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"devDependencies": {
 				"@csstools/postcss-tape": "*"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -129,6 +141,16 @@
 		"experimental/postcss-gradient-stop-increments": {
 			"name": "@csstools/postcss-gradient-stop-increments-experimental",
 			"version": "1.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-calc": "^1.1.1",
@@ -141,10 +163,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -152,6 +170,16 @@
 		"experimental/postcss-nesting": {
 			"name": "@csstools/postcss-nesting-experimental",
 			"version": "2.0.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -161,10 +189,6 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -3038,6 +3062,15 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@webref/css": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/@webref/css/-/css-6.5.1.tgz",
+			"integrity": "sha512-PttNJ+5pGbyDZRrqQ6uvwuYQZPqjYPTCf9nmX3I5ItkuDfVvyAaaPC4HKMTGrkqFcqI31VcNWUrevNKYVXJMyA==",
+			"dev": true,
+			"peerDependencies": {
+				"css-tree": "^2.3.1"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.8.2",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -3672,6 +3705,27 @@
 		"node_modules/css-prefers-color-scheme": {
 			"resolved": "plugins/css-prefers-color-scheme",
 			"link": true
+		},
+		"node_modules/css-tree": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"mdn-data": "2.0.30",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/css-tree/node_modules/mdn-data": {
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/cssdb": {
 			"version": "7.5.4",
@@ -7404,13 +7458,19 @@
 		"packages/base-cli": {
 			"name": "@csstools/base-cli",
 			"version": "0.1.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -7419,13 +7479,19 @@
 		"packages/cascade-layer-name-parser": {
 			"name": "@csstools/cascade-layer-name-parser",
 			"version": "1.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"@csstools/css-parser-algorithms": "^2.1.1",
@@ -7435,25 +7501,37 @@
 		"packages/color-helpers": {
 			"name": "@csstools/color-helpers",
 			"version": "2.0.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			}
 		},
 		"packages/css-calc": {
 			"name": "@csstools/css-calc",
 			"version": "1.1.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"@csstools/css-parser-algorithms": "^2.1.1",
@@ -7463,6 +7541,16 @@
 		"packages/css-color-parser": {
 			"name": "@csstools/css-color-parser",
 			"version": "1.1.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/color-helpers": "^2.0.0",
@@ -7470,10 +7558,6 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"@csstools/css-parser-algorithms": "^2.1.1",
@@ -7483,13 +7567,19 @@
 		"packages/css-parser-algorithms": {
 			"name": "@csstools/css-parser-algorithms",
 			"version": "2.1.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"@csstools/css-tokenizer": "^2.1.1"
@@ -7498,6 +7588,16 @@
 		"packages/css-tokenizer": {
 			"name": "@csstools/css-tokenizer",
 			"version": "2.1.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"devDependencies": {
 				"@rmenke/css-tokenizer-tests": "^1.0.9",
@@ -7505,37 +7605,45 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			}
 		},
 		"packages/generate-test-cases": {
 			"name": "@csstools/generate-test-cases",
 			"version": "1.0.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"devDependencies": {
 				"mdn-data": "^2.0.28"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			}
 		},
 		"packages/media-query-list-parser": {
 			"name": "@csstools/media-query-list-parser",
 			"version": "2.0.4",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"@csstools/css-parser-algorithms": "^2.1.1",
@@ -7545,6 +7653,16 @@
 		"packages/postcss-tape": {
 			"name": "@csstools/postcss-tape",
 			"version": "2.0.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss": "~8.4",
@@ -7553,15 +7671,21 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			}
 		},
 		"packages/selector-specificity": {
 			"name": "@csstools/selector-specificity",
 			"version": "2.2.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"devDependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -7569,16 +7693,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss-selector-parser": "^6.0.10"
 			}
 		},
 		"plugin-packs/postcss-preset-env": {
 			"version": "8.3.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/postcss-cascade-layers": "^3.0.1",
@@ -7639,14 +7769,11 @@
 			},
 			"devDependencies": {
 				"@csstools/postcss-tape": "*",
+				"@webref/css": "^6.5.1",
 				"postcss-simple-vars": "^7.0.1"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -7654,6 +7781,16 @@
 		},
 		"plugins/css-blank-pseudo": {
 			"version": "5.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -7665,16 +7802,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/css-has-pseudo": {
 			"version": "5.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/selector-specificity": "^2.0.1",
@@ -7689,16 +7832,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/css-prefers-color-scheme": {
 			"version": "8.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"devDependencies": {
 				"@csstools/postcss-tape": "*",
@@ -7707,16 +7856,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-attribute-case-insensitive": {
 			"version": "6.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -7727,10 +7882,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -7738,16 +7889,22 @@
 		"plugins/postcss-base-plugin": {
 			"name": "@csstools/postcss-base-plugin",
 			"version": "0.0.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"devDependencies": {
 				"@csstools/postcss-tape": "*"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -7756,6 +7913,16 @@
 		"plugins/postcss-cascade-layers": {
 			"name": "@csstools/postcss-cascade-layers",
 			"version": "3.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/selector-specificity": "^2.0.2",
@@ -7769,10 +7936,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -7780,6 +7943,16 @@
 		"plugins/postcss-color-function": {
 			"name": "@csstools/postcss-color-function",
 			"version": "2.2.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-color-parser": "^1.1.2",
@@ -7794,16 +7967,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-color-functional-notation": {
 			"version": "5.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -7814,16 +7993,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-color-hex-alpha": {
 			"version": "9.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -7834,10 +8019,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -7845,6 +8026,16 @@
 		"plugins/postcss-color-mix-function": {
 			"name": "@csstools/postcss-color-mix-function",
 			"version": "1.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-color-parser": "^1.1.2",
@@ -7858,16 +8049,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-color-rebeccapurple": {
 			"version": "8.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -7878,10 +8075,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -7889,6 +8082,16 @@
 		"plugins/postcss-conditional-values": {
 			"name": "@csstools/postcss-conditional-values",
 			"version": "2.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"devDependencies": {
 				"@csstools/postcss-tape": "*",
@@ -7897,16 +8100,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-custom-media": {
 			"version": "9.1.3",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/cascade-layer-name-parser": "^1.0.2",
@@ -7920,16 +8129,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-custom-properties": {
 			"version": "13.1.5",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/cascade-layer-name-parser": "^1.0.2",
@@ -7944,16 +8159,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-custom-selectors": {
 			"version": "7.1.3",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/cascade-layer-name-parser": "^1.0.2",
@@ -7967,10 +8188,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -7978,6 +8195,16 @@
 		"plugins/postcss-design-tokens": {
 			"name": "@csstools/postcss-design-tokens",
 			"version": "2.0.4",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-parser-algorithms": "^2.1.1",
@@ -7992,16 +8219,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-dir-pseudo-class": {
 			"version": "7.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -8012,16 +8245,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-double-position-gradients": {
 			"version": "4.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/postcss-progressive-custom-properties": "^2.0.0",
@@ -8033,16 +8272,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-env-function": {
 			"version": "5.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -8052,10 +8297,6 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -8064,6 +8305,16 @@
 		"plugins/postcss-extract": {
 			"name": "@csstools/postcss-extract",
 			"version": "2.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -8074,16 +8325,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-focus-visible": {
 			"version": "8.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -8095,16 +8352,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-focus-within": {
 			"version": "7.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -8115,10 +8378,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8126,6 +8385,16 @@
 		"plugins/postcss-font-format-keywords": {
 			"name": "@csstools/postcss-font-format-keywords",
 			"version": "2.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -8136,26 +8405,28 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-gap-properties": {
 			"version": "4.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"devDependencies": {
 				"@csstools/postcss-tape": "*"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -8164,6 +8435,16 @@
 		"plugins/postcss-global-data": {
 			"name": "@csstools/postcss-global-data",
 			"version": "1.0.3",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"devDependencies": {
 				"@csstools/postcss-tape": "*",
@@ -8172,10 +8453,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8183,6 +8460,16 @@
 		"plugins/postcss-gradients-interpolation-method": {
 			"name": "@csstools/postcss-gradients-interpolation-method",
 			"version": "3.0.3",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-color-parser": "^1.1.2",
@@ -8196,10 +8483,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8207,6 +8490,16 @@
 		"plugins/postcss-hwb-function": {
 			"name": "@csstools/postcss-hwb-function",
 			"version": "2.2.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-color-parser": "^1.1.2",
@@ -8219,10 +8512,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8230,6 +8519,16 @@
 		"plugins/postcss-ic-unit": {
 			"name": "@csstools/postcss-ic-unit",
 			"version": "2.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/postcss-progressive-custom-properties": "^2.0.0",
@@ -8241,16 +8540,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-image-set-function": {
 			"version": "5.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -8260,10 +8565,6 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -8272,6 +8573,16 @@
 		"plugins/postcss-is-pseudo-class": {
 			"name": "@csstools/postcss-is-pseudo-class",
 			"version": "3.2.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/selector-specificity": "^2.0.0",
@@ -8284,16 +8595,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-lab-function": {
 			"version": "5.2.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-color-parser": "^1.1.2",
@@ -8307,16 +8624,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-logical": {
 			"version": "6.1.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -8326,10 +8649,6 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -8338,16 +8657,22 @@
 		"plugins/postcss-logical-float-and-clear": {
 			"name": "@csstools/postcss-logical-float-and-clear",
 			"version": "1.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"devDependencies": {
 				"@csstools/postcss-tape": "*"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -8356,6 +8681,16 @@
 		"plugins/postcss-logical-resize": {
 			"name": "@csstools/postcss-logical-resize",
 			"version": "1.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -8366,10 +8701,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8377,6 +8708,16 @@
 		"plugins/postcss-logical-viewport-units": {
 			"name": "@csstools/postcss-logical-viewport-units",
 			"version": "1.0.3",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-tokenizer": "^2.1.1"
@@ -8387,10 +8728,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8398,6 +8735,16 @@
 		"plugins/postcss-media-minmax": {
 			"name": "@csstools/postcss-media-minmax",
 			"version": "1.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/css-calc": "^1.1.1",
@@ -8411,10 +8758,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8422,6 +8765,16 @@
 		"plugins/postcss-media-queries-aspect-ratio-number-values": {
 			"name": "@csstools/postcss-media-queries-aspect-ratio-number-values",
 			"version": "1.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-parser-algorithms": "^2.1.1",
@@ -8434,10 +8787,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8445,6 +8794,16 @@
 		"plugins/postcss-nested-calc": {
 			"name": "@csstools/postcss-nested-calc",
 			"version": "2.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -8455,16 +8814,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-nesting": {
 			"version": "11.2.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/selector-specificity": "^2.0.0",
@@ -8477,10 +8842,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8488,6 +8849,16 @@
 		"plugins/postcss-normalize-display-values": {
 			"name": "@csstools/postcss-normalize-display-values",
 			"version": "2.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -8498,10 +8869,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8509,6 +8876,16 @@
 		"plugins/postcss-oklab-function": {
 			"name": "@csstools/postcss-oklab-function",
 			"version": "2.2.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-color-parser": "^1.1.2",
@@ -8522,16 +8899,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-overflow-shorthand": {
 			"version": "4.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -8541,10 +8924,6 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -8552,6 +8931,16 @@
 		},
 		"plugins/postcss-place": {
 			"version": "8.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -8561,10 +8950,6 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -8573,6 +8958,16 @@
 		"plugins/postcss-progressive-custom-properties": {
 			"name": "@csstools/postcss-progressive-custom-properties",
 			"version": "2.1.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -8583,16 +8978,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-pseudo-class-any-link": {
 			"version": "8.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -8602,10 +9003,6 @@
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
@@ -8614,6 +9011,16 @@
 		"plugins/postcss-scope-pseudo-class": {
 			"name": "@csstools/postcss-scope-pseudo-class",
 			"version": "2.0.2",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -8624,16 +9031,22 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
 		},
 		"plugins/postcss-selector-not": {
 			"version": "7.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^6.0.10"
@@ -8644,10 +9057,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8655,6 +9064,16 @@
 		"plugins/postcss-stepped-value-functions": {
 			"name": "@csstools/postcss-stepped-value-functions",
 			"version": "2.1.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-calc": "^1.1.1",
@@ -8667,10 +9086,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8678,6 +9093,16 @@
 		"plugins/postcss-text-decoration-shorthand": {
 			"name": "@csstools/postcss-text-decoration-shorthand",
 			"version": "2.2.3",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/color-helpers": "^2.0.0",
@@ -8690,10 +9115,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8701,6 +9122,16 @@
 		"plugins/postcss-todo-or-die": {
 			"name": "@csstools/postcss-todo-or-die",
 			"version": "1.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-parser-algorithms": "^2.1.1",
@@ -8713,10 +9144,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8724,6 +9151,16 @@
 		"plugins/postcss-trigonometric-functions": {
 			"name": "@csstools/postcss-trigonometric-functions",
 			"version": "2.1.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@csstools/css-calc": "^1.1.1",
@@ -8736,10 +9173,6 @@
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
 			"peerDependencies": {
 				"postcss": "^8.4"
 			}
@@ -8747,16 +9180,22 @@
 		"plugins/postcss-unset-value": {
 			"name": "@csstools/postcss-unset-value",
 			"version": "2.0.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"license": "CC0-1.0",
 			"devDependencies": {
 				"@csstools/postcss-tape": "*"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"

--- a/plugin-packs/postcss-preset-env/.tape.mjs
+++ b/plugin-packs/postcss-preset-env/.tape.mjs
@@ -396,6 +396,14 @@ postcssTape(plugin)({
 			}
 		}
 	},
+	'logical-properties': {
+		message: 'supports all known logical properties',
+		options: {
+			autoprefixer: false,
+			stage: 0,
+			browsers: '> 0%'
+		},
+	},
 	'progressive-custom-properties': {
 		message: 'supports progressive custom properties plugin',
 		options: {

--- a/plugin-packs/postcss-preset-env/package.json
+++ b/plugin-packs/postcss-preset-env/package.json
@@ -110,11 +110,12 @@
 	},
 	"devDependencies": {
 		"@csstools/postcss-tape": "*",
+		"@webref/css": "^6.5.1",
 		"postcss-simple-vars": "^7.0.1"
 	},
 	"scripts": {
 		"prebuild": "node ./scripts/generate-plugins-data.mjs && eslint --fix ./src/plugins/*.mjs",
-		"build": "rollup -c ../../rollup/default.mjs",
+		"build": "rollup -c ../../rollup/default.mjs && node ./scripts/update-logical-properties-test.mjs",
 		"docs": "node ../../.github/bin/generate-docs/install.mjs && node ./docs/generate.mjs",
 		"lint": "node ../../.github/bin/format-package-json.mjs",
 		"prepublishOnly": "npm run build && npm run test",

--- a/plugin-packs/postcss-preset-env/scripts/update-logical-properties-test.mjs
+++ b/plugin-packs/postcss-preset-env/scripts/update-logical-properties-test.mjs
@@ -33,4 +33,3 @@ for (const property of properties) {
 }
 
 await fs.writeFile('test/logical-properties.css', buffer);
-

--- a/plugin-packs/postcss-preset-env/scripts/update-logical-properties-test.mjs
+++ b/plugin-packs/postcss-preset-env/scripts/update-logical-properties-test.mjs
@@ -1,0 +1,36 @@
+import css from '@webref/css';
+import fs from 'fs/promises';
+
+const logicalProperties = new Set();
+
+const parsedFiles = await css.listAll();
+for (const [, data] of Object.entries(parsedFiles)) {
+	for (const property of data.properties) {
+		if (property.logicalPropertyGroup) {
+			logicalProperties.add(property);
+		}
+	}
+}
+
+const properties = Array.from(logicalProperties);
+properties.sort((a, b) => {
+	if (a.logicalPropertyGroup === b.logicalPropertyGroup) {
+		return a.name.localeCompare(b.name);
+	}
+
+	return a.logicalPropertyGroup.localeCompare(b.logicalPropertyGroup);
+});
+
+let buffer = '/* This test aims to make it easy to find new logical properties that don\'t have a transform. */\n\n';
+
+for (const property of properties) {
+	buffer += `.${property.logicalPropertyGroup.toLowerCase()} {
+	/* ${property.name} */
+	${property.name}: inherit;
+}
+
+`;
+}
+
+await fs.writeFile('test/logical-properties.css', buffer);
+

--- a/plugin-packs/postcss-preset-env/test/logical-properties.css
+++ b/plugin-packs/postcss-preset-env/test/logical-properties.css
@@ -1,0 +1,562 @@
+/* This test aims to make it easy to find new logical properties that don't have a transform. */
+
+.background-position {
+	/* background-position-block */
+	background-position-block: inherit;
+}
+
+.background-position {
+	/* background-position-inline */
+	background-position-inline: inherit;
+}
+
+.background-position {
+	/* background-position-x */
+	background-position-x: inherit;
+}
+
+.background-position {
+	/* background-position-y */
+	background-position-y: inherit;
+}
+
+.border-color {
+	/* border-block-end-color */
+	border-block-end-color: inherit;
+}
+
+.border-color {
+	/* border-block-start-color */
+	border-block-start-color: inherit;
+}
+
+.border-color {
+	/* border-bottom-color */
+	border-bottom-color: inherit;
+}
+
+.border-color {
+	/* border-bottom-color */
+	border-bottom-color: inherit;
+}
+
+.border-color {
+	/* border-inline-end-color */
+	border-inline-end-color: inherit;
+}
+
+.border-color {
+	/* border-inline-start-color */
+	border-inline-start-color: inherit;
+}
+
+.border-color {
+	/* border-left-color */
+	border-left-color: inherit;
+}
+
+.border-color {
+	/* border-left-color */
+	border-left-color: inherit;
+}
+
+.border-color {
+	/* border-right-color */
+	border-right-color: inherit;
+}
+
+.border-color {
+	/* border-right-color */
+	border-right-color: inherit;
+}
+
+.border-color {
+	/* border-top-color */
+	border-top-color: inherit;
+}
+
+.border-color {
+	/* border-top-color */
+	border-top-color: inherit;
+}
+
+.border-radius {
+	/* border-bottom-left-radius */
+	border-bottom-left-radius: inherit;
+}
+
+.border-radius {
+	/* border-bottom-right-radius */
+	border-bottom-right-radius: inherit;
+}
+
+.border-radius {
+	/* border-end-end-radius */
+	border-end-end-radius: inherit;
+}
+
+.border-radius {
+	/* border-end-start-radius */
+	border-end-start-radius: inherit;
+}
+
+.border-radius {
+	/* border-start-end-radius */
+	border-start-end-radius: inherit;
+}
+
+.border-radius {
+	/* border-start-start-radius */
+	border-start-start-radius: inherit;
+}
+
+.border-radius {
+	/* border-top-left-radius */
+	border-top-left-radius: inherit;
+}
+
+.border-radius {
+	/* border-top-right-radius */
+	border-top-right-radius: inherit;
+}
+
+.border-style {
+	/* border-block-end-style */
+	border-block-end-style: inherit;
+}
+
+.border-style {
+	/* border-block-start-style */
+	border-block-start-style: inherit;
+}
+
+.border-style {
+	/* border-bottom-style */
+	border-bottom-style: inherit;
+}
+
+.border-style {
+	/* border-inline-end-style */
+	border-inline-end-style: inherit;
+}
+
+.border-style {
+	/* border-inline-start-style */
+	border-inline-start-style: inherit;
+}
+
+.border-style {
+	/* border-left-style */
+	border-left-style: inherit;
+}
+
+.border-style {
+	/* border-right-style */
+	border-right-style: inherit;
+}
+
+.border-style {
+	/* border-top-style */
+	border-top-style: inherit;
+}
+
+.border-width {
+	/* border-block-end-width */
+	border-block-end-width: inherit;
+}
+
+.border-width {
+	/* border-block-start-width */
+	border-block-start-width: inherit;
+}
+
+.border-width {
+	/* border-bottom-width */
+	border-bottom-width: inherit;
+}
+
+.border-width {
+	/* border-inline-end-width */
+	border-inline-end-width: inherit;
+}
+
+.border-width {
+	/* border-inline-start-width */
+	border-inline-start-width: inherit;
+}
+
+.border-width {
+	/* border-left-width */
+	border-left-width: inherit;
+}
+
+.border-width {
+	/* border-right-width */
+	border-right-width: inherit;
+}
+
+.border-width {
+	/* border-top-width */
+	border-top-width: inherit;
+}
+
+.contain-intrinsic-size {
+	/* contain-intrinsic-block-size */
+	contain-intrinsic-block-size: inherit;
+}
+
+.contain-intrinsic-size {
+	/* contain-intrinsic-height */
+	contain-intrinsic-height: inherit;
+}
+
+.contain-intrinsic-size {
+	/* contain-intrinsic-inline-size */
+	contain-intrinsic-inline-size: inherit;
+}
+
+.contain-intrinsic-size {
+	/* contain-intrinsic-width */
+	contain-intrinsic-width: inherit;
+}
+
+.inset {
+	/* bottom */
+	bottom: inherit;
+}
+
+.inset {
+	/* inset-block-end */
+	inset-block-end: inherit;
+}
+
+.inset {
+	/* inset-block-start */
+	inset-block-start: inherit;
+}
+
+.inset {
+	/* inset-inline-end */
+	inset-inline-end: inherit;
+}
+
+.inset {
+	/* inset-inline-start */
+	inset-inline-start: inherit;
+}
+
+.inset {
+	/* left */
+	left: inherit;
+}
+
+.inset {
+	/* right */
+	right: inherit;
+}
+
+.inset {
+	/* top */
+	top: inherit;
+}
+
+.margin {
+	/* margin-block-end */
+	margin-block-end: inherit;
+}
+
+.margin {
+	/* margin-block-start */
+	margin-block-start: inherit;
+}
+
+.margin {
+	/* margin-bottom */
+	margin-bottom: inherit;
+}
+
+.margin {
+	/* margin-inline-end */
+	margin-inline-end: inherit;
+}
+
+.margin {
+	/* margin-inline-start */
+	margin-inline-start: inherit;
+}
+
+.margin {
+	/* margin-left */
+	margin-left: inherit;
+}
+
+.margin {
+	/* margin-right */
+	margin-right: inherit;
+}
+
+.margin {
+	/* margin-top */
+	margin-top: inherit;
+}
+
+.max-size {
+	/* max-block-size */
+	max-block-size: inherit;
+}
+
+.max-size {
+	/* max-height */
+	max-height: inherit;
+}
+
+.max-size {
+	/* max-inline-size */
+	max-inline-size: inherit;
+}
+
+.max-size {
+	/* max-width */
+	max-width: inherit;
+}
+
+.min-size {
+	/* min-block-size */
+	min-block-size: inherit;
+}
+
+.min-size {
+	/* min-height */
+	min-height: inherit;
+}
+
+.min-size {
+	/* min-inline-size */
+	min-inline-size: inherit;
+}
+
+.min-size {
+	/* min-width */
+	min-width: inherit;
+}
+
+.overflow {
+	/* overflow-block */
+	overflow-block: inherit;
+}
+
+.overflow {
+	/* overflow-inline */
+	overflow-inline: inherit;
+}
+
+.overflow {
+	/* overflow-x */
+	overflow-x: inherit;
+}
+
+.overflow {
+	/* overflow-y */
+	overflow-y: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-block-end */
+	overflow-clip-margin-block-end: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-block-start */
+	overflow-clip-margin-block-start: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-bottom */
+	overflow-clip-margin-bottom: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-inline-end */
+	overflow-clip-margin-inline-end: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-inline-start */
+	overflow-clip-margin-inline-start: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-left */
+	overflow-clip-margin-left: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-right */
+	overflow-clip-margin-right: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-top */
+	overflow-clip-margin-top: inherit;
+}
+
+.overscroll-behavior {
+	/* overscroll-behavior-block */
+	overscroll-behavior-block: inherit;
+}
+
+.overscroll-behavior {
+	/* overscroll-behavior-inline */
+	overscroll-behavior-inline: inherit;
+}
+
+.overscroll-behavior {
+	/* overscroll-behavior-x */
+	overscroll-behavior-x: inherit;
+}
+
+.overscroll-behavior {
+	/* overscroll-behavior-y */
+	overscroll-behavior-y: inherit;
+}
+
+.padding {
+	/* padding-block-end */
+	padding-block-end: inherit;
+}
+
+.padding {
+	/* padding-block-start */
+	padding-block-start: inherit;
+}
+
+.padding {
+	/* padding-bottom */
+	padding-bottom: inherit;
+}
+
+.padding {
+	/* padding-inline-end */
+	padding-inline-end: inherit;
+}
+
+.padding {
+	/* padding-inline-start */
+	padding-inline-start: inherit;
+}
+
+.padding {
+	/* padding-left */
+	padding-left: inherit;
+}
+
+.padding {
+	/* padding-right */
+	padding-right: inherit;
+}
+
+.padding {
+	/* padding-top */
+	padding-top: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-block-end */
+	scroll-margin-block-end: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-block-start */
+	scroll-margin-block-start: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-bottom */
+	scroll-margin-bottom: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-inline-end */
+	scroll-margin-inline-end: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-inline-start */
+	scroll-margin-inline-start: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-left */
+	scroll-margin-left: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-right */
+	scroll-margin-right: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-top */
+	scroll-margin-top: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-block-end */
+	scroll-padding-block-end: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-block-start */
+	scroll-padding-block-start: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-bottom */
+	scroll-padding-bottom: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-inline-end */
+	scroll-padding-inline-end: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-inline-start */
+	scroll-padding-inline-start: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-left */
+	scroll-padding-left: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-right */
+	scroll-padding-right: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-top */
+	scroll-padding-top: inherit;
+}
+
+.size {
+	/* block-size */
+	block-size: inherit;
+}
+
+.size {
+	/* height */
+	height: inherit;
+}
+
+.size {
+	/* inline-size */
+	inline-size: inherit;
+}
+
+.size {
+	/* width */
+	width: inherit;
+}
+

--- a/plugin-packs/postcss-preset-env/test/logical-properties.expect.css
+++ b/plugin-packs/postcss-preset-env/test/logical-properties.expect.css
@@ -1,0 +1,562 @@
+/* This test aims to make it easy to find new logical properties that don't have a transform. */
+
+.background-position {
+	/* background-position-block */
+	background-position-block: inherit;
+}
+
+.background-position {
+	/* background-position-inline */
+	background-position-inline: inherit;
+}
+
+.background-position {
+	/* background-position-x */
+	background-position-x: inherit;
+}
+
+.background-position {
+	/* background-position-y */
+	background-position-y: inherit;
+}
+
+.border-color {
+	/* border-block-end-color */
+	border-bottom-color: inherit;
+}
+
+.border-color {
+	/* border-block-start-color */
+	border-top-color: inherit;
+}
+
+.border-color {
+	/* border-bottom-color */
+	border-bottom-color: inherit;
+}
+
+.border-color {
+	/* border-bottom-color */
+	border-bottom-color: inherit;
+}
+
+.border-color {
+	/* border-inline-end-color */
+	border-right-color: inherit;
+}
+
+.border-color {
+	/* border-inline-start-color */
+	border-left-color: inherit;
+}
+
+.border-color {
+	/* border-left-color */
+	border-left-color: inherit;
+}
+
+.border-color {
+	/* border-left-color */
+	border-left-color: inherit;
+}
+
+.border-color {
+	/* border-right-color */
+	border-right-color: inherit;
+}
+
+.border-color {
+	/* border-right-color */
+	border-right-color: inherit;
+}
+
+.border-color {
+	/* border-top-color */
+	border-top-color: inherit;
+}
+
+.border-color {
+	/* border-top-color */
+	border-top-color: inherit;
+}
+
+.border-radius {
+	/* border-bottom-left-radius */
+	border-bottom-left-radius: inherit;
+}
+
+.border-radius {
+	/* border-bottom-right-radius */
+	border-bottom-right-radius: inherit;
+}
+
+.border-radius {
+	/* border-end-end-radius */
+	border-bottom-right-radius: inherit;
+}
+
+.border-radius {
+	/* border-end-start-radius */
+	border-bottom-left-radius: inherit;
+}
+
+.border-radius {
+	/* border-start-end-radius */
+	border-top-right-radius: inherit;
+}
+
+.border-radius {
+	/* border-start-start-radius */
+	border-top-left-radius: inherit;
+}
+
+.border-radius {
+	/* border-top-left-radius */
+	border-top-left-radius: inherit;
+}
+
+.border-radius {
+	/* border-top-right-radius */
+	border-top-right-radius: inherit;
+}
+
+.border-style {
+	/* border-block-end-style */
+	border-bottom-style: inherit;
+}
+
+.border-style {
+	/* border-block-start-style */
+	border-top-style: inherit;
+}
+
+.border-style {
+	/* border-bottom-style */
+	border-bottom-style: inherit;
+}
+
+.border-style {
+	/* border-inline-end-style */
+	border-right-style: inherit;
+}
+
+.border-style {
+	/* border-inline-start-style */
+	border-left-style: inherit;
+}
+
+.border-style {
+	/* border-left-style */
+	border-left-style: inherit;
+}
+
+.border-style {
+	/* border-right-style */
+	border-right-style: inherit;
+}
+
+.border-style {
+	/* border-top-style */
+	border-top-style: inherit;
+}
+
+.border-width {
+	/* border-block-end-width */
+	border-bottom-width: inherit;
+}
+
+.border-width {
+	/* border-block-start-width */
+	border-top-width: inherit;
+}
+
+.border-width {
+	/* border-bottom-width */
+	border-bottom-width: inherit;
+}
+
+.border-width {
+	/* border-inline-end-width */
+	border-right-width: inherit;
+}
+
+.border-width {
+	/* border-inline-start-width */
+	border-left-width: inherit;
+}
+
+.border-width {
+	/* border-left-width */
+	border-left-width: inherit;
+}
+
+.border-width {
+	/* border-right-width */
+	border-right-width: inherit;
+}
+
+.border-width {
+	/* border-top-width */
+	border-top-width: inherit;
+}
+
+.contain-intrinsic-size {
+	/* contain-intrinsic-block-size */
+	contain-intrinsic-block-size: inherit;
+}
+
+.contain-intrinsic-size {
+	/* contain-intrinsic-height */
+	contain-intrinsic-height: inherit;
+}
+
+.contain-intrinsic-size {
+	/* contain-intrinsic-inline-size */
+	contain-intrinsic-inline-size: inherit;
+}
+
+.contain-intrinsic-size {
+	/* contain-intrinsic-width */
+	contain-intrinsic-width: inherit;
+}
+
+.inset {
+	/* bottom */
+	bottom: inherit;
+}
+
+.inset {
+	/* inset-block-end */
+	bottom: inherit;
+}
+
+.inset {
+	/* inset-block-start */
+	top: inherit;
+}
+
+.inset {
+	/* inset-inline-end */
+	right: inherit;
+}
+
+.inset {
+	/* inset-inline-start */
+	left: inherit;
+}
+
+.inset {
+	/* left */
+	left: inherit;
+}
+
+.inset {
+	/* right */
+	right: inherit;
+}
+
+.inset {
+	/* top */
+	top: inherit;
+}
+
+.margin {
+	/* margin-block-end */
+	margin-bottom: inherit;
+}
+
+.margin {
+	/* margin-block-start */
+	margin-top: inherit;
+}
+
+.margin {
+	/* margin-bottom */
+	margin-bottom: inherit;
+}
+
+.margin {
+	/* margin-inline-end */
+	margin-right: inherit;
+}
+
+.margin {
+	/* margin-inline-start */
+	margin-left: inherit;
+}
+
+.margin {
+	/* margin-left */
+	margin-left: inherit;
+}
+
+.margin {
+	/* margin-right */
+	margin-right: inherit;
+}
+
+.margin {
+	/* margin-top */
+	margin-top: inherit;
+}
+
+.max-size {
+	/* max-block-size */
+	max-height: inherit;
+}
+
+.max-size {
+	/* max-height */
+	max-height: inherit;
+}
+
+.max-size {
+	/* max-inline-size */
+	max-width: inherit;
+}
+
+.max-size {
+	/* max-width */
+	max-width: inherit;
+}
+
+.min-size {
+	/* min-block-size */
+	min-height: inherit;
+}
+
+.min-size {
+	/* min-height */
+	min-height: inherit;
+}
+
+.min-size {
+	/* min-inline-size */
+	min-width: inherit;
+}
+
+.min-size {
+	/* min-width */
+	min-width: inherit;
+}
+
+.overflow {
+	/* overflow-block */
+	overflow-block: inherit;
+}
+
+.overflow {
+	/* overflow-inline */
+	overflow-inline: inherit;
+}
+
+.overflow {
+	/* overflow-x */
+	overflow-x: inherit;
+}
+
+.overflow {
+	/* overflow-y */
+	overflow-y: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-block-end */
+	overflow-clip-margin-block-end: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-block-start */
+	overflow-clip-margin-block-start: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-bottom */
+	overflow-clip-margin-bottom: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-inline-end */
+	overflow-clip-margin-inline-end: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-inline-start */
+	overflow-clip-margin-inline-start: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-left */
+	overflow-clip-margin-left: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-right */
+	overflow-clip-margin-right: inherit;
+}
+
+.overflow-clip-margin {
+	/* overflow-clip-margin-top */
+	overflow-clip-margin-top: inherit;
+}
+
+.overscroll-behavior {
+	/* overscroll-behavior-block */
+	overscroll-behavior-block: inherit;
+}
+
+.overscroll-behavior {
+	/* overscroll-behavior-inline */
+	overscroll-behavior-inline: inherit;
+}
+
+.overscroll-behavior {
+	/* overscroll-behavior-x */
+	overscroll-behavior-x: inherit;
+}
+
+.overscroll-behavior {
+	/* overscroll-behavior-y */
+	overscroll-behavior-y: inherit;
+}
+
+.padding {
+	/* padding-block-end */
+	padding-bottom: inherit;
+}
+
+.padding {
+	/* padding-block-start */
+	padding-top: inherit;
+}
+
+.padding {
+	/* padding-bottom */
+	padding-bottom: inherit;
+}
+
+.padding {
+	/* padding-inline-end */
+	padding-right: inherit;
+}
+
+.padding {
+	/* padding-inline-start */
+	padding-left: inherit;
+}
+
+.padding {
+	/* padding-left */
+	padding-left: inherit;
+}
+
+.padding {
+	/* padding-right */
+	padding-right: inherit;
+}
+
+.padding {
+	/* padding-top */
+	padding-top: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-block-end */
+	scroll-margin-block-end: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-block-start */
+	scroll-margin-block-start: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-bottom */
+	scroll-margin-bottom: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-inline-end */
+	scroll-margin-inline-end: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-inline-start */
+	scroll-margin-inline-start: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-left */
+	scroll-margin-left: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-right */
+	scroll-margin-right: inherit;
+}
+
+.scroll-margin {
+	/* scroll-margin-top */
+	scroll-margin-top: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-block-end */
+	scroll-padding-block-end: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-block-start */
+	scroll-padding-block-start: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-bottom */
+	scroll-padding-bottom: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-inline-end */
+	scroll-padding-inline-end: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-inline-start */
+	scroll-padding-inline-start: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-left */
+	scroll-padding-left: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-right */
+	scroll-padding-right: inherit;
+}
+
+.scroll-padding {
+	/* scroll-padding-top */
+	scroll-padding-top: inherit;
+}
+
+.size {
+	/* block-size */
+	height: inherit;
+}
+
+.size {
+	/* height */
+	height: inherit;
+}
+
+.size {
+	/* inline-size */
+	width: inherit;
+}
+
+.size {
+	/* width */
+	width: inherit;
+}
+


### PR DESCRIPTION
`@webref/css` now adds a marker to properties that are part of a "logical property group".
This makes it possible to generate a list of related properties of which some are logical properties. (`height` and `block-size` are part of the same group)

This gives us a good signal if new logical properties are added to CSS specs and gives us extra coverage for all logical related plugins.