### PR TITLE
add access checking to release planner

### DIFF
--- a/.github/bin/release-plan/npm-can-publish.mjs
+++ b/.github/bin/release-plan/npm-can-publish.mjs
@@ -22,13 +22,17 @@ export async function canPublish(packageName) {
 
 		whoamiCmd.on('close', (code) => {
 			if (0 !== code) {
-				reject(new Error(`'npm install' exited with code ${code}`));
+				reject(new Error(`'npm whoami' exited with code ${code}`));
 				return;
 			}
 
 			resolve(result.trim());
 		});
 	});
+
+	if (!myName) {
+		return false;
+	}
 
 	return new Promise((resolve, reject) => {
 		const accessListCmd = spawn(
@@ -54,7 +58,7 @@ export async function canPublish(packageName) {
 
 		accessListCmd.on('close', (code) => {
 			if (0 !== code) {
-				reject(new Error(`'npm install' exited with code ${code}`));
+				reject(new Error(`'npm ${['access', 'list', 'collaborators', packageName, myName].join(' ')}' exited with code ${code}`));
 				return;
 			}
 

--- a/.github/bin/release-plan/npm-can-publish.mjs
+++ b/.github/bin/release-plan/npm-can-publish.mjs
@@ -1,0 +1,67 @@
+import { spawn } from 'child_process';
+import { platform } from 'process';
+
+export async function canPublish(packageName) {
+	const myName = await new Promise((resolve, reject) => {
+		const whoamiCmd = spawn(
+			'npm',
+			[
+				'whoami'
+			],
+			{
+				shell: platform === 'win32',
+				stdio: 'pipe'
+			}
+		);
+
+		let result = '';
+
+		whoamiCmd.stdout.on('data', (data) => {
+			result += data;
+		});
+
+		whoamiCmd.on('close', (code) => {
+			if (0 !== code) {
+				reject(new Error(`'npm install' exited with code ${code}`));
+				return;
+			}
+
+			resolve(result.trim());
+		});
+	});
+
+	return new Promise((resolve, reject) => {
+		const accessListCmd = spawn(
+			'npm',
+			[
+				'access',
+				'list',
+				'collaborators',
+				packageName,
+				myName
+			],
+			{
+				shell: platform === 'win32',
+				stdio: 'pipe'
+			}
+		);
+
+		let result = '';
+
+		accessListCmd.stdout.on('data', (data) => {
+			result += data;
+		});
+
+		accessListCmd.on('close', (code) => {
+			if (0 !== code) {
+				reject(new Error(`'npm install' exited with code ${code}`));
+				return;
+			}
+
+			resolve(
+				result.trim().includes(myName) &&
+				result.trim().includes('read-write')
+			);
+		});
+	});
+}


### PR DESCRIPTION
There are still a few plugins I don't have access to.
This makes it harder for me to release new versions if one of the pending releases if for something I can't release.

This change adds access checks so that a release plan can be created that will complete without error.

Without this change a plan would be started and would error half way through, leaving the repo in a weird state.