### PR TITLE
Link to dependencies from changelogs

### DIFF
--- a/.github/bin/release-plan/release-plan.mjs
+++ b/.github/bin/release-plan/release-plan.mjs
@@ -117,6 +117,10 @@ for (const workspace of notReleasableNow.values()) {
 		if (needsRelease.has(dependency)) {
 			const updated = needsRelease.get(dependency);
 
+			const dependencyLink = `/${updated.path.replaceAll('\\', '/')}`;
+			const nameAsLink = `[\`${updated.name}\`](${dependencyLink})`;
+			const versionAsLink = `[\`${updated.newVersion}\`](${dependencyLink}/CHANGELOG.md)`;
+
 			if (
 				packageInfo.dependencies &&
 				packageInfo.dependencies[updated.name] &&
@@ -124,7 +128,7 @@ for (const workspace of notReleasableNow.values()) {
 				updated.newVersion
 			) {
 				packageInfo.dependencies[updated.name] = '^' + updated.newVersion;
-				changeLogAdditions += `- Updated \`${updated.name}\` to \`${updated.newVersion}\` (${updated.increment})\n`;
+				changeLogAdditions += `- Updated ${nameAsLink} to ${versionAsLink} (${updated.increment})\n`;
 				didChange = true;
 			}
 			if (
@@ -144,7 +148,7 @@ for (const workspace of notReleasableNow.values()) {
 				updated.newVersion
 			) {
 				packageInfo.peerDependencies[updated.name] = '^' + updated.newVersion;
-				changeLogAdditions += `- Updated \`${updated.name}\` to \`${updated.newVersion}\` (${updated.increment})\n`;
+				changeLogAdditions += `- Updated ${nameAsLink} to ${versionAsLink} (${updated.increment})\n`;
 				didChange = true;
 			}
 		}


### PR DESCRIPTION
Thanks for the assistance! This seems to do the trick.

I made the links relative with a leading slash: When rendering Markdown blobs, GitHub resolves those relative to the root of the repository and the branch being viewed, so the links work across forks and branches.

Here are some examples from a test branch on my fork:
* [css-calc changelog](https://github.com/ehoogeveen-medweb/postcss-plugins/blob/linkify-dependencies-test/packages/css-calc/CHANGELOG.md)
* [postcss-custom-properties changelog](https://github.com/ehoogeveen-medweb/postcss-plugins/blob/linkify-dependencies-test/plugins/postcss-custom-properties/CHANGELOG.md)

Fixes https://github.com/csstools/postcss-plugins/issues/1002.