### PR TITLE
fix: include container-query type in patch output

### DIFF
--- a/packages/css-syntax-patches-for-csstree/CHANGELOG.md
+++ b/packages/css-syntax-patches-for-csstree/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to CSS Syntax Patches For CSSTree
 
+### Unreleased (patch)
+
+- Fixed missing `container-query` type definition in patch output
+
 ### 1.1.3
 
 _April 12, 2026_

--- a/packages/css-syntax-patches-for-csstree/dist/index.json
+++ b/packages/css-syntax-patches-for-csstree/dist/index.json
@@ -435,6 +435,7 @@
 		"types": {
 			"dashed-ident": "<custom-property-name>",
 			"unicode-range-token": "<urange>",
+			"container-query": "not <query-in-parens> | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]",
 			"alpha()": "alpha( [ from <color> ] [ / [ <alpha-value> | alpha | none ] ]? )",
 			"an+b": "odd | even | <integer> | <n-dimension> | '+'? n | -n | <ndashdigit-dimension> | '+'? <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'? n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'? n- <signless-integer> | -n- <signless-integer> | <n-dimension> [ '+' | '-' ] <signless-integer> | '+'? n [ '+' | '-' ] <signless-integer> | -n [ '+' | '-' ] <signless-integer>",
 			"anchored-feature": "fallback : <'position-try-fallbacks'>",

--- a/packages/css-syntax-patches-for-csstree/scripts/apply-patches.mjs
+++ b/packages/css-syntax-patches-for-csstree/scripts/apply-patches.mjs
@@ -108,6 +108,7 @@ export function apply_patches(patches, onto) {
 	// Manual patches to smooth over compat between csstree and webref/css
 	types['dashed-ident'] = '<custom-property-name>';
 	types['unicode-range-token'] = '<urange>';
+	types['container-query'] = 'not <query-in-parens> | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]';
 
 	for (const [name, definition] of Object.entries(onto.types)) {
 		const patch = patches.types[name];

--- a/packages/css-syntax-patches-for-csstree/tests/container-query.test.mjs
+++ b/packages/css-syntax-patches-for-csstree/tests/container-query.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'path';
+import { fork, parse } from 'css-tree';
+
+const patches = JSON.parse(await fs.readFile(path.join('dist', 'index.json'), 'utf-8')).next;
+
+test('container-query type is defined in patch output', () => {
+	assert.ok(
+		patches.types['container-query'],
+		'container-query must be in patch output because container-condition and query-in-parens reference it',
+	);
+});
+
+test('@container prelude validates without error', () => {
+	const forkedLexer = fork({
+		atrules: patches.atrules,
+		properties: patches.properties,
+		types: patches.types,
+	}).lexer;
+
+	const prelude = parse('(min-width: 768px)', { context: 'atrulePrelude', atrule: 'container' });
+	const result = forkedLexer.matchAtrulePrelude('container', prelude);
+	assert.equal(result.error, null, `should validate @container prelude, got: ${result.error?.message}`);
+});


### PR DESCRIPTION
## Problem

The patched `container-condition` and `query-in-parens` types both reference `<container-query>` in their syntax, but `container-query` itself is never included in `dist/index.json`.

### How this happened

In `b670b0cac` (#1466), when the package was first created, css-tree didn't have `container-query` in its base grammar. It appeared in the diff as `type: "added"` and was correctly included in the output.

In `a0880e31b` (#1792), css-tree was updated to `^3.2.1`, which added `container-query` to its base grammar. Since both sources now defined it identically, `diff_sets()` excluded it from the diff, and it was removed from the patches. But `container-condition` and `query-in-parens` still reference `<container-query>` in their merged syntax — creating a dangling reference in the patch output.

### Why it crashes

In css-tree's base grammar, `container-condition` is defined as:

```
container-condition = not <query-in-parens> | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]
```

The patch replaces this with the newer spec definition:

```
container-condition = [ <container-name>? <container-query>? ]!
```

This new syntax references `<container-query>`. But `container-query` isn't in the patch output — because both css-tree and webref now define it with the exact same syntax, so the diff step sees no difference and excludes it. When consumed with a css-tree version whose base grammar doesn't include `container-query`, there's no definition for it anywhere, and css-tree throws:

```
Error: Bad syntax reference: <container-query>
```

This crashes tools like stylelint entirely (not a lint warning — an unhandled exception) when validating `@container` rules.

## Fix

Added `container-query` to the manual compatibility patches in `apply-patches.mjs`, following the existing pattern for `dashed-ident` and `unicode-range-token`. This ensures the patch output is self-contained for the types it references.

Also added a test that verifies `container-query` is present in the output and that `@container` preludes validate without error.
