### PR TITLE
Fix building postcss-preset-env on Windows

### DIFF
--- a/plugin-packs/postcss-preset-env/scripts/generate-plugins-data.mjs
+++ b/plugin-packs/postcss-preset-env/scripts/generate-plugins-data.mjs
@@ -38,7 +38,7 @@ function generatePluginOptions(data) {
 		const plugin = plugins[i];
 
 		if (existsSync(path.join('./src/types/', plugin.packageName, 'plugin-options.ts'))) {
-			result += `import type { pluginOptions as ${plugin.importName} } from '${path.join('../types/', plugin.packageName, 'plugin-options')}';\n`;
+			result += `import type { pluginOptions as ${plugin.importName} } from '${path.posix.join('../types/', plugin.packageName, 'plugin-options')}';\n`;
 		} else {
 			result += `import type { pluginOptions as ${plugin.importName} } from '${plugin.packageName}';\n`;
 		}


### PR DESCRIPTION
Since paths use backslashes on Windows but import statements need forward slashes, using `path.join` generates an invalid `plugins-options.ts` file.

By using `path.posix.join` instead, it outputs forward slashes regardless of the host platform, the generated file matches the committed file and the build works as expected (with `Git Bash` or similar).