### PR TITLE
`postcss-is-pseudo-class` Process :matches in addition to :is

### DIFF
--- a/plugins/postcss-is-pseudo-class/src/index.ts
+++ b/plugins/postcss-is-pseudo-class/src/index.ts
@@ -24,7 +24,7 @@ export type pluginOptions = {
 	specificityMatchingName?: string
 };
 
-const HAS_IS_PSEUDO_REGEX = /:is\(/i;
+const HAS_IS_PSEUDO_REGEX = /:(is|matches)\(/i;
 
 const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 	const options = {

--- a/plugins/postcss-is-pseudo-class/src/split-selectors/complex.ts
+++ b/plugins/postcss-is-pseudo-class/src/split-selectors/complex.ts
@@ -7,7 +7,7 @@ import { isPseudoInFirstCompound } from './complex/is-pseudo-in-first-compound';
 
 export default function complexSelectors(selectors: Array<string>, pluginOptions: { onComplexSelector?: 'warning' }, warnOnComplexSelector: () => void, warnOnPseudoElements: () => void) {
 	return selectors.flatMap((selector) => {
-		if (selector.indexOf(':-csstools-matches') === -1 && selector.toLowerCase().indexOf(':is') === -1) {
+		if (selector.test(/:(-csstools-matches|is|matches)/i)) {
 			return selector;
 		}
 
@@ -15,7 +15,7 @@ export default function complexSelectors(selectors: Array<string>, pluginOptions
 		selectorAST.walkPseudos((pseudo) => {
 			// `:is()` -> `:not(*)`
 			if (
-				pseudo.value.toLowerCase() === ':is' &&
+				pseudo.value.test(/^:(is|matches)$/i) &&
 				pseudo.nodes &&
 				pseudo.nodes.length &&
 				pseudo.nodes[0].type === 'selector' &&

--- a/plugins/postcss-is-pseudo-class/src/split-selectors/split-selectors.ts
+++ b/plugins/postcss-is-pseudo-class/src/split-selectors/split-selectors.ts
@@ -10,7 +10,7 @@ export default function splitSelectors(selectors: Array<string>, pluginOptions: 
 	const specificityMatchingNameTag = ':not(' + pluginOptions.specificityMatchingName + ')';
 
 	return selectors.flatMap((selector) => {
-		if (selector.toLowerCase().indexOf(':is') === -1) {
+		if (!selector.test(/:(is|matches)/i)) {
 			return selector;
 		}
 
@@ -23,7 +23,7 @@ export default function splitSelectors(selectors: Array<string>, pluginOptions: 
 
 		const selectorAST = parser().astSync(selector);
 		selectorAST.walkPseudos((pseudo) => {
-			if (pseudo.value.toLowerCase() !== ':is' || !pseudo.nodes || !pseudo.nodes.length) {
+			if (!pseudo.value.test(/^:(is|matches)$/i) || !pseudo.nodes || !pseudo.nodes.length) {
 				return;
 			}
 
@@ -49,7 +49,7 @@ export default function splitSelectors(selectors: Array<string>, pluginOptions: 
 
 			let parent = pseudo.parent;
 			while (parent) {
-				if (parent.value && parent.value.toLowerCase() === ':is' && parent.type === 'pseudo') {
+				if (parent.value && parent.value.test(/^:(is|matches)$/i) && parent.type === 'pseudo') {
 					foundNestedIs = true;
 					return;
 				}


### PR DESCRIPTION
Considering:
- :matches() was the predecessor to :is()
- :matches() was implemented in Safari
- :matches() is still supported in Safari
- it is fairly easy to add support for :matches()

This PR makes sure `postcss-is-pseudo-class` plugin processes selectors which include `:matches()` as if they are `:is()`.

No plans to add `:any()`, `:-moz-any()` or `:-webkit-any()` as they have a different specificity handling compared to :is() and :matches().