### PR TITLE
Fix weird indentation in postcss-nesting README

### DIFF
--- a/plugins/postcss-nesting/README.md
+++ b/plugins/postcss-nesting/README.md
@@ -30,16 +30,16 @@ you might want to use [PostCSS Nested] instead.
 	color: red;
 }
 .foo:hover {
-		color: green;
-	}
+	color: green;
+}
 .foo > .bar {
-		color: blue;
-	}
+	color: blue;
+}
 @media (prefers-color-scheme: dark) {
 	.foo {
 		color: cyan;
-}
 	}
+}
 ```
 
 ## Usage


### PR DESCRIPTION
This makes the CSS snippet in the nesting plugin's README correctly formatted and more readable.

Please note that this is my first contribution to this project. Please comment if you would like me to do anything else!

> _Side Note:_ The code oddly enough uses tabs instead of spaces. Would you like me to fix that too, or keep it how it is?