### PR TITLE
Move `postcss` to `devDependencies` in "css-syntax-patches-for-csstree"

### DIFF
--- a/packages/css-syntax-patches-for-csstree/package.json
+++ b/packages/css-syntax-patches-for-csstree/package.json
@@ -35,12 +35,10 @@
 		"README.md",
 		"dist"
 	],
-	"peerDependencies": {
-		"postcss": "^8.4"
-	},
 	"devDependencies": {
 		"@webref/css": "6.22.0",
-		"css-tree": "^3.1.0"
+		"css-tree": "^3.1.0",
+		"postcss": "^8.4.0"
 	},
 	"scripts": {
 		"build": "node ./scripts/index.mjs",


### PR DESCRIPTION
When installing this package as nested dependency of cssstyle with Yarn PnP on the latest Yarn version (4.10.3), one is presented with the following error:
```
➤ YN0086: │ Some peer dependencies are incorrectly met by dependencies; run yarn explain peer-requirements for details.
``` 
which when inspected can be traced to
```
pb97ead → ✘ cssstyle@npm:5.3.1 doesn't provide postcss to @csstools/css-syntax-patches-for-csstree@npm:1.0.14 [bb38a]
```

Given that seemingly this package does not interact with `postcss` when inspecting the code, apart from in a single e2e test, I think moving it to be a dev dependency is more accurate.