### PR TITLE
Failing test demonstrating incorrect order when mixin present

### DIFF
--- a/plugins/postcss-nesting/test/_tape.mjs
+++ b/plugins/postcss-nesting/test/_tape.mjs
@@ -191,6 +191,10 @@ postcssTape(plugin)({
 		message: 'supports mixin with nested rules',
 		plugins: [mixinPluginNestedRules(), plugin()],
 	},
+	'mixin-rule-order': {
+		message: 'preserves expected rule order with mixins',
+		plugins: [mixinPluginDeclaration(), plugin()],
+	},
 	'spec-examples': {
 		message: 'supports all spec examples',
 	},

--- a/plugins/postcss-nesting/test/mixin-rule-order.css
+++ b/plugins/postcss-nesting/test/mixin-rule-order.css
@@ -1,0 +1,5 @@
+a {
+	& b { }
+	@mixin;
+	color: green;
+}

--- a/plugins/postcss-nesting/test/mixin-rule-order.expect.css
+++ b/plugins/postcss-nesting/test/mixin-rule-order.expect.css
@@ -1,0 +1,5 @@
+a b { }
+a {
+	color: blue;
+	color: green;
+}


### PR DESCRIPTION
I'm currently refactoring a codebase from SASS -> PostCSS with `postcss-nesting` & `postcss-mixin`, and have discovered what I think is a bug in `postcss-nesting`'s handling of `@mixin` rules.

This PR contains a new test which I would have expected to pass, but which is failing:

We have a mixin with a bunch of properties declared in it used throughout the codebase. In one particular case we want to use the mixin but overwrite one property the mixin is setting (let's say `color`). The `@mixin` invocation is positioned just after a nested ruleset:

```css
/* input */
@define-mixin blue {
	color: blue;
}
a {
	& b { }
	@mixin blue;
	color: green;
}
```

`a`'s final `color` should be `green` (overwriting `blue` from the mixin):

```css
/* expected output */
a b { }
a {
	color: blue;
	color: green;
}
```

However, the final value is actually `blue` due to the earlier `& b` nested rule splitting the parent rule in half, but the `color: green` declaration was _incorrectly_ hoisted to the parent ruleset before the `@mixin` was processed by `postcss-mixin`:

```css
/* actual output */
a {
	color: green;
}
a b { }
a {
	color: blue;
}
```

### Investigation

I'm pretty sure it's coming from [the code attempting to group declarations after a nested ruleset](https://github.com/csstools/postcss-plugins/blob/209d4050f04804ef133d9e87cca5a10146520d26/plugins/postcss-nesting/src/lib/group-declarations.ts#L15-L34). In particular I noticed this:

```javascript
// We assume that
// - a mixin after declarations will resolve to declarations
// - a mixin after rules or at-rules will resolve to rules or at-rules
```

I'm not sure that assumption can be made (as per the failing test in this PR). Perhaps this logic needs to collect declarations up to, but not including, the first rule it encounters, then bail from the loop and leave everything after for the second chunk?

#### Postcss Event Ordering

I dug deep and captured some debug logs of the order of operations within postcss with respect to the two plugins. With a config of roughly:

```javascript
plugins: [
  require('postcss-mixins')(),
  require('postcss-nesting')(),
];
```

I got the following output (green is the input, grey is the output):

<img width="314" alt="Screenshot 2024-03-05 at 14 26 06" src="https://github.com/csstools/postcss-plugins/assets/612020/d81b8731-d1cb-46c9-ba97-653a6f309ead">

1. (not shown) `postcss-mixin`'s `AtRule` is run over the `a { ... }` rule, but [it doesn't match known rule names](https://github.com/postcss/postcss-mixins/blob/1522e1c42097630948e63577de52115c66924575/index.js#L252-L263) so is skipped.
1. `postcss-nesting`'s `Rule` event handler processes the `a { ... }` rule which _isn't_ a nested rule, but because of the recursive `walk` function, it goes and finds the nested rules and modifies the AST deeply.
1. `postcss-mixins`'s `AtRule` event handler is given the `@mixin` to process, replacing the AST node with the declaration from the mixin.

I think step 2 is where things are going wrong: Instead of waiting for `postcss` to call `postcss-nesting`'s `Rule` event handler, it's eagerly walking down the tree. On the other hand, `postcss-mixins` is waiting patiently for its `AtRule` event handler to be called.

Ideally, `postcss-nesting` would wait for `postcss-mixins` to replace a node, _then_ it would split it up into multiple selectors if necessary.

##### A potential solution

Assuming `postcss` does a breadth-first ordered iteration of child nodes, `postcss-nesting` could rely on the `Rule` event, and "dumbly" split nested rules out to after the parent node (like it currently is) without trying to group any sibling declarations to the top, or any special handling of `@mixin` nodes:

```css
/* input */
a {
	& { color: red }
	color: green;
}

/* expected output */
a {
	color: green;
}
a { color: red }
```

On the first pass, this should work fine. However, subsequent nested rules would be appended out of order:


```css
/* input */
a {
	& { color: red }
	& { color: blue }
	color: green;
}

/* expected output */
a {
	color: green;
}
a { color: red }
a { color: blue }

/* actual output */
a {
	color: green;
}
a { color: blue }
a { color: red } /* wrong order! */
```

To combat this, we could store some metadata on the nested node's parent (`& { color: red }`'s parent is `a`) which points at where to insert subsequent nested rules.

So in this case, once `& { color: red }` is moved out of `a`, we could set `a#insertNestedAfter = extractedRed`. Then when `& { color: blue }` is to be extracted, it first looks at its parent's metadata `a#insertNestedAfter` to see where the newly unnested node must be inserted.

So the output then correctly becomes:

```css
/* expected & actual output */
a {
	color: green;
}
a { color: red }
a { color: blue }
```

The nice thing about this approach is the order of the plugins doesn't matter. Since the metadata is stored on the parent, the `@mixin`s can be replaced at any time and `postcss` will just trigger `postcss-nesting`'s "dumb" `Rule` event handler.

### Mitigation

Moving the nested rules to _after_ the mixin will mitigate the issue in this:

```css
/* input */
@define-mixin blue {
	color: blue;
}
a {
	@mixin blue;
	& b { }
	color: green;
}
```

```css
/* expected & actual output */
a {
	color: blue;
	color: green;
}
a b { }
```