### PR TITLE
Clarify add-to-changelog logic

### DIFF
--- a/.github/bin/release-plan/add-to-changelog.mjs
+++ b/.github/bin/release-plan/add-to-changelog.mjs
@@ -1,42 +1,49 @@
 export function addUpdatedPackagesToChangelog(workspace, changelog, changeLogAdditions) {
 	if (changelog.includes('Unreleased')) {
-		let unreleasedSectionStart = changelog.indexOf('Unreleased');
+		// Find the heading for the unreleased changes.
+		const unreleasedSectionStart = changelog.indexOf('Unreleased');
 		if (unreleasedSectionStart === -1) {
 			console.log('Unable to update the Changelog for ' + workspace.name);
 			return changelog;
 		}
 
-		let unreleasedSectionContent = changelog.indexOf('\n', unreleasedSectionStart);
-		if (unreleasedSectionContent === -1) {
+		// Find the start of the section content for the unreleased changes.
+		const unreleasedSectionContent = changelog.indexOf('\n', unreleasedSectionStart) + 1;
+		if (unreleasedSectionContent === 0) {
 			console.log('Unable to update the Changelog for ' + workspace.name);
 			return changelog;
 		}
 
+		// Find the heading for the next section (if any).
 		let nextSectionStart = changelog.indexOf('### ', unreleasedSectionContent);
 		if (nextSectionStart === -1) {
 			nextSectionStart = changelog.length;
 		}
 
-		let listEnd = changelog.lastIndexOf('- ', nextSectionStart);
-		if (listEnd === -1) {
+		// Search backward from the next section to find the line for the last unreleased change.
+		const listEnd = changelog.lastIndexOf('- ', nextSectionStart);
+		if (listEnd < unreleasedSectionContent) {
 			console.log('Unable to update the Changelog for ' + workspace.name);
 			return changelog;
 		}
 
-		let nextLine = changelog.indexOf('\n', listEnd);
-		if (nextLine === -1) {
+		// Get the start of the next line after the last change.
+		const nextLine = changelog.indexOf('\n', listEnd) + 1;
+		if (nextLine === 0) {
 			console.log('Unable to update the Changelog for ' + workspace.name);
 			return changelog;
 		}
 
-		changelog = changelog.slice(0, nextLine + 1) + changeLogAdditions + '\n' + changelog.slice(nextLine + 1);
+		// Insert the changelog additions on the line after the last change.
+		changelog = changelog.slice(0, nextLine) + changeLogAdditions + changelog.slice(nextLine);
 	} else {
+		// There are no unreleased changes, so prepend the changelog additions in a new unreleased segment.
 		let nextSectionStart = changelog.indexOf('### ');
 		if (nextSectionStart === -1) {
 			nextSectionStart = changelog.length;
 		}
 
-		changelog = changelog.slice(0, nextSectionStart) + `### Unreleased (patch)\n\n${changeLogAdditions}\n\n` + changelog.slice(nextSectionStart);
+		changelog = changelog.slice(0, nextSectionStart) + `### Unreleased (patch)\n\n${changeLogAdditions}\n` + changelog.slice(nextSectionStart);
 	}
 
 	return changelog;


### PR DESCRIPTION
I got a bit confused reading through the logic of `addUpdatedPackagesToChangelog()` - in particular, it took a while before I realized that `String.prototype.lastIndexOf` searches *backward* from the given index.

This change:
* Adds a comment for each step (maybe slightly overkill, but I tried to make them informative).
* Changes `unreleasedSectionContent` and `nextLine` to use the index of the character *after* the newline.
  * I think this is clearer, but I wasn't 100% sure where to put the `+ 1`.
  * An alternative would be to use `nextLine++ === -1` to keep comparing against `-1`, but I thought that looked more confusing.
  * It would also be possible to compare the returned index against `unreleasedSectionStart` (since both `-1` and `0` should always be less than `unreleasedSectionStart`).
* Compares `listEnd` against `unreleasedSectionContent` to ensure we didn't find a stray entry *above* the Unreleased section.
* Uses `const` where possible.
* (functional change) Removes the extra newline after `changeLogAdditions`: It's redundant as the additions are constructed from strings ending in newlines.
  * Technically this would break if the caller switched to something like `[change1, ..., changeN].join('\n')` - but it's only called by `release-plan.mjs` so I think the risk of accidentally breaking it is low.

Changelog comparisons:
* With existing unreleased changes: [main](https://github.com/ehoogeveen-medweb/postcss-plugins/blob/main-test/packages/css-calc/CHANGELOG.md) | [after this change](https://github.com/ehoogeveen-medweb/postcss-plugins/blob/clarify-add-to-changelog-test/packages/css-calc/CHANGELOG.md)
* Without unreleased changes: [main](https://github.com/ehoogeveen-medweb/postcss-plugins/blob/main-test/experimental/postcss-gradient-stop-increments/CHANGELOG.md) | [after this change](https://github.com/ehoogeveen-medweb/postcss-plugins/blob/clarify-add-to-changelog-test/experimental/postcss-gradient-stop-increments/CHANGELOG.md)

They're rendered the same, but after the change there's no redundant newlines in the raw files.