### PR TITLE
On Windows, spawn npm with shell: true

### DIFF
--- a/.github/bin/release-plan/commit.mjs
+++ b/.github/bin/release-plan/commit.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { platform } from 'process';
 
 export async function commitAfterPackageRelease(newVersion, packageDirectory, packageName) {
 	await new Promise((resolve, reject) => {
@@ -10,7 +11,8 @@ export async function commitAfterPackageRelease(newVersion, packageDirectory, pa
 				`${packageName} v${newVersion}` // "@csstools/css-tokenizer v1.0.0"
 			],
 			{
-				cwd: packageDirectory
+				cwd: packageDirectory,
+				shell: platform === 'win32'
 			}
 		);
 

--- a/.github/bin/release-plan/docs.mjs
+++ b/.github/bin/release-plan/docs.mjs
@@ -12,7 +12,7 @@ export async function updateDocumentation(packageDirectory) {
 			],
 			{
 				cwd: packageDirectory,
-				shell: platform == 'win32'
+				shell: platform === 'win32'
 			}
 		);
 

--- a/.github/bin/release-plan/docs.mjs
+++ b/.github/bin/release-plan/docs.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { platform } from 'process';
 
 export async function updateDocumentation(packageDirectory) {
 	await new Promise((resolve, reject) => {
@@ -10,7 +11,8 @@ export async function updateDocumentation(packageDirectory) {
 				'--if-present'
 			],
 			{
-				cwd: packageDirectory
+				cwd: packageDirectory,
+				shell: platform == 'win32'
 			}
 		);
 

--- a/.github/bin/release-plan/npm-install.mjs
+++ b/.github/bin/release-plan/npm-install.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { platform } from 'process';
 
 export async function npmInstall() {
 	await new Promise((resolve, reject) => {
@@ -7,6 +8,9 @@ export async function npmInstall() {
 			[
 				'install'
 			],
+			{
+				shell: platform == 'win32'
+			}
 		);
 
 		installCmd.on('close', (code) => {

--- a/.github/bin/release-plan/npm-install.mjs
+++ b/.github/bin/release-plan/npm-install.mjs
@@ -9,7 +9,7 @@ export async function npmInstall() {
 				'install'
 			],
 			{
-				shell: platform == 'win32'
+				shell: platform === 'win32'
 			}
 		);
 

--- a/.github/bin/release-plan/npm-publish.mjs
+++ b/.github/bin/release-plan/npm-publish.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { platform } from 'process';
 
 export async function npmPublish(packageDirectory, packageName) {
 	await new Promise((resolve, reject) => {
@@ -11,7 +12,8 @@ export async function npmPublish(packageDirectory, packageName) {
 			],
 			{
 				stdio: 'inherit',
-				cwd: packageDirectory
+				cwd: packageDirectory,
+				shell: platform == 'win32'
 			}
 		);
 

--- a/.github/bin/release-plan/npm-publish.mjs
+++ b/.github/bin/release-plan/npm-publish.mjs
@@ -13,7 +13,7 @@ export async function npmPublish(packageDirectory, packageName) {
 			{
 				stdio: 'inherit',
 				cwd: packageDirectory,
-				shell: platform == 'win32'
+				shell: platform === 'win32'
 			}
 		);
 

--- a/.github/bin/release-plan/npm-version.mjs
+++ b/.github/bin/release-plan/npm-version.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { platform } from 'process';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -34,7 +35,8 @@ export async function npmVersion(increment, packageDirectory) {
 				increment
 			],
 			{
-				cwd: packageDirectory
+				cwd: packageDirectory,
+				shell: platform == 'win32'
 			}
 		);
 

--- a/.github/bin/release-plan/npm-version.mjs
+++ b/.github/bin/release-plan/npm-version.mjs
@@ -36,7 +36,7 @@ export async function npmVersion(increment, packageDirectory) {
 			],
 			{
 				cwd: packageDirectory,
-				shell: platform == 'win32'
+				shell: platform === 'win32'
 			}
 		);
 


### PR DESCRIPTION
I hit some more errors trying to run the release plan on Windows!

On Windows, `npm` goes through a few layers of indirection and the initial entry point is `npm.cmd` in the Node.js installation folder (e.g. `C:\Program Files\nodejs`).

So to spawn `npm` from Node.js on Windows, it needs a shell. But not on Linux (or any platform other than Windows, probably), so pass the platform check into `child_process.spawn` as a boolean :)