### PR TITLE
release plan : smaller published footprint

### DIFF
--- a/.github/bin/release-plan/minify-changelog-and-package-json.mjs
+++ b/.github/bin/release-plan/minify-changelog-and-package-json.mjs
@@ -1,0 +1,51 @@
+import fs from 'fs/promises'
+import path from 'path'
+
+export async function minifyChangelogAndPackageJSON(workspace) {
+	const originalPackageInfo = JSON.parse(await fs.readFile(path.join(workspace.path, 'package.json')));
+	const originalChangelog = (await fs.readFile(path.join(workspace.path, 'CHANGELOG.md'))).toString();
+
+	const minifiedPackageInfo = JSON.parse(JSON.stringify(originalPackageInfo));
+	let minifiedChangelog = originalChangelog;
+
+	// package.json
+	// - remove some fields that are not useful for end users
+	{
+		delete minifiedPackageInfo.devDependencies;
+		delete minifiedPackageInfo.scripts;
+		delete minifiedPackageInfo.csstools;
+		delete minifiedPackageInfo.volta;
+		delete minifiedPackageInfo.eslintConfig;
+	}
+
+	// CHANGELOG.md
+	// - remove some older entries
+	// - keep the last 3 entries
+	// - add a link to the full changelog
+	{
+		let headingIndex = -1;
+		for (let i = 0; i < 4; i++) {
+			headingIndex = minifiedChangelog.indexOf('\n### ', headingIndex + 1);
+
+			if (headingIndex === -1) {
+				break;
+			}
+		}
+
+		if (headingIndex > -1) {
+			minifiedChangelog = minifiedChangelog.slice(0, headingIndex);
+
+			const dependencyLink = `https://github.com/csstools/postcss-plugins/tree/main/${workspace.path.replaceAll('\\', '/')}`;
+			const versionAsLink = `[Full CHANGELOG](${dependencyLink}/CHANGELOG.md)`;
+			minifiedChangelog += `\n${versionAsLink}\n`;
+		}
+	}
+
+	await fs.writeFile(path.join(workspace.path, 'package.json'), JSON.stringify(minifiedPackageInfo, null, '\t') + '\n');
+	await fs.writeFile(path.join(workspace.path, 'CHANGELOG.md'), minifiedChangelog);
+
+	return async () => {
+		await fs.writeFile(path.join(workspace.path, 'package.json'), JSON.stringify(originalPackageInfo, null, '\t') + '\n');
+		await fs.writeFile(path.join(workspace.path, 'CHANGELOG.md'), originalChangelog);
+	}
+}

--- a/.github/bin/release-plan/npm-prepublish-scripts.mjs
+++ b/.github/bin/release-plan/npm-prepublish-scripts.mjs
@@ -1,0 +1,35 @@
+import { spawn } from 'child_process';
+import { platform } from 'process';
+
+export async function npmPrepublishScripts(packageDirectory, packageName) {
+	await new Promise((resolve, reject) => {
+		if (process.env.DEBUG) {
+			resolve(true);
+
+			return;
+		}
+
+		const publishCmd = spawn(
+			'npm',
+			[
+				'run',
+				'prepublishOnly',
+				'--if-present'
+			],
+			{
+				stdio: 'inherit',
+				cwd: packageDirectory,
+				shell: platform === 'win32'
+			}
+		);
+
+		publishCmd.on('close', (code) => {
+			if (0 !== code) {
+				reject(new Error(`'npm run prepublishOnly' exited with code ${code} for ${packageName}`));
+				return;
+			}
+
+			resolve(true);
+		});
+	});
+}

--- a/.github/bin/release-plan/prepare-next-release-plan.mjs
+++ b/.github/bin/release-plan/prepare-next-release-plan.mjs
@@ -2,7 +2,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import { addUpdatedPackagesToChangelog } from './add-to-changelog.mjs';
 
-export async function prepareNextReleasePlan(needsRelease, notReleasableNow, maybeNextPlan) {
+export async function prepareNextReleasePlan(needsRelease, notReleasableNow) {
 	// Downstream dependents
 	let didChangeDownstreamPackages = false;
 

--- a/.github/bin/release-plan/release-plan.mjs
+++ b/.github/bin/release-plan/release-plan.mjs
@@ -10,6 +10,8 @@ import { updateDocumentation } from './docs.mjs';
 import { prepareCurrentReleasePlan } from './prepare-current-release-plan.mjs';
 import { prepareNextReleasePlan } from './prepare-next-release-plan.mjs';
 import { runAndPrintDebugOnFail } from './run-and-print-debug-on-fail.mjs';
+import { npmPrepublishScripts } from './npm-prepublish-scripts.mjs';
+import { minifyChangelogAndPackageJSON } from './minify-changelog-and-package-json.mjs';
 
 const {
 	needsRelease,
@@ -51,6 +53,17 @@ for (const workspace of needsRelease.values()) {
 		'Please fix the error and try again from a clean git state.'
 	);
 
+	// Run pre-publish scripts
+	await runAndPrintDebugOnFail(
+		npmPrepublishScripts(workspace.path, workspace.name),
+		`When releasing ${workspace.name} an error occurred.`,
+		'This happened while running the pre-publish scripts.\n' +
+		'A commit with changes relevant to this release has already been made.\n' +
+		'Please fix the error and try again.'
+	);
+
+	const restoreChangelogAndPackageJSON = await minifyChangelogAndPackageJSON(workspace);
+
 	// Publish to npm
 	await runAndPrintDebugOnFail(
 		npmPublish(workspace.path, workspace.name),
@@ -59,6 +72,8 @@ for (const workspace of needsRelease.values()) {
 		'A commit with changes relevant to this release has already been made.\n' +
 		'Please fix the error and try again.'
 	);
+
+	await restoreChangelogAndPackageJSON();
 
 	// Announce on discord
 	await runAndPrintDebugOnFail(
@@ -69,7 +84,7 @@ for (const workspace of needsRelease.values()) {
 	);
 }
 
-const didChangeDownstreamPackages = await prepareNextReleasePlan(needsRelease, notReleasableNow, maybeNextPlan);
+const didChangeDownstreamPackages = await prepareNextReleasePlan(needsRelease, notReleasableNow);
 
 console.log('\nUpdating lock file');
 await npmInstall();
@@ -86,6 +101,6 @@ if (didChangeDownstreamPackages || maybeNextPlan.size > 0) {
 		console.log('  - updated "package.json" files of downstream packages.');
 	}
 	if (maybeNextPlan.size) {
-		console.log('  - some packages where excluded from this plan. A next plan of releases might be available now.');
+		console.log('  - some packages were excluded from this plan. A next plan of releases might be available now.');
 	}
 }


### PR DESCRIPTION
A significant portion of each package is information that isn't useful to running the plugins.

- dev tooling in `package.json`
- metadata in `package.json`
- older `CHANGELOG.md` entries

<img width="798" alt="Screenshot 2023-12-05 at 17 43 19" src="https://github.com/csstools/postcss-plugins/assets/11521496/1a11c3bf-7193-498c-a74c-d5d78f53967f">

Especially the `CHANGELOG.md` is something that annoys me.
We have really nice changelog entries now but they are verbose and these files keep growing over time.

Only including the last few entries when publishing to npm ensures that our packages have a somewhat stable size.

I have no strong preference for the number of entries.
I picked 3 because that seemed like a sane number.

A link is added to the full changelog on GitHub.
So anyone who needs to see the details of more releases can do so easily.