### PR TITLE
Log what browsers require polyfills in preset-env

### DIFF
--- a/plugin-packs/postcss-preset-env/src/lib/list-features.mjs
+++ b/plugin-packs/postcss-preset-env/src/lib/list-features.mjs
@@ -124,15 +124,21 @@ export function listFeatures(cssdbList, options, sharedOptions, logger) {
 			ignoreUnknownVersions: true,
 		});
 
-		const needsPolyfill = supportedBrowsers.some(supportedBrowser => {
+		const needsPolyfill = supportedBrowsers.filter(supportedBrowser => {
 			return unsupportedBrowsers.some(unsupportedBrowser => unsupportedBrowser === supportedBrowser);
 		});
 
-		if (!needsPolyfill) {
+		if (needsPolyfill.length > 0) {
+			let logList = ">5 targets";
+			if (needsPolyfill.length <= 5) {
+				logList = needsPolyfill.join(', ');
+			}
+			logger.log(`${feature.id} needed (${logList})`);
+		} else {
 			logger.log(`${feature.id} disabled due to browser support`);
 		}
 
-		return needsPolyfill;
+		return needsPolyfill.length > 0;
 	});
 
 	return supportedFeatures;


### PR DESCRIPTION
The debug feature will mention which plugins are disabled, but not why certain ones were enabled. I found this particularly useful when deciding how to configure my browserslist, and think it's worth including since it's gated behind a debug mode.

I decided arbitrarily to not print more than five browsers in the list, since it felt like a good "small" number. But I'm open to changing it if desired.