### PR TITLE
update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5281,9 +5281,9 @@
 			"dev": true
 		},
 		"node_modules/cssdb": {
-			"version": "7.9.1",
-			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.9.1.tgz",
-			"integrity": "sha512-fqy6ZnNfpb8qAvTT0qijWyTsUmYThsDX2F2ctMG4ceI7mI4DtsMILSiMBiuuDnVIYTyWvCctdp9Nb08p/6m2SQ==",
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.10.0.tgz",
+			"integrity": "sha512-yGZ5tmA57gWh/uvdQBHs45wwFY0IBh3ypABk5sEubPBPSzXzkNgsWReqx7gdx6uhC+QoFBe+V8JwBB9/hQ6cIA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7044,9 +7044,9 @@
 			}
 		},
 		"node_modules/knip": {
-			"version": "3.8.4",
-			"resolved": "https://registry.npmjs.org/knip/-/knip-3.8.4.tgz",
-			"integrity": "sha512-pmgUD7LSe3tRf84qogBnIe8uXcfTR+bjbVwW+TrKeHLayOhpw5Xa2vSqXOQ68fMQ8lBrpp8cW+c+hsYMc2YE+w==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-3.9.0.tgz",
+			"integrity": "sha512-pZgJdC4bSTEU/YT+4Q9uT22HuME+V0h0HT2fsOo0TrW7KY5Ghse+2ngNwOctzUn5LeYQ0eY83Z1DhKDIbe5WkA==",
 			"dev": true,
 			"funding": [
 				{

--- a/plugin-packs/postcss-preset-env/test/basic.vendors-2.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.vendors-2.expect.css
@@ -45,23 +45,23 @@
 .test-nesting-rules {
 	order: 4;
 
-	& p {
-		order: 5;
-	}
-
 	order: 6;
 }
+
+.test-nesting-rules p {
+		order: 5;
+	}
 
 .test-nesting-rules,
 #test-is-pseudo {
 	order: 7;
 
-	& + p {
-		order: 8;
-	}
-
 	order: 9;
 }
+
+.test-nesting-rules + p, #test-is-pseudo + p {
+		order: 8;
+	}
 
 @custom-media --narrow-window (max-width: 30em);
 
@@ -542,11 +542,9 @@
 
 @custom-selector :--view-m [data-view-size=m];
 
-.view {
-	:--view-m & {
+:--view-m .view {
 		background: red;
 	}
-}
 
 .nested-calc {
 	order: calc(1 * (8 / 3 + (5 * 10)));
@@ -621,17 +619,17 @@
 }
 
 .test-css-color-5-interop {
-	color-1: color(from rgb(196, 129, 72) a98-rgb r g b / alpha);
+	color-1: rgb(196, 129, 72);
 	color-2: color(from rgb(196, 129, 72) a98-rgb r g b / none);
-	color-3: color(from rgb(234, 133, 82) prophoto-rgb r g b);
+	color-3: rgb(234, 133, 82);
 	color-4: color(from rgb(234, 133, 82) prophoto-rgb r g none);
-	color-5: hwb(from rgb(179, 157, 51) h w b);
-	color-6: lab(from rgb(179, 35, 35) l a b);
-	color-7: lch(from rgb(163, 57, 39) l c h);
-	color-8: oklab(from rgb(141, 0, 0) l a b);
-	color-8: oklab(from color(display-p3 0.50566 0.0781 0) l a b);
-	color-9: oklch(from rgb(130, 31, 0) l c h);
-	color-9: oklch(from color(display-p3 0.48896 0.1211 0) l c h);
+	color-5: rgb(179, 157, 51);
+	color-6: rgb(179, 35, 35);
+	color-7: rgb(163, 57, 39);
+	color-8: rgb(141, 0, 0);
+	color-8: color(display-p3 0.50566 0.0781 0);
+	color-9: rgb(130, 31, 0);
+	color-9: color(display-p3 0.48896 0.1211 0);
 }
 
 .test-property-with-var {

--- a/plugin-packs/postcss-preset-env/test/basic.vendors-3.expect.css
+++ b/plugin-packs/postcss-preset-env/test/basic.vendors-3.expect.css
@@ -45,23 +45,23 @@
 .test-nesting-rules {
 	order: 4;
 
-	& p {
-		order: 5;
-	}
-
 	order: 6;
 }
+
+.test-nesting-rules p {
+		order: 5;
+	}
 
 .test-nesting-rules,
 #test-is-pseudo {
 	order: 7;
 
-	& + p {
-		order: 8;
-	}
-
 	order: 9;
 }
+
+.test-nesting-rules + p, #test-is-pseudo + p {
+		order: 8;
+	}
 
 @custom-media --narrow-window (max-width: 30em);
 
@@ -541,11 +541,9 @@
 
 @custom-selector :--view-m [data-view-size=m];
 
-.view {
-	:--view-m & {
+:--view-m .view {
 		background: red;
 	}
-}
 
 .nested-calc {
 	order: calc(1 * (8 / 3 + (5 * 10)));

--- a/plugins/css-blank-pseudo/src/index.ts
+++ b/plugins/css-blank-pseudo/src/index.ts
@@ -109,7 +109,6 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 
 									if (i === selectorAST.nodes[0].nodes.length - 1) {
 										// Append the class to the end of the selector if no combinator or pseudo element was found.
-										// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 										selectorAST.nodes[0].append(parser.className({ value: POLYFILL_READY_CLASSNAME }));
 										break;
 									}
@@ -118,9 +117,7 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 
 							if (selectorAST.nodes?.[0]?.nodes) {
 								// Prepend a space combinator and the class to the beginning of the selector.
-								// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 								selectorASTClone.nodes[0].prepend(parser.combinator({ value: ' ' }));
-								// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 								selectorASTClone.nodes[0].prepend(parser.className({ value: POLYFILL_READY_CLASSNAME }));
 							}
 

--- a/plugins/css-has-pseudo/src/index.ts
+++ b/plugins/css-has-pseudo/src/index.ts
@@ -136,12 +136,10 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 									if (x.type === 'selector') {
 										x.nodes.forEach((y) => {
 											delete y.parent;
-											// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 											hasContainingSelector.append(y);
 										});
 									} else {
 										delete x.parent;
-										// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 										hasContainingSelector.append(x);
 									}
 								});
@@ -167,7 +165,6 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 							const replacementNodes = encodedSelectorAST.nodes[0].nodes;
 
 							for (let i = replacementNodes.length - 1; i >= 0; i--) {
-								// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 								container.prepend(replacementNodes[i]);
 							}
 						});

--- a/plugins/postcss-attribute-case-insensitive/src/index.ts
+++ b/plugins/postcss-attribute-case-insensitive/src/index.ts
@@ -36,7 +36,6 @@ function createSensitiveAttributes(attribute: selectorParser.Attribute) {
 			insensitive: false,
 		});
 
-		// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 		newAttribute.setValue(x);
 
 		return newAttribute;
@@ -49,7 +48,6 @@ function createNewSelectors(selector: selectorParser.Selector) {
 	selector.each((node) => {
 		if (!nodeIsInsensitiveAttribute(node)) {
 			newSelectors.forEach(newSelector => {
-				// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 				newSelector.append(node.clone());
 			});
 			return;
@@ -61,9 +59,7 @@ function createNewSelectors(selector: selectorParser.Selector) {
 		sensitiveAttributes.forEach(newNode => {
 			newSelectors.forEach(newSelector => {
 				const newSelectorWithNewNode = newSelector.clone({});
-				// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 				newSelectorWithNewNode.append(newNode);
-				// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 				newSelectorsWithSensitiveAttributes.push(newSelectorWithNewNode);
 			});
 		});

--- a/plugins/postcss-dir-pseudo-class/src/index.ts
+++ b/plugins/postcss-dir-pseudo-class/src/index.ts
@@ -114,7 +114,6 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 
 									if (first && !firstIsHtml && !firstIsRoot && !firstIsSpaceCombinator) {
 										parent.prepend(
-											// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 											selectorParser.combinator({
 												value: ' ',
 											}),
@@ -171,7 +170,6 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 											parent.insertAfter(first, notDirAttr);
 										} else {
 											// prepend :root
-											// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 											parent.prepend(notDirAttr);
 										}
 									} else if (firstIsHtml) {
@@ -179,11 +177,9 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 										parent.insertAfter(first, dirAttr);
 									} else if (options.shadow && !firstIsRoot) {
 										// prepend :host-context([dir])
-										// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 										parent.prepend(hostContextPseudo);
 									} else {
 										// otherwise, prepend the dir attribute
-										// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 										parent.prepend(dirAttr);
 									}
 								});

--- a/plugins/postcss-focus-visible/src/index.ts
+++ b/plugins/postcss-focus-visible/src/index.ts
@@ -97,7 +97,6 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 
 									if (i === selectorAST.nodes[0].nodes.length - 1) {
 										// Append the class to the end of the selector if not combinator or pseudo element was found.
-										// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 										selectorAST.nodes[0].append(parser.className({ value: POLYFILL_READY_CLASSNAME }));
 										break;
 									}
@@ -106,9 +105,7 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 
 							if (selectorAST.nodes?.[0]?.nodes) {
 								// Prepend a space combinator and the class to the beginning of the selector.
-								// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 								selectorASTClone.nodes[0].prepend(parser.combinator({ value: ' ' }));
-								// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 								selectorASTClone.nodes[0].prepend(parser.className({ value: POLYFILL_READY_CLASSNAME }));
 							}
 

--- a/plugins/postcss-focus-within/src/index.ts
+++ b/plugins/postcss-focus-within/src/index.ts
@@ -109,7 +109,6 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 
 									if (i === selectorAST.nodes[0].nodes.length - 1) {
 										// Append the class to the end of the selector if not combinator or pseudo element was found.
-										// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 										selectorAST.nodes[0].append(parser.className({ value: POLYFILL_READY_CLASSNAME }));
 										break;
 									}
@@ -118,9 +117,7 @@ const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 
 							if (selectorAST.nodes?.[0]?.nodes) {
 								// Prepend a space combinator and the class to the beginning of the selector.
-								// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 								selectorASTClone.nodes[0].prepend(parser.combinator({ value: ' ' }));
-								// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 								selectorASTClone.nodes[0].prepend(parser.className({ value: POLYFILL_READY_CLASSNAME }));
 							}
 

--- a/plugins/postcss-pseudo-class-any-link/src/replace-any-link.ts
+++ b/plugins/postcss-pseudo-class-any-link/src/replace-any-link.ts
@@ -59,25 +59,21 @@ function modifiedSelector(selector: string, areaHrefNeedsFixing: boolean) {
 			}
 
 			if (!areaHrefNeedsFixing) {
-				// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 				replacements.push([linkAST.clone(), visitedAST.clone()]);
 				return;
 			}
 
 			const tags = getTagElementsNextToPseudo(pseudo);
 			if (tags.includes('area')) {
-				// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 				replacements.push([linkAST.clone(), visitedAST.clone(), hrefAST.clone()]);
 				return;
 			}
 
 			if (tags.length) {
-				// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 				replacements.push([linkAST.clone(), visitedAST.clone()]);
 				return;
 			}
 
-			// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 			replacements.push([linkAST.clone(), visitedAST.clone(), areaHrefAST.clone()]);
 		});
 
@@ -89,7 +85,6 @@ function modifiedSelector(selector: string, areaHrefNeedsFixing: boolean) {
 
 		replacementsCartesianProduct.forEach((replacement) => {
 			const clone = selectorsAST.clone();
-			// @ts-expect-error https://github.com/postcss/postcss-selector-parser/pull/284
 			clone.walkPseudos((pseudo) => {
 				if (pseudo.value.toLowerCase() !== ':any-link' || (pseudo.nodes && pseudo.nodes.length)) {
 					return;


### PR DESCRIPTION
- `postcss-selector-parser` has fixed typings : https://github.com/postcss/postcss-selector-parser/blob/master/CHANGELOG.md#6014
- cssdb reflects improved support for nesting and color functions