### PR TITLE
[css-tokenizer] add types entry in package.json for older projects

### DIFF
--- a/packages/css-tokenizer/package.json
+++ b/packages/css-tokenizer/package.json
@@ -30,6 +30,7 @@
 	"type": "module",
 	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": {


### PR DESCRIPTION
namely where `compilerOptions.moduleResolution < "node16"` in tsconfig.json