### PR TITLE
`stylelint-at-risk`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11456,6 +11456,7 @@
 			}
 		},
 		"plugins-stylelint/at-risk": {
+			"name": "@csstools/stylelint-at-risk",
 			"version": "0.0.0",
 			"funding": [
 				{
@@ -11469,7 +11470,6 @@
 			],
 			"license": "MIT-0",
 			"devDependencies": {
-				"postcss": "^8.4",
 				"stylelint": "^16.2.1",
 				"stylelint-test-rule-node": "^0.2.1"
 			},
@@ -11477,7 +11477,6 @@
 				"node": "^14 || ^16 || >=18"
 			},
 			"peerDependencies": {
-				"postcss": "^8.4",
 				"stylelint": "^16.2.1"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -2202,6 +2202,10 @@
 			"resolved": "packages/selector-specificity",
 			"link": true
 		},
+		"node_modules/@csstools/stylelint-at-risk": {
+			"resolved": "plugins-stylelint/at-risk",
+			"link": true
+		},
 		"node_modules/@csstools/stylelint-no-at-nest-rule": {
 			"resolved": "plugins-stylelint/no-at-nest-rule",
 			"link": true
@@ -11449,6 +11453,32 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
+			}
+		},
+		"plugins-stylelint/at-risk": {
+			"version": "0.0.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"devDependencies": {
+				"postcss": "^8.4",
+				"stylelint": "^16.2.1",
+				"stylelint-test-rule-node": "^0.2.1"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4",
+				"stylelint": "^16.2.1"
 			}
 		},
 		"plugins-stylelint/no-at-nest-rule": {

--- a/plugins-stylelint/at-risk/CHANGELOG.md
+++ b/plugins-stylelint/at-risk/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+### Unreleased (major)
+
+Initial release

--- a/plugins-stylelint/at-risk/LICENSE.md
+++ b/plugins-stylelint/at-risk/LICENSE.md
@@ -1,0 +1,18 @@
+MIT No Attribution (MIT-0)
+
+Copyright 2023 Romain Menke, Antonio Laguna <antonio@laguna.es>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins-stylelint/at-risk/README.md
+++ b/plugins-stylelint/at-risk/README.md
@@ -1,0 +1,33 @@
+# [@csstools/stylelint-at-risk](https://www.npmjs.com/package/@csstools/stylelint-at-risk)
+
+[![version](https://img.shields.io/npm/v/@csstools/stylelint-at-risk.svg)](https://www.npmjs.com/package/@csstools/stylelint-at-risk)
+
+Warn when features are used that are at risk of being removed or changed.
+
+- [Re-ordering of declarations after other nested rules or at-rules](https://github.com/w3c/csswg-drafts/issues/8738)
+
+_This rule will be updated with similar warnings if and when they are needed._
+
+## Why?
+
+Sometimes a web feature doesn't ship quite right and should be changed.  
+While at the same time it is very important not to break existing web content.  
+This plugin aims to warn you when you are using a CSS feature that is at risk of being removed or changed.  
+
+Reducing the number of occurrences in the wild makes it more likely that the needed change can be made.
+
+## Usage
+
+`npm install --save-dev @csstools/stylelint-at-risk`
+
+```js
+// stylelint.config.js
+module.exports = {
+	plugins: [
+		"@csstools/stylelint-at-risk",
+	],
+	rules: {
+		"@csstools/stylelint-at-risk": true,
+	},
+}
+```

--- a/plugins-stylelint/at-risk/index.mjs
+++ b/plugins-stylelint/at-risk/index.mjs
@@ -1,0 +1,55 @@
+import stylelint from 'stylelint';
+
+const ruleName = '@csstools/stylelint-at-risk';
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+	rejectedNestingDeclOrder: () => {
+		return 'Declarations after nested rules or at-rules are currently re-ordered but might not be in the future. Place all declarations before any nested rules or at-rules to prevent future compat issues.';
+	},
+});
+
+const meta = {
+	url: 'https://github.com/csstools/postcss-plugins/blob/main/plugins-stylelint/at-risk',
+	fixable: true,
+};
+
+const ruleFunction = (primaryOption) => {
+	return (postcssRoot, postcssResult) => {
+		if (!primaryOption) {
+			return;
+		}
+
+		// Nested Declarations after Rules/At-Rules
+		{
+			postcssRoot.walkDecls((decl) => {
+				let prev = decl.prev();
+
+				while (prev && prev.type === 'comment') {
+					prev = prev.prev();
+				}
+
+				if (!prev) {
+					return;
+				}
+
+				if (prev?.type !== 'decl') {
+					stylelint.utils.report({
+						message: messages.rejectedNestingDeclOrder(),
+						node: decl,
+						index: 0,
+						endIndex: 5,
+						result: postcssResult,
+						ruleName,
+					});
+				}
+			});
+		}
+
+	};
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default stylelint.createPlugin(ruleName, ruleFunction);

--- a/plugins-stylelint/at-risk/index.test.mjs
+++ b/plugins-stylelint/at-risk/index.test.mjs
@@ -1,0 +1,61 @@
+import { testRule } from 'stylelint-test-rule-node';
+import noAtNestRule from './index.mjs';
+
+const rule = noAtNestRule.rule;
+
+testRule({
+	plugins: ['./index.mjs'],
+	ruleName: rule.ruleName,
+	config: true,
+
+	accept: [
+		{
+			code: 'div { color: cyan; & { color: purple } }',
+			description: 'decl before rule',
+		},
+	],
+
+	reject: [
+		{
+			code: 'div { & { color: purple } color: cyan; }',
+			description: 'decl after rule',
+			message: rule.messages.rejectedNestingDeclOrder(),
+			line: 1,
+			column: 27,
+			endLine: 1,
+			endColumn: 32,
+		},
+		{
+			code: 'div { @layer foo; color: cyan; }',
+			description: 'decl after rule',
+			message: rule.messages.rejectedNestingDeclOrder(),
+			line: 1,
+			column: 19,
+			endLine: 1,
+			endColumn: 24,
+		},
+		{
+			code: 'div { @layer foo; /* a comment */ color: cyan; }',
+			description: 'decl after rule',
+			message: rule.messages.rejectedNestingDeclOrder(),
+			line: 1,
+			column: 35,
+			endLine: 1,
+			endColumn: 40,
+		},
+	],
+});
+
+testRule({
+	plugins: ['./index.mjs'],
+	ruleName: rule.ruleName,
+	config: null,
+
+	accept: [
+		{
+			code: 'div { & { color: purple } color: cyan; }',
+		},
+	],
+
+	reject: [],
+});

--- a/plugins-stylelint/at-risk/package.json
+++ b/plugins-stylelint/at-risk/package.json
@@ -55,10 +55,10 @@
 	},
 	"bugs": "https://github.com/csstools/postcss-plugins/issues",
 	"keywords": [
-		"stylelint",
-		"stylelint-plugin",
 		"csswg",
-		"standards"
+		"standards",
+		"stylelint",
+		"stylelint-plugin"
 	],
 	"volta": {
 		"extends": "../../package.json"

--- a/plugins-stylelint/at-risk/package.json
+++ b/plugins-stylelint/at-risk/package.json
@@ -1,0 +1,66 @@
+{
+	"name": "@csstools/stylelint-at-risk",
+	"description": "Warn on CSS features at risk of changes or removal",
+	"version": "0.0.0",
+	"contributors": [
+		{
+			"name": "Antonio Laguna",
+			"email": "antonio@laguna.es",
+			"url": "https://antonio.laguna.es"
+		},
+		{
+			"name": "Romain Menke",
+			"email": "romainmenke@gmail.com"
+		}
+	],
+	"license": "MIT-0",
+	"funding": [
+		{
+			"type": "github",
+			"url": "https://github.com/sponsors/csstools"
+		},
+		{
+			"type": "opencollective",
+			"url": "https://opencollective.com/csstools"
+		}
+	],
+	"engines": {
+		"node": "^14 || ^16 || >=18"
+	},
+	"type": "module",
+	"main": "index.mjs",
+	"files": [
+		"LICENSE.md",
+		"README.md",
+		"index.mjs"
+	],
+	"peerDependencies": {
+		"postcss": "^8.4",
+		"stylelint": "^16.2.1"
+	},
+	"devDependencies": {
+		"postcss": "^8.4",
+		"stylelint": "^16.2.1",
+		"stylelint-test-rule-node": "^0.2.1"
+	},
+	"scripts": {
+		"lint": "node ../../.github/bin/format-package-json.mjs",
+		"test": "node --test"
+	},
+	"homepage": "https://github.com/csstools/postcss-plugins/blob/main/plugins-stylelint/at-risk#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/csstools/postcss-plugins.git",
+		"directory": "plugins-stylelint/at-risk"
+	},
+	"bugs": "https://github.com/csstools/postcss-plugins/issues",
+	"keywords": [
+		"stylelint",
+		"stylelint-plugin",
+		"csswg",
+		"standards"
+	],
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/plugins-stylelint/at-risk/package.json
+++ b/plugins-stylelint/at-risk/package.json
@@ -35,11 +35,9 @@
 		"index.mjs"
 	],
 	"peerDependencies": {
-		"postcss": "^8.4",
 		"stylelint": "^16.2.1"
 	},
 	"devDependencies": {
-		"postcss": "^8.4",
 		"stylelint": "^16.2.1",
 		"stylelint-test-rule-node": "^0.2.1"
 	},


### PR DESCRIPTION
Currently there isn't a good feedback channel between implementers and CSS authors when considering changes.

Implementers have use counters but those do not warn authors that they are using a feature that might be changed.

This implies two issues:
- authors continue to make more use of the feature in question, unaware of the problem
- even after a change it might take a while before it becomes safe to use the updated version

This stylelint plugin probably won't see that much adoption at first, but if we never start building communication channels we will also never have them :)